### PR TITLE
revert messing with domain_broker_v2_alb_count

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -589,7 +589,7 @@ jobs:
       TF_VAR_shibboleth_hosts: '["idp.fr.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "5"
-      TF_VAR_domain_broker_v2_alb_count: "5"
+      TF_VAR_domain_broker_v2_alb_count: "3"
       TF_VAR_challenge_bucket: production-domains-broker-challenge
       TF_VAR_iam_cert_prefix: "/domains/production/*"
       TF_VAR_alb_prefix: "production-domains-*"


### PR DESCRIPTION
## Changes proposed in this pull request:
- don't mess with domain_broker_v2_alb_count. This is part of the mess where we have 2 sets of config pointing at the same resources. I thought changing them in sync was important, but it turns out we need to just never change domain_broker_v2_alb_count


## security considerations
None