### PR TITLE
add payer account access to read S3 bucket tagging

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -247,6 +247,7 @@ jobs:
       TF_VAR_concourse_varz_bucket: ((concourse_varz_bucket))
       TF_VAR_oidc_client: ((tooling_oidc_client))
       TF_VAR_oidc_client_secret: ((tooling_oidc_client_secret))
+      TF_VAR_payer_account_id: ((payer_account_id))
   - *notify-slack
 
 - name: bootstrap-tooling

--- a/terraform/stacks/tooling/cross_account_iam.tf
+++ b/terraform/stacks/tooling/cross_account_iam.tf
@@ -41,7 +41,7 @@ resource "aws_iam_policy" "read_s3_tags" {
             "s3:GetBucketLocation",
             "s3:GetBucketTagging"
            ],
-          "Resource": "arn:aws:s3:::*"
+          "Resource": "arn:${data.aws_partition.current.partition}:s3:::*"
         }
       ]
     }

--- a/terraform/stacks/tooling/cross_account_iam.tf
+++ b/terraform/stacks/tooling/cross_account_iam.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_role" "payer_account_access" {
+    name = "payer-account-access"
+
+    assume_role_policy = <<EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::${var.payer_account_id}:root"
+          },
+          "Action": "sts:AssumeRole",
+          "Condition": {
+            "Bool": {
+              "aws:MultiFactorAuthPresent": "true"
+            }
+          }
+        }
+      ]
+    }
+    EOF
+}
+
+resource "aws_iam_policy" "read_s3_tags" {
+    name = "read-s3-bucket-tags"
+    description = "Allow reading bucket tags in s3"
+
+    policy = <<EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListAllMyBuckets",
+          "Resource": "*"
+        },
+        {
+          "Effect": "Allow",
+          "Action": [
+            "s3:GetBucketLocation",
+            "s3:GetBucketTagging"
+           ],
+          "Resource": "arn:aws:s3:::*"
+        }
+      ]
+    }
+    EOF
+}
+
+resource "aws_iam_role_policy_attachment" "payer_read_s3_tags" {
+    role = "payer-account-access"
+    policy = "read-s3-bucket-tags"
+}

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -123,3 +123,5 @@ variable "log_bucket_name" {
 variable "oidc_client" {}
 
 variable "oidc_client_secret" {}
+
+variable "payer_account_id" {}


### PR DESCRIPTION
## Changes proposed in this pull request:
- allow payer account to read s3 bucket tags

## security considerations
Allows users of the payer account to see the names and tags of all of our buckets