### PR TITLE
Simplify configuration for external-domain-broker

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -79,13 +79,13 @@ jobs:
       AWS_DEFAULT_REGION: ((aws_external_region))
       TF_VAR_stack_description: staging
       TF_VAR_aws_default_region: ((aws_external_region))
+      # Do not copy the pattern below.  You should not need separate variables
+      # for staging/prod.  Instead, use ${var.stack_name} in your .tf and get
+      # IDs from `data` resources.
       TF_VAR_cdn_broker_username: ((cdn_broker_username_staging))
       TF_VAR_cdn_broker_bucket: ((cdn_broker_bucket_staging))
       TF_VAR_cdn_broker_cloudfront_prefix: ((cdn_broker_cloudfront_prefix_staging))
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_staging))
-      TF_VAR_external_domain_broker_username: ((external_domain_broker_username_staging))
-      TF_VAR_external_domain_broker_cloudfront_prefix: ((external_domain_broker_cloudfront_prefix_staging))
-      TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_staging))
       TF_VAR_domain_broker_v2_username: ((domain_broker_v2_username_staging))
       TF_VAR_domain_broker_v2_bucket: ((domain_broker_v2_bucket_staging))
       TF_VAR_domain_broker_v2_cloudfront_prefix: ((domain_broker_v2_cloudfront_prefix_staging))
@@ -142,13 +142,13 @@ jobs:
       AWS_DEFAULT_REGION: ((aws_external_region))
       TF_VAR_stack_description: production
       TF_VAR_aws_default_region: ((aws_external_region))
+      # Do not copy the pattern below.  You should not need separate variables
+      # for staging/prod.  Instead, use ${var.stack_name} in your .tf and get
+      # IDs from `data` resources.
       TF_VAR_cdn_broker_username: ((cdn_broker_username_production))
       TF_VAR_cdn_broker_bucket: ((cdn_broker_bucket_production))
       TF_VAR_cdn_broker_cloudfront_prefix: ((cdn_broker_cloudfront_prefix_production))
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_production))
-      TF_VAR_external_domain_broker_username: ((external_domain_broker_username_production))
-      TF_VAR_external_domain_broker_cloudfront_prefix: ((external_domain_broker_cloudfront_prefix_production))
-      TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_production))
       TF_VAR_domain_broker_v2_username: ((domain_broker_v2_username_production))
       TF_VAR_domain_broker_v2_bucket: ((domain_broker_v2_bucket_production))
       TF_VAR_domain_broker_v2_cloudfront_prefix: ((domain_broker_v2_cloudfront_prefix_production))
@@ -340,6 +340,9 @@ jobs:
       AWS_DEFAULT_REGION: ((aws_default_region))
       TF_VAR_stack_description: development
       TF_VAR_force_restricted_network: "yes"
+      # Do not copy the pattern below.  You should not need separate variables
+      # for staging/prod.  Instead, use ${var.stack_name} in your .tf and get
+      # IDs from `data` resources.
       TF_VAR_rds_password: ((development_rds_password))
       TF_VAR_rds_db_size: ((development_rds_db_size))
       TF_VAR_rds_apply_immediately: "true"
@@ -452,6 +455,9 @@ jobs:
       AWS_DEFAULT_REGION: ((aws_default_region))
       TF_VAR_stack_description: staging
       TF_VAR_force_restricted_network: "no"
+      # Do not copy the pattern below.  You should not need separate variables
+      # for staging/prod.  Instead, use ${var.stack_name} in your .tf and get
+      # IDs from `data` resources.
       TF_VAR_rds_password: ((staging_rds_password))
       TF_VAR_rds_db_size: ((staging_rds_db_size))
       TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
@@ -561,6 +567,9 @@ jobs:
       AWS_DEFAULT_REGION: ((aws_default_region))
       TF_VAR_stack_description: production
       TF_VAR_force_restricted_network: "no"
+      # Do not copy the pattern below.  You should not need separate variables
+      # for staging/prod.  Instead, use ${var.stack_name} in your .tf and get
+      # IDs from `data` resources.
       TF_VAR_rds_password: ((production_rds_password))
       TF_VAR_rds_db_size: ((production_rds_db_size))
       TF_VAR_credhub_rds_password: ((production_credhub_rds_password))

--- a/terraform/modules/external_domain_broker/policy.json
+++ b/terraform/modules/external_domain_broker/policy.json
@@ -10,7 +10,7 @@
         "iam:UpdateServerCertificate"
       ],
       "Resource": [
-        "arn:${aws_partition}:iam::${account_id}:server-certificate/cloudfront/${cloudfront_prefix}"
+        "arn:aws:iam::${account_id}:server-certificate/cloudfront/external-domains-${stack}/*"
       ]
     },
     {
@@ -24,7 +24,7 @@
         "route53:ChangeResourceRecordSets"
       ],
       "Resource": [
-        "arn:${aws_partition}:route53:::hostedzone/${hosted_zone}"
+        "arn:aws:route53:::hostedzone/${hosted_zone_id}"
       ]
     }
   ]

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "zone" {
-  name    = "${var.hosted_zone}"
+  name    = "external-domains-${var.stack_description}.cloud.gov"
   comment = "Hosts TXT and CNAME records for the external-domain-broker"
 }
 
@@ -25,15 +25,14 @@ data "template_file" "policy" {
   template = "${file("${path.module}/policy.json")}"
 
   vars {
-    aws_partition     = "${var.aws_partition}"
     account_id        = "${var.account_id}"
-    cloudfront_prefix = "${var.cloudfront_prefix}"
-    hosted_zone       = "${aws_route53_zone.zone.zone_id}"
+    hosted_zone_id    = "${aws_route53_zone.zone.zone_id}"
+    stack             = "${var.stack_description}"
   }
 }
 
 resource "aws_iam_user" "iam_user" {
-  name = "${var.username}"
+  name = "external-domain-broker-${var.stack_description}"
 }
 
 resource "aws_iam_access_key" "iam_access_key_v3" {

--- a/terraform/modules/external_domain_broker/variables.tf
+++ b/terraform/modules/external_domain_broker/variables.tf
@@ -1,5 +1,2 @@
-variable "username" {}
 variable "account_id" {}
-variable "aws_partition" {}
-variable "cloudfront_prefix" {}
-variable "hosted_zone" {}
+variable "stack_description" {}

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -13,10 +13,7 @@ module "external_domain_broker" {
   source = "../../modules/external_domain_broker"
 
   account_id        = "${data.aws_caller_identity.current.account_id}"
-  aws_partition     = "${data.aws_partition.current.partition}"
-  username          = "${var.external_domain_broker_username}"
-  cloudfront_prefix = "${var.external_domain_broker_cloudfront_prefix}"
-  hosted_zone       = "${var.external_domain_broker_hosted_zone}"
+  stack_description = "${var.stack_description}"
 }
 
 module "cdn_broker" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- We should NOT be passing in `TF_VAR_foo_staging` or `TF_VAR_foo_production` variables into our pipeline tasks.  We already pass in `STACK_NAME`.  This should be enough.
- Change values to match what's configured in the broker and its pipeline.

[Closes cloud-gov/external-domain-broker#71]

## security considerations

None
