### PR TITLE
Revert "Remove the v2 domain broker from terraform"

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -86,6 +86,9 @@ jobs:
       TF_VAR_external_domain_broker_username: ((external_domain_broker_username_staging))
       TF_VAR_external_domain_broker_cloudfront_prefix: ((external_domain_broker_cloudfront_prefix_staging))
       TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_staging))
+      TF_VAR_domain_broker_v2_username: ((domain_broker_v2_username_staging))
+      TF_VAR_domain_broker_v2_bucket: ((domain_broker_v2_bucket_staging))
+      TF_VAR_domain_broker_v2_cloudfront_prefix: ((domain_broker_v2_cloudfront_prefix_staging))
       TF_VAR_lets_encrypt_hosted_zone: ((lets_encrypt_hosted_zone_staging))
   - &notify-slack
     put: slack
@@ -146,6 +149,9 @@ jobs:
       TF_VAR_external_domain_broker_username: ((external_domain_broker_username_production))
       TF_VAR_external_domain_broker_cloudfront_prefix: ((external_domain_broker_cloudfront_prefix_production))
       TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_production))
+      TF_VAR_domain_broker_v2_username: ((domain_broker_v2_username_production))
+      TF_VAR_domain_broker_v2_bucket: ((domain_broker_v2_bucket_production))
+      TF_VAR_domain_broker_v2_cloudfront_prefix: ((domain_broker_v2_cloudfront_prefix_production))
       TF_VAR_lets_encrypt_hosted_zone: ((lets_encrypt_hosted_zone_production))
   - *notify-slack
 
@@ -355,11 +361,14 @@ jobs:
       TF_VAR_shibboleth_hosts: '["idp.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "2"
