### PR TITLE
fix param name and lookup

### DIFF
--- a/terraform/stacks/tooling/cross_account_iam.tf
+++ b/terraform/stacks/tooling/cross_account_iam.tf
@@ -49,6 +49,6 @@ resource "aws_iam_policy" "read_s3_tags" {
 }
 
 resource "aws_iam_role_policy_attachment" "payer_read_s3_tags" {
-    role = "payer-account-access"
-    policy = "read-s3-bucket-tags"
+    role = "${aws_iam_role.payer_account_access.name}"
+    policy_arn = "${aws_iam_policy.read_s3_tags.arn}""
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- reference `policy_arn` rather than `policy`, because that's what the API is
- look up the ARN and name

Docs on this module [here](https://www.terraform.io/docs/providers/aws/r/iam_role_policy_attachment.html) 
## security considerations
None