### PR TITLE
Added Redis access to aws-broker policy

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -48,6 +48,26 @@
         "arn:${aws_partition}:s3:::${remote_state_bucket}/cg-aws-broker-*",
         "arn:${aws_partition}:s3:::${remote_state_bucket}/cg-aws-broker-*/*"
       ]
-    }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+          "elasticache:DescribeReplicationGroups",
+          "elasticache:RemoveTagsFromResource",
+          "elasticache:DescribeCacheParameters",
+          "elasticache:CreateReplicationGroup",
+          "elasticache:AddTagsToResource",
+          "elasticache:DeleteReplicationGroup",
+          "elasticache:DescribeCacheSubnetGroups",
+          "elasticache:IncreaseReplicaCount",
+          "elasticache:DescribeCacheParameterGroups",
+          "elasticache:ModifyReplicationGroup",
+          "elasticache:DecreaseReplicaCount",
+          "elasticache:DescribeCacheSecurityGroups",
+          "elasticache:ListTagsForResource",
+          "elasticache:ModifyReplicationGroupShardConfiguration"
+      ],
+      "Resource": "*"
+  }
   ]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Elasticache Replication Groups access added


## security considerations
Gives aws-broker to do Elasticache API functions