+      TF_VAR_domain_broker_v2_alb_count: "2"
       TF_VAR_challenge_bucket: development-domains-broker-challenge
       TF_VAR_iam_cert_prefix: "/domains/development/*"
       TF_VAR_alb_prefix: "development-domains-*"
       TF_VAR_domains_broker_rds_username: ((development_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((development_domains_broker_rds_password))
+      TF_VAR_domain_broker_v2_rds_username: ((development_domain_broker_v2_rds_username))
+      TF_VAR_domain_broker_v2_rds_password: ((development_domain_broker_v2_rds_password))
   - *notify-slack
 
 - name: bootstrap-development
@@ -462,11 +471,14 @@ jobs:
       TF_VAR_shibboleth_hosts: '["idp.fr-stage.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr-stage.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "2"
+      TF_VAR_domain_broker_v2_alb_count: "2"
       TF_VAR_challenge_bucket: staging-domains-broker-challenge
       TF_VAR_iam_cert_prefix: "/domains/staging/*"
       TF_VAR_alb_prefix: "staging-domains-*"
       TF_VAR_domains_broker_rds_username: ((staging_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((staging_domains_broker_rds_password))
+      TF_VAR_domain_broker_v2_rds_username: ((staging_domain_broker_v2_rds_username))
+      TF_VAR_domain_broker_v2_rds_password: ((staging_domain_broker_v2_rds_password))
   - *notify-slack
 
 - name: bootstrap-staging
@@ -568,11 +580,14 @@ jobs:
       TF_VAR_shibboleth_hosts: '["idp.fr.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "4"
+      TF_VAR_domain_broker_v2_alb_count: "3"
       TF_VAR_challenge_bucket: production-domains-broker-challenge
       TF_VAR_iam_cert_prefix: "/domains/production/*"
       TF_VAR_alb_prefix: "production-domains-*"
       TF_VAR_domains_broker_rds_username: ((production_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((production_domains_broker_rds_password))
+      TF_VAR_domain_broker_v2_rds_username: ((production_domain_broker_v2_rds_username))
+      TF_VAR_domain_broker_v2_rds_password: ((production_domain_broker_v2_rds_password))
   - *notify-slack
 
 - name: bootstrap-production

--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -81,3 +81,24 @@ output "lets_encrypt_access_key_id_curr" {
 output "lets_encrypt_secret_access_key_curr" {
   value = "${module.lets_encrypt_user.secret_access_key_curr}"
 }
+
+// Domain Broker v2
+output "domain_broker_v2" {
+  value = "${module.domain_broker_v2_user.username}"
+}
+
+output "domain_broker_v2_access_key_id_prev" {
+  value = "${module.domain_broker_v2_user.access_key_id_prev}"
+}
+
+output "domain_broker_v2_secret_access_key_prev" {
+  value = "${module.domain_broker_v2_user.secret_access_key_prev}"
+}
+
+output "domain_broker_v2_access_key_id_curr" {
+  value = "${module.domain_broker_v2_user.access_key_id_curr}"
+}
+
+output "domain_broker_v2_secret_access_key_curr" {
+  value = "${module.domain_broker_v2_user.secret_access_key_curr}"
+}

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -41,3 +41,14 @@ module "lets_encrypt_user" {
   hosted_zone   = "${var.lets_encrypt_hosted_zone}"
   username      = "lets-encrypt-${var.stack_description}"
 }
+
+module "domain_broker_v2_user" {
+  source            = "../../modules/cdn_broker"
+  account_id        = "${data.aws_caller_identity.current.account_id}"
+  aws_partition     = "${data.aws_partition.current.partition}"
+  username          = "${var.domain_broker_v2_username}"
+  bucket            = "${var.domain_broker_v2_bucket}"
+  cloudfront_prefix = "${var.domain_broker_v2_cloudfront_prefix}"
+  hosted_zone       = "${var.cdn_broker_hosted_zone}"
+  username          = "domain-broker-v2"
+}

--- a/terraform/stacks/external/variables.tf
+++ b/terraform/stacks/external/variables.tf
@@ -10,3 +10,9 @@ variable "cdn_broker_hosted_zone" {}
 variable "cdn_broker_bucket" {}
 
 variable "lets_encrypt_hosted_zone" {}
+
+variable "domain_broker_v2_username" {}
+
+variable "domain_broker_v2_bucket" {}
+
+variable "domain_broker_v2_cloudfront_prefix" {}

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -1,15 +1,17 @@
 variable "domains_broker_alb_count" {
   default = 0
 }
-
 variable "domains_broker_rds_username" {}
 variable "domains_broker_rds_password" {}
+variable "domain_broker_v2_rds_username" {}
+variable "domain_broker_v2_rds_password" {}
+variable "domain_broker_v2_alb_count" {
+  default = 0
+}
 variable "challenge_bucket" {}
-
 variable "iam_cert_prefix" {
   default = "/domains/*"
 }
-
 variable "alb_prefix" {
   default = "domains-*"
 }
@@ -20,7 +22,6 @@ resource "aws_lb" "domains_broker_internal" {
   subnets         = ["${module.cf.services_subnet_az1}", "${module.cf.services_subnet_az2}"]
   security_groups = ["${module.stack.bosh_security_group}"]
   internal        = true
-
   access_logs = {
     bucket = "${var.log_bucket_name}"
     prefix = "${var.stack_description}"
@@ -52,7 +53,6 @@ resource "aws_lb_target_group" "domains_broker_internal" {
 output "domains_broker_internal_dns_name" {
   value = "${aws_lb.domains_broker_internal.dns_name}"
 }
-
 output "domains_broker_internal_target_group" {
   value = "${aws_lb_target_group.domains_broker_internal.name}"
 }
@@ -73,15 +73,12 @@ resource "aws_db_instance" "domains_broker" {
 output "domains_broker_rds_username" {
   value = "${aws_db_instance.domains_broker.username}"
 }
-
 output "domains_broker_rds_password" {
   value = "${aws_db_instance.domains_broker.password}"
 }
-
 output "domains_broker_rds_address" {
   value = "${aws_db_instance.domains_broker.address}"
 }
-
 output "domains_broker_rds_port" {
   value = "${aws_db_instance.domains_broker.port}"
 }
@@ -95,7 +92,6 @@ resource "aws_lb" "domains_broker" {
   security_groups = ["${module.stack.web_traffic_security_group}"]
   ip_address_type = "dualstack"
   idle_timeout    = 3600
-
   access_logs = {
     bucket = "${var.log_bucket_name}"
     prefix = "${var.stack_description}"
@@ -198,23 +194,236 @@ resource "aws_lb_target_group" "domains_broker_challenge" {
 output "domains_broker_alb_names" {
   value = "${aws_lb.domains_broker.*.name}"
 }
-
 output "domains_broker_target_group_apps_names" {
   value = "${aws_lb_target_group.domains_broker_apps.*.name}"
 }
-
 output "domains_broker_target_group_challenge_names" {
   value = "${aws_lb_target_group.domains_broker_challenge.*.name}"
 }
-
 output "domains_broker_listener_arns" {
   value = "${aws_lb_listener.domains_broker_http.*.arn}"
 }
 
-// this bucket is used for domains broker and cdn broker
+/* new broker ALB */
+
+resource "aws_iam_user" "domain_broker_v2" {
+  name = "domain_broker_v2_${var.stack_description}"
+  path = "/domain-broker-v2/"
+}
+
+resource "aws_iam_access_key" "domain_broker_v2_access_key" {
+  user = "${aws_iam_user.domain_broker_v2.name}"
+}
+
+resource "aws_iam_user_policy" "domain_broker_v2_policy" {
+  name   = "domain_broker_v2_policy"
+  user   = "${aws_iam_user.domain_broker_v2.name}"
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:DeleteLoadBalancer"
+            ],
+            "Effect": "Deny",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:CreateLoadBalancerListeners",
+                "elasticloadbalancing:CreateTargetGroup",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:DeleteRule",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:DeregisterTargets",
+                "elasticloadbalancing:Describe*",
+                "elasticloadbalancing:Modify*",
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:RemoveListenerCertificates"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:DeleteServerCertificate",
+                "iam:GetServerCertificate",
+                "iam:ListServerCertificates",
+                "iam:UpdateServerCertificate",
+                "iam:UploadServerCertificate"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_lb" "domain_broker_v2" {
+  count = "${var.domain_broker_v2_alb_count}"
+
+  name            = "${var.stack_description}-domains-${count.index}"
+  subnets         = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
+  security_groups = ["${module.stack.web_traffic_security_group}"]
+  ip_address_type = "dualstack"
+  idle_timeout    = 3600
+  access_logs = {
+    bucket = "${var.log_bucket_name}"
+    prefix = "${var.stack_description}"
+  }
+}
+
+resource "aws_lb_listener" "domain_broker_v2_http" {
+  count = "${var.domain_broker_v2_alb_count}"
+
+  load_balancer_arn = "${aws_lb.domain_broker_v2.*.arn[count.index]}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.domain_broker_v2_apps.*.arn[count.index]}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "domain_broker_v2_https" {
+  count = "${var.domain_broker_v2_alb_count}"
+
+  load_balancer_arn = "${aws_lb.domain_broker_v2.*.arn[count.index]}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = "${data.aws_iam_server_certificate.wildcard.arn}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.domain_broker_v2_apps.*.arn[count.index]}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener_rule" "domain_broker_v2static_http" {
+  count = "${var.domain_broker_v2_alb_count}"
+
+  listener_arn = "${aws_lb_listener.domain_broker_v2_http.*.arn[count.index]}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.domain_broker_v2_challenge.*.arn[count.index]}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/.well-known/acme-challenge/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "domain_broker_v2_static_https" {
+  count = "${var.domain_broker_v2_alb_count}"
+
+  listener_arn = "${aws_lb_listener.domain_broker_v2_https.*.arn[count.index]}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.domain_broker_v2_challenge.*.arn[count.index]}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/.well-known/acme-challenge/*"]
+    }
+  }
+}
+
+resource "aws_lb_target_group" "domain_broker_v2_apps" {
+  count = "${var.domain_broker_v2_alb_count}"
+
+  name     = "${var.stack_description}-domains-apps-${count.index}"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${module.stack.vpc_id}"
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 4
+    interval            = 5
+    port                = 81
+    matcher             = 200
+  }
+}
+
+resource "aws_lb_target_group" "domain_broker_v2_challenge" {
+  count = "${var.domain_broker_v2_alb_count}"
+
+  name     = "${var.stack_description}-domains-acme-${count.index}"
+  port     = 8081
+  protocol = "HTTP"
+  vpc_id   = "${module.stack.vpc_id}"
+
+  health_check {
+    path = "/health"
+  }
+}
+
+resource "aws_db_instance" "domain_broker_v2" {
+  name                   = "domain_broker_v2"
+  storage_type           = "gp2"
+  allocated_storage      = 10
+  instance_class         = "db.t2.micro"
+  username               = "${var.domain_broker_v2_rds_username}"
+  password               = "${var.domain_broker_v2_rds_password}"
+  engine                 = "postgres"
+  db_subnet_group_name   = "${module.stack.rds_subnet_group}"
+  vpc_security_group_ids = ["${module.stack.rds_postgres_security_group}"]
+}
+
+output "domain_broker_v2_rds_username" {
+  value = "${aws_db_instance.domain_broker_v2.username}"
+}
+output "domain_broker_v2_rds_password" {
+  value = "${aws_db_instance.domain_broker_v2.password}"
+}
+output "domain_broker_v2_rds_address" {
+  value = "${aws_db_instance.domain_broker_v2.address}"
+}
+output "domain_broker_v2_rds_port" {
+  value = "${aws_db_instance.domain_broker_v2.port}"
+}
+
+output "domain_broker_v2_alb_names" {
+  value = "${aws_lb.domain_broker_v2.*.name}"
+}
+output "domain_broker_v2_target_group_apps_names" {
+  value = "${aws_lb_target_group.domain_broker_v2_apps.*.name}"
+}
+output "domain_broker_v2_target_group_challenge_names" {
+  value = "${aws_lb_target_group.domain_broker_v2_challenge.*.name}"
+}
+output "domain_broker_v2_listener_arns" {
+  value = "${aws_lb_listener.domain_broker_v2_http.*.arn}"
+}
+output "domain_broker_v2_access_key_id" {
+  value = "${aws_iam_access_key.domain_broker_v2_access_key.id}"
+}
+output "domain_broker_v2_secret_access_key" {
+  value = "${aws_iam_access_key.domain_broker_v2_access_key.secret}"
+}
+/* end new broker alb config */
+
+/* n.b. this bucket is used for:
+   - original domains broker
+   - original cdn broker
+   - new domains + cdn broker
+ */
 resource "aws_s3_bucket" "domains_bucket" {
   bucket = "${var.challenge_bucket}"
-
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -232,11 +441,9 @@ resource "aws_s3_bucket" "domains_bucket" {
 }
 EOF
 }
-
 output "challenge_bucket" {
   value = "${aws_s3_bucket.domains_bucket.id}"
 }
-
 output "challenge_bucket_domain_name" {
   value = "${aws_s3_bucket.domains_bucket.bucket_domain_name}"
 }
@@ -248,9 +455,8 @@ resource "aws_iam_instance_profile" "domains_broker" {
 }
 
 resource "aws_iam_role" "domains_broker" {
-  name = "${var.stack_description}-domains-broker"
-  path = "/bosh-passed/"
-
+  name               = "${var.stack_description}-domains-broker"
+  path               = "/bosh-passed/"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -268,8 +474,7 @@ EOF
 }
 
 resource "aws_iam_policy" "domains_broker" {
-  name = "${var.stack_description}-domains-broker"
-
+  name   = "${var.stack_description}-domains-broker"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -311,9 +516,8 @@ EOF
 resource "aws_iam_policy_attachment" "domains_broker" {
   name       = "${var.stack_description}-domains-broker"
   policy_arn = "${aws_iam_policy.domains_broker.arn}"
-
   roles = [
-    "${aws_iam_role.domains_broker.name}",
+    "${aws_iam_role.domains_broker.name}"
   ]
 }
 

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -1,11 +1,9 @@
 output "az1" {
   value = "${data.aws_availability_zones.available.names[0]}"
 }
-
 output "az2" {
   value = "${data.aws_availability_zones.available.names[1]}"
 }
-
 output "stack_description" {
   value = "${var.stack_description}"
 }
@@ -14,15 +12,12 @@ output "stack_description" {
 output "vpc_region" {
   value = "${var.aws_default_region}"
 }
-
 output "vpc_id" {
   value = "${module.stack.vpc_id}"
 }
-
 output "vpc_cidr" {
   value = "${module.stack.vpc_cidr}"
 }
-
 output "vpc_cidr_dns" {
   value = "${cidrhost("${module.stack.vpc_cidr}", 2)}"
 }
@@ -31,39 +26,30 @@ output "vpc_cidr_dns" {
 output "private_subnet_az1" {
   value = "${module.stack.private_subnet_az1}"
 }
-
 output "private_subnet_az2" {
   value = "${module.stack.private_subnet_az2}"
 }
-
 output "private_subnet_cidr_az1" {
   value = "${module.stack.private_cidr_az1}"
 }
-
 output "private_subnet_cidr_az2" {
   value = "${module.stack.private_cidr_az2}"
 }
-
 output "private_subnet_gateway_az1" {
   value = "${cidrhost("${module.stack.private_cidr_az1}", 1)}"
 }
-
 output "private_subnet_gateway_az2" {
   value = "${cidrhost("${module.stack.private_cidr_az2}", 1)}"
 }
-
 output "private_subnet_reserved_az1" {
   value = "${cidrhost("${module.stack.private_cidr_az1}", 0)} - ${cidrhost("${module.stack.private_cidr_az1}", 3)}"
 }
-
 output "private_subnet_reserved_az2" {
   value = "${cidrhost("${module.stack.private_cidr_az2}", 0)} - ${cidrhost("${module.stack.private_cidr_az2}", 3)}"
 }
-
 output "private_route_table_az1" {
   value = "${module.stack.private_route_table_az1}"
 }
-
 output "private_route_table_az2" {
   value = "${module.stack.private_route_table_az2}"
 }
@@ -72,43 +58,33 @@ output "private_route_table_az2" {
 output "public_subnet_az1" {
   value = "${module.stack.public_subnet_az1}"
 }
-
 output "public_subnet_az2" {
   value = "${module.stack.public_subnet_az2}"
 }
-
 output "public_subnet_cidr_az1" {
   value = "${module.stack.public_cidr_az1}"
 }
-
 output "public_subnet_cidr_az2" {
   value = "${module.stack.public_cidr_az2}"
 }
-
 output "public_subnet_gateway_az1" {
   value = "${cidrhost("${module.stack.public_cidr_az1}", 1)}"
 }
-
 output "public_subnet_gateway_az2" {
   value = "${cidrhost("${module.stack.public_cidr_az2}", 1)}"
 }
-
 output "public_subnet_reserved_az1" {
   value = "${cidrhost("${module.stack.public_cidr_az1}", 0)} - ${cidrhost("${module.stack.public_cidr_az1}", 3)}"
 }
-
 output "public_subnet_reserved_az2" {
   value = "${cidrhost("${module.stack.public_cidr_az2}", 0)} - ${cidrhost("${module.stack.public_cidr_az2}", 3)}"
 }
-
 output "public_route_table" {
   value = "${module.stack.public_route_table}"
 }
-
 output "nat_egress_ip_az1" {
   value = "${module.stack.nat_egress_ip_az1}"
 }
-
 output "nat_egress_ip_az2" {
   value = "${module.stack.nat_egress_ip_az2}"
 }
@@ -117,31 +93,24 @@ output "nat_egress_ip_az2" {
 output "services_subnet_az1" {
   value = "${module.cf.services_subnet_az1}"
 }
-
 output "services_subnet_az2" {
   value = "${module.cf.services_subnet_az2}"
 }
-
 output "services_subnet_cidr_az1" {
   value = "${module.cf.services_cidr_1}"
 }
-
 output "services_subnet_cidr_az2" {
   value = "${module.cf.services_cidr_2}"
 }
-
 output "services_subnet_gateway_az1" {
   value = "${cidrhost("${module.cf.services_cidr_1}", 1)}"
 }
-
 output "services_subnet_gateway_az2" {
   value = "${cidrhost("${module.cf.services_cidr_2}", 1)}"
 }
-
 output "services_subnet_reserved_az1" {
   value = "${cidrhost("${module.cf.services_cidr_1}", 0)} - ${cidrhost("${module.cf.services_cidr_1}", 3)}"
 }
-
 output "services_subnet_reserved_az2" {
   value = "${cidrhost("${module.cf.services_cidr_2}", 0)} - ${cidrhost("${module.cf.services_cidr_2}", 3)}"
 }
@@ -150,32 +119,24 @@ output "services_subnet_reserved_az2" {
 /* TODO: Make this go away */
 data "template_file" "logsearch_static_ips" {
   count = 31
-
   vars {
     address = "${cidrhost("${module.cf.services_cidr_1}", "${count.index + 20}")}"
   }
-
   template = "$${address}"
 }
-
 output "logsearch_static_ips" {
   value = ["${data.template_file.logsearch_static_ips.*.rendered}"]
 }
-
 data "template_file" "kubernetes_static_ips" {
   count = 50
-
   vars {
     address = "${cidrhost("${module.cf.services_cidr_1}", "${count.index + 200}")}"
   }
-
   template = "$${address}"
 }
-
 output "kubernetes_static_ips" {
   value = ["${data.template_file.kubernetes_static_ips.*.rendered}"]
 }
-
 output "services_static_ips" {
   value = "${concat(
     data.template_file.logsearch_static_ips.*.rendered,
@@ -187,7 +148,6 @@ output "services_static_ips" {
 output "main_lb_name" {
   value = "${aws_lb.main.name}"
 }
-
 output "main_lb_dns_name" {
   value = "${aws_lb.main.dns_name}"
 }
@@ -196,7 +156,6 @@ output "main_lb_dns_name" {
 output "cf_lb_name" {
   value = "${module.cf.lb_name}"
 }
-
 output "cf_lb_dns_name" {
   value = "${module.cf.lb_dns_name}"
 }
@@ -204,7 +163,6 @@ output "cf_lb_dns_name" {
 output "cf_apps_lb_name" {
   value = "${module.cf.apps_lb_name}"
 }
-
 output "cf_apps_lb_dns_name" {
   value = "${module.cf.apps_lb_dns_name}"
 }
@@ -215,13 +173,14 @@ output "cf_router_target_groups" {
     list("${module.cf.apps_lb_target_group}"),
     aws_lb_target_group.domains_broker_apps.*.name,
     aws_lb_target_group.domains_broker_challenge.*.name,
+    aws_lb_target_group.domain_broker_v2_apps.*.name,
+    aws_lb_target_group.domain_broker_v2_challenge.*.name
   )}"
 }
 
 output "cf_target_group" {
   value = "${module.cf.lb_target_group}"
 }
-
 output "cf_apps_target_group" {
   value = "${module.cf.apps_lb_target_group}"
 }
@@ -230,48 +189,38 @@ output "cf_apps_target_group" {
 output "bosh_security_group" {
   value = "${module.stack.bosh_security_group}"
 }
-
 output "local_vpc_traffic_security_group" {
-  value = "${module.stack.local_vpc_traffic_security_group}"
+    value = "${module.stack.local_vpc_traffic_security_group}"
 }
-
 output "web_traffic_security_group" {
   value = "${module.stack.web_traffic_security_group}"
 }
 
 /* RDS Network */
 output "rds_subnet_az1" {
-  value = "${module.stack.rds_subnet_az1}"
+    value = "${module.stack.rds_subnet_az1}"
 }
-
 output "rds_subnet_az2" {
-  value = "${module.stack.rds_subnet_az2}"
+    value = "${module.stack.rds_subnet_az2}"
 }
-
 output "rds_subnet_cidr_az1" {
   value = "${module.stack.rds_private_cidr_1}"
 }
-
 output "rds_subnet_cidr_az2" {
   value = "${module.stack.rds_private_cidr_2}"
 }
-
 output "rds_subnet_group" {
-  value = "${module.stack.rds_subnet_group}"
+    value = "${module.stack.rds_subnet_group}"
 }
-
 output "rds_mysql_security_group" {
   value = "${module.stack.rds_mysql_security_group}"
 }
-
 output "rds_postgres_security_group" {
   value = "${module.stack.rds_postgres_security_group}"
 }
-
 output "rds_mssql_security_group" {
   value = "${module.stack.rds_mssql_security_group}"
 }
-
 output "rds_oracle_security_group" {
   value = "${module.stack.rds_oracle_security_group}"
 }
@@ -280,31 +229,24 @@ output "rds_oracle_security_group" {
 output "elasticache_subnet_az1" {
   value = "${module.elasticache_broker_network.elasticache_subnet_az1}"
 }
-
 output "elasticache_subnet_az2" {
   value = "${module.elasticache_broker_network.elasticache_subnet_az2}"
 }
-
 output "elasticache_subnet_cidr_az1" {
   value = "${module.elasticache_broker_network.elasticache_private_cidr_1}"
 }
-
 output "elasticache_subnet_cidr_az2" {
   value = "${module.elasticache_broker_network.elasticache_private_cidr_2}"
 }
-
 output "elasticache_subnet_group" {
   value = "${module.elasticache_broker_network.elasticache_subnet_group}"
 }
-
 output "elasticache_redis_security_group" {
   value = "${module.elasticache_broker_network.elasticache_redis_security_group}"
 }
-
 output "elasticache_broker_elb_name" {
   value = "${module.elasticache_broker_network.elasticache_elb_name}"
 }
-
 output "elasticache_broker_elb_dns_name" {
   value = "${module.elasticache_broker_network.elasticache_elb_dns_name}"
 }
@@ -313,27 +255,21 @@ output "elasticache_broker_elb_dns_name" {
 output "bosh_rds_url_curr" {
   value = "${module.stack.bosh_rds_url_curr}"
 }
-
 output "bosh_rds_host_curr" {
   value = "${module.stack.bosh_rds_host_curr}"
 }
-
 output "bosh_rds_url_prev" {
   value = "${module.stack.bosh_rds_url_prev}"
 }
-
 output "bosh_rds_host_prev" {
   value = "${module.stack.bosh_rds_host_prev}"
 }
-
 output "bosh_rds_port" {
   value = "${module.stack.bosh_rds_port}"
 }
-
 output "bosh_rds_username" {
   value = "${module.stack.bosh_rds_username}"
 }
-
 output "bosh_rds_password" {
   value = "${module.stack.bosh_rds_password}"
 }
@@ -342,23 +278,18 @@ output "bosh_rds_password" {
 output "cf_rds_url" {
   value = "${module.cf.cf_rds_url}"
 }
-
 output "cf_rds_host" {
   value = "${module.cf.cf_rds_host}"
 }
-
 output "cf_rds_port" {
   value = "${module.cf.cf_rds_port}"
 }
-
 output "cf_rds_username" {
   value = "${module.cf.cf_rds_username}"
 }
-
 output "cf_rds_password" {
   value = "${module.cf.cf_rds_password}"
 }
-
 output "cf_rds_engine" {
   value = "${module.cf.cf_rds_engine}"
 }
@@ -367,19 +298,15 @@ output "cf_rds_engine" {
 output "credhub_rds_url" {
   value = "${module.stack.credhub_rds_url}"
 }
-
 output "credhub_rds_host" {
   value = "${module.stack.credhub_rds_host}"
 }
-
 output "credhub_rds_port" {
   value = "${module.stack.credhub_rds_port}"
 }
-
 output "credhub_rds_username" {
   value = "${module.stack.credhub_rds_username}"
 }
-
 output "credhub_rds_password" {
   value = "${module.stack.credhub_rds_password}"
 }
@@ -397,15 +324,12 @@ output "diego_elb_dns_name" {
 output "kubernetes_elb_name" {
   value = "${module.kubernetes.kubernetes_elb_name}"
 }
-
 output "kubernetes_elb_dns_name" {
   value = "${module.kubernetes.kubernetes_elb_dns_name}"
 }
-
 output "kubernetes_elb_security_group" {
   value = "${module.kubernetes.kubernetes_elb_security_group}"
 }
-
 output "kubernetes_ec2_security_group" {
   value = "${module.kubernetes.kubernetes_ec2_security_group}"
 }
@@ -414,7 +338,6 @@ output "kubernetes_ec2_security_group" {
 output "logsearch_elb_name" {
   value = "${module.logsearch.logsearch_elb_name}"
 }
-
 output "logsearch_elb_dns_name" {
   value = "${module.logsearch.logsearch_elb_dns_name}"
 }
@@ -422,7 +345,6 @@ output "logsearch_elb_dns_name" {
 output "platform_syslog_elb_name" {
   value = "${module.logsearch.platform_syslog_elb_name}"
 }
-
 output "platform_syslog_elb_dns_name" {
   value = "${module.logsearch.platform_syslog_elb_dns_name}"
 }
@@ -440,11 +362,9 @@ output "shibboleth_lb_target_group" {
 output "admin_lb_name" {
   value = "${module.admin.admin_lb_name}"
 }
-
 output "admin_lb_dns_name" {
   value = "${module.admin.admin_lb_dns_name}"
 }
-
 output "admin_lb_target_group" {
   value = "${module.admin.admin_lb_target_group}"
 }
@@ -453,47 +373,36 @@ output "admin_lb_target_group" {
 output "default_profile" {
   value = "${module.default_role.profile_name}"
 }
-
 output "bosh_profile" {
   value = "${module.bosh_role.profile_name}"
 }
-
 output "bosh_compilation_profile" {
   value = "${module.bosh_compilation_role.profile_name}"
 }
-
 output "logsearch_ingestor_profile" {
   value = "${module.logsearch_ingestor_role.profile_name}"
 }
-
 output "kubernetes_master_profile" {
   value = "${module.kubernetes_master_role.profile_name}"
 }
-
 output "kubernetes_minion_profile" {
   value = "${module.kubernetes_minion_role.profile_name}"
 }
-
 output "kubernetes_node_profile" {
   value = "${module.kubernetes_node_role.profile_name}"
 }
-
 output "kubernetes_logger_profile" {
   value = "${module.kubernetes_logger_role.profile_name}"
 }
-
 output "etcd_backup_profile" {
   value = "${module.etcd_backup_role.profile_name}"
 }
-
 output "cf_blobstore_profile" {
   value = "${module.cf_blobstore_role.profile_name}"
 }
-
 output "elasticache_broker_profile" {
   value = "${module.elasticache_broker_role.profile_name}"
 }
-
 output "platform_profile" {
   value = "${module.platform_role.profile_name}"
 }
@@ -505,10 +414,9 @@ output "upstream_bosh_compilation_profile" {
 output "bosh_static_ip" {
   value = "${cidrhost("${module.stack.private_cidr_az1}", 7)}"
 }
-
 output "bosh_network_static_ips" {
   value = [
-    "${cidrhost("${module.stack.private_cidr_az1}", 7)}",
+    "${cidrhost("${module.stack.private_cidr_az1}", 7)}"
   ]
 }
 
@@ -516,27 +424,21 @@ output "bosh_network_static_ips" {
 output "logsearch_archive_bucket_name" {
   value = "${module.cf.logsearch_archive_bucket_name}"
 }
-
 output "etcd_backup_bucket_name" {
   value = "${module.cf.etcd_backup_bucket_name}"
 }
-
 output "bosh_blobstore_bucket" {
   value = "${module.bosh_blobstore_bucket.bucket_name}"
 }
-
-output "elb_log_bucket" {
+output "elb_log_bucket"{
   value = "${var.log_bucket_name}"
 }
-
 output "tooling_bosh_static_ip" {
   value = "${data.terraform_remote_state.target_vpc.tooling_bosh_static_ip}"
 }
-
 output "master_bosh_static_ip" {
   value = "${data.terraform_remote_state.target_vpc.master_bosh_static_ip}"
 }
-
 output "nessus_static_ip" {
   value = "${data.terraform_remote_state.target_vpc.nessus_static_ip}"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

This reverts commit 739d7ce88e3e067c291677b012a91bfb7c767aa3.

Turns out the v2 resources were sharing names with other resources
:shrug:.  when terraform went to remove these, it broke stuff in staging
and dev.

## security considerations

None