### PR TITLE
Policy Updates for AWS Broker

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -52,6 +52,69 @@
     {
       "Effect": "Allow",
       "Action": [
+        "es:ESHttpGet",
+        "es:CreateElasticsearchDomain",
+        "es:ListTags",
+        "es:DescribeElasticsearchDomainConfig",
+        "es:ESHttpDelete",
+        "es:GetUpgradeHistory",
+        "es:AddTags",
+        "es:RemoveTags",
+        "es:ESHttpHead",
+        "es:DeleteElasticsearchDomain",
+        "es:DescribeElasticsearchDomain",
+        "es:UpgradeElasticsearchDomain",
+        "es:UpdateElasticsearchDomainConfig",
+        "es:ESHttpPost",
+        "es:GetCompatibleElasticsearchVersions",
+        "es:ESHttpPatch",
+        "es:GetUpgradeStatus",
+        "es:DescribeElasticsearchDomains",
+        "es:ESHttpPut"
+      ],
+      "Resource": [
+        "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:domain:cg-*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "es:ListDomainNames",
+        "es:ListElasticsearchInstanceTypeDetails",
+        "es:CreateElasticsearchServiceRole",
+        "es:DeleteElasticsearchServiceRole",
+        "es:ListElasticsearchInstanceTypes",
+        "es:DescribeElasticsearchInstanceTypeLimits",
+        "es:ListElasticsearchVersions"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
+      "Action": [
+        "iam:GetUser",
+        "iam:CreateUser",
+        "iam:DeleteUser",
+        "iam:ListAccessKeys",
+        "iam:CreateAccessKey",
+        "iam:DeleteAccessKey",
+        "iam:CreatePolicy",
+        "iam:DeletePolicy",
+        "iam:ListAttachedUserPolicies",
+        "iam:AttachUserPolicy",
+        "iam:DetachUserPolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:${aws_partition}:iam::${account_id}:user${iam_path}*",
+        "arn:${aws_partition}:iam::${account_id}:policy${iam_path}",
+        "arn:${aws_partition}:iam::${account_id}:policy${iam_path}*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
           "elasticache:DescribeReplicationGroups",
           "elasticache:RemoveTagsFromResource",
           "elasticache:DescribeCacheParameters",

--- a/terraform/modules/iam_role_policy/aws_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.tf
@@ -7,6 +7,7 @@ data "template_file" "policy" {
     aws_partition = "${var.aws_partition}"
     remote_state_bucket = "${var.remote_state_bucket}"
     rds_subgroup = "${var.rds_subgroup}"
+    iam_path = "${var.iam_path}"
   }
 }
 

--- a/terraform/modules/iam_role_policy/aws_broker/variables.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/variables.tf
@@ -4,3 +4,7 @@ variable "aws_partition" {}
 variable "aws_default_region" {}
 variable "remote_state_bucket" {}
 variable "rds_subgroup" {}
+variable "iam_path" {
+  default = "/"
+}
+


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds Elasticsearch access for AWS Broker
- Adds Iam Access for AWS Broker

## security considerations
This gives permissions for broker to create elasticsearch domains only for our account. Additionally, elasticsearch service requires creating an IAM user so permissions to IAM is added similar to what s3 broker currently has. 
