### PR TITLE
correct iam server certificate path for external domain broker

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/policy.json
+++ b/terraform/modules/external_domain_broker_govcloud/policy.json
@@ -9,7 +9,7 @@
         "iam:DeleteServerCertificate"
       ],
       "Resource": [
-        "arn:aws-us-gov:iam::${account_id}:server-certificate/alb/external-domain-broker-${stack}"
+        "arn:aws-us-gov:iam::${account_id}:server-certificate/alb/external-domains-${stack}"
       ]
     },
     {

--- a/terraform/modules/external_domain_broker_govcloud/policy.json
+++ b/terraform/modules/external_domain_broker_govcloud/policy.json
@@ -9,7 +9,7 @@
         "iam:DeleteServerCertificate"
       ],
       "Resource": [
-        "arn:aws-us-gov:iam::${account_id}:server-certificate/alb/external-domains-${stack}"
+        "arn:aws-us-gov:iam::${account_id}:server-certificate/alb/external-domains-${stack}/*"
       ]
     },
     {


### PR DESCRIPTION
## Changes proposed in this pull request:
- correct the path expected for the external domain broker user

## security considerations
None