### PR TITLE
add external domain broker user for govcloud partition

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/outputs.tf
+++ b/terraform/modules/external_domain_broker_govcloud/outputs.tf
@@ -1,0 +1,15 @@
+output "username" {
+  value = "${aws_iam_user.iam_user.name}"
+}
+output "access_key_id_prev" {
+  value = ""
+}
+output "secret_access_key_prev" {
+  value = ""
+}
+output "access_key_id_curr" {
+  value = "${aws_iam_access_key.iam_access_key_v1.id}"
+}
+output "secret_access_key_curr" {
+  value = "${aws_iam_access_key.iam_access_key_v1.secret}"
+}

--- a/terraform/modules/external_domain_broker_govcloud/policy.json
+++ b/terraform/modules/external_domain_broker_govcloud/policy.json
@@ -1,0 +1,23 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListServerCertificates",
+        "iam:UploadServerCertificate",
+        "iam:DeleteServerCertificate"
+      ],
+      "Resource": [
+        "arn:aws-gov:iam::${account_id}:server-certificate/alb/external-domain-broker-${stack}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:*"
+      ],
+      "Resource": ["*"]
+    }
+  ]
+}

--- a/terraform/modules/external_domain_broker_govcloud/resources.tf
+++ b/terraform/modules/external_domain_broker_govcloud/resources.tf
@@ -12,7 +12,7 @@ data "template_file" "policy" {
 }
 
 resource "aws_iam_user" "iam_user" {
-  name = "external-domain-broker-${var.stack_description}"
+  name = "external-domain-broker-gov-${var.stack_description}"
 }
 
 resource "aws_iam_access_key" "iam_access_key_v1" {

--- a/terraform/modules/external_domain_broker_govcloud/resources.tf
+++ b/terraform/modules/external_domain_broker_govcloud/resources.tf
@@ -1,0 +1,26 @@
+# These resources are for https://github.com/cloud-gov/external-domain-broker
+# Note that the broker needs both commercial and govcloud users because it operates
+# on both commercial (cloudfront, route53) and govcloud (alb) resources
+
+data "template_file" "policy" {
+  template = "${file("${path.module}/policy.json")}"
+
+  vars {
+    account_id        = "${var.account_id}"
+    stack             = "${var.stack_description}"
+  }
+}
+
+resource "aws_iam_user" "iam_user" {
+  name = "external-domain-broker-${var.stack_description}"
+}
+
+resource "aws_iam_access_key" "iam_access_key_v1" {
+  user = "${aws_iam_user.iam_user.name}"
+}
+
+resource "aws_iam_user_policy" "iam_policy" {
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = "${aws_iam_user.iam_user.name}"
+  policy = "${data.template_file.policy.rendered}"
+}

--- a/terraform/modules/external_domain_broker_govcloud/variables.tf
+++ b/terraform/modules/external_domain_broker_govcloud/variables.tf
@@ -1,0 +1,2 @@
+variable "account_id" {}
+variable "stack_description" {}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -214,3 +214,10 @@ module "elasticache_broker_network" {
   elb_security_groups        = ["${module.stack.bosh_security_group}"]
   log_bucket_name            = "${var.log_bucket_name}"
 }
+
+module "external_domain_broker_govcloud" {
+  source = "../../modules/external_domain_broker_govcloud"
+
+  account_id        = "${data.aws_caller_identity.current.account_id}"
+  stack_description = "${var.stack_description}"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- create an exernal-domain-broker user with correct permissions in govcloud

## security considerations
Adds a new user with permissions.