### PR TITLE
Add support for "sts:GetFederationToken"

### DIFF
--- a/terraform/modules/iam_role_policy/self_managed_credentials/policy.json
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/policy.json
@@ -8,8 +8,7 @@
                 "iam:GetAccountPasswordPolicy",
                 "iam:ListVirtualMFADevices",
                 "iam:ListUsers",
-                "iam:GetAccountSummary",
-                "sts:GetFederationToken"
+                "iam:GetAccountSummary"
             ],
             "Resource": "*"
         },

--- a/terraform/modules/iam_role_policy/self_managed_credentials/policy.json
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/policy.json
@@ -8,7 +8,8 @@
                 "iam:GetAccountPasswordPolicy",
                 "iam:ListVirtualMFADevices",
                 "iam:ListUsers",
-                "iam:GetAccountSummary"
+                "iam:GetAccountSummary",
+                "sts:GetFederationToken"
             ],
             "Resource": "*"
         },
@@ -70,7 +71,8 @@
               "iam:ListMFADevices",
               "iam:ListVirtualMFADevices",
               "iam:ResyncMFADevice",
-              "sts:GetSessionToken"
+              "sts:GetSessionToken",
+              "sts:GetFederationToken"
           ],
           "Resource": "*",
           "Condition": {


### PR DESCRIPTION
This change adds support for `sts:GetFederationToken` to the self-managed-credentials policy so that users are able to use `aws-vault login` to get to the AWS web console.

This action had to be added to two different sections to account for the different levels of access our team has.

## Changes proposed in this pull request:
- Add `sts:GetFederationToken` to the `DenyAllExceptListedIfNoMFA` section

## Security considerations
We need to consider the impact of [`sts:GetFederationToken`](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetFederationToken.html) for anyone who has the `self-managed-credentials` policy attached.