### PR TITLE
Additional perms needed to view WAF

### DIFF
--- a/terraform/modules/iam_role_policy/compliance_role/outputs.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/outputs.tf
@@ -1,0 +1,6 @@
+output "name" {
+  value = "${aws_iam_policy.iam_policy.name}"
+}
+output "arn" {
+  value = "${aws_iam_policy.iam_policy.arn}"
+}

--- a/terraform/modules/iam_role_policy/compliance_role/policy.json
+++ b/terraform/modules/iam_role_policy/compliance_role/policy.json
@@ -9,23 +9,20 @@
             "waf:List*",
             "waf:Get*",
             "waf-regional:List*",
-            "waf-regional:Get*"
+            "waf-regional:GetByteMatchSet",
+            "waf-regional:GetIPSet",
+            "waf-regional:GetRule",
+            "waf-regional:GetSampledRequests",
+            "waf-regional:GetSizeConstraintSet",
+            "waf-regional:GetSqlInjectionMatchSet",
+            "waf-regional:GetWebACL",
+            "waf-regional:GetWebACLForResource",
+            "waf-regional:GetXssMatchSet",
             "wafv2:CheckCapacity",
             "wafv2:Describe*",
             "wafv2:Get*",
             "wafv2:List*"
         ]
-    },
-    {
-      "Sid": "cloudgovComplianceRoleDeny",
-      "Effect": "Deny",
-      "Resource": "*",
-      "Action": [
-        "waf:GetChangeToken",
-        "waf:GetChangeTokenStatus",
-        "waf-regional:GetChangeToken",
-        "waf-regional:GetChangeTokenStatus"
-    ]
-}
+    }
   ]
 }

--- a/terraform/modules/iam_role_policy/compliance_role/policy.json
+++ b/terraform/modules/iam_role_policy/compliance_role/policy.json
@@ -1,0 +1,31 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Sid": "cloudgovComplianceRoleAllow",
+          "Effect": "Allow",
+          "Resource": "*",
+          "Action": [
+            "waf:List*",
+            "waf:Get*",
+            "waf-regional:List*",
+            "waf-regional:Get*"
+            "wafv2:CheckCapacity",
+            "wafv2:Describe*",
+            "wafv2:Get*",
+            "wafv2:List*"
+        ]
+    },
+    {
+      "Sid": "cloudgovComplianceRoleDeny",
+      "Effect": "Deny",
+      "Resource": "*",
+      "Action": [
+        "waf:GetChangeToken",
+        "waf:GetChangeTokenStatus",
+        "waf-regional:GetChangeToken",
+        "waf-regional:GetChangeTokenStatus"
+    ]
+}
+  ]
+}

--- a/terraform/modules/iam_role_policy/compliance_role/policy.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/policy.tf
@@ -1,0 +1,11 @@
+data "template_file" "policy" {
+  template = "${file("${path.module}/policy.json")}"
+  vars {
+    aws_partition = "${var.aws_partition}"
+  }
+}
+
+resource "aws_iam_policy" "iam_policy" {
+  name = "${var.policy_name}"
+  policy = "${data.template_file.policy.rendered}"
+}

--- a/terraform/modules/iam_role_policy/compliance_role/variables.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/variables.tf
@@ -1,0 +1,2 @@
+variable "policy_name" {}
+variable "aws_partition" {}

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -92,6 +92,13 @@ module "self_managed_mfa" {
   aws_partition = "${data.aws_partition.current.partition}"
 }
 
+module "compliance_role" {
+  source        = "../../modules/iam_role_policy/compliance_role"
+  policy_name   = "compliance-role"
+  aws_partition = "${data.aws_partition.current.partition}"
+
+}
+
 module "default_role" {
   source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-default"


### PR DESCRIPTION
## Changes proposed in this pull request:

- create a new iam_role_policy `compliance-role`
- this is to be used in addition to the aws-managed `Security Audit` role
- It is OK to use this policy in both Commercial and GovCloud. Actions that aren't applicable will be ignored (the `Security Audit` roles does the same thing).
- Denies the few `GetToken..` actions that seem dicey.


## security considerations

Gives more read-only permission to compliance role
