### PR TITLE
set enabled=true for access_logs per new terraform default

### DIFF
--- a/terraform/modules/admin/admin_elb_main.tf
+++ b/terraform/modules/admin/admin_elb_main.tf
@@ -7,6 +7,7 @@ resource "aws_lb" "admin" {
   access_logs = {
       bucket        = "${var.log_bucket_name}"
       prefix        = "${var.stack_description}"
+      enabled       = true
   }
 }
 

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -7,6 +7,7 @@ resource "aws_lb" "cf_apps" {
   access_logs = {
       bucket        = "${var.log_bucket_name}"
       prefix        = "${var.stack_description}"
+      enabled       = true
   }
 }
 

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -7,6 +7,7 @@ resource "aws_lb" "cf" {
   access_logs = {
       bucket        = "${var.log_bucket_name}"
       prefix        = "${var.stack_description}"
+      enabled       = true
   }
 }
 

--- a/terraform/modules/diego/diego_elb_main.tf
+++ b/terraform/modules/diego/diego_elb_main.tf
@@ -85,5 +85,6 @@ resource "aws_elb" "diego_elb_main" {
    access_logs = {
       bucket        = "${var.log_bucket_name}"
       bucket_prefix        = "${var.stack_description}"
+      enabled       = true
     }
 }

--- a/terraform/modules/elasticache_broker_network/elb.tf
+++ b/terraform/modules/elasticache_broker_network/elb.tf
@@ -26,5 +26,6 @@ resource "aws_elb" "elasticache_elb" {
    access_logs = {
       bucket        = "${var.log_bucket_name}"
       bucket_prefix        = "${var.stack_description}"
+      enabled       = true
     }
 }

--- a/terraform/modules/kubernetes/elb.tf
+++ b/terraform/modules/kubernetes/elb.tf
@@ -27,5 +27,6 @@ resource "aws_elb" "kubernetes_elb" {
    access_logs = {
       bucket        = "${var.log_bucket_name}"
       bucket_prefix        = "${var.stack_description}"
+      enabled       = true
     }
 }

--- a/terraform/modules/logsearch/elb.tf
+++ b/terraform/modules/logsearch/elb.tf
@@ -27,5 +27,6 @@ resource "aws_elb" "logsearch_elb" {
    access_logs = {
       bucket        = "${var.log_bucket_name}"
       bucket_prefix        = "${var.stack_description}"
+      enabled       = true
     }
 }

--- a/terraform/modules/logsearch/elb_platform_syslog.tf
+++ b/terraform/modules/logsearch/elb_platform_syslog.tf
@@ -27,5 +27,6 @@ resource "aws_elb" "platform_syslog_elb" {
    access_logs = {
       bucket        = "${var.log_bucket_name}"
       bucket_prefix        = "${var.stack_description}"
+      enabled       = true
     }
 }

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -100,6 +100,7 @@ resource "aws_lb" "domain_broker_v2" {
   access_logs = {
     bucket = "${var.log_bucket_name}"
     prefix = "${var.stack_description}"
+    enabled       = true
   }
 }
 

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -20,6 +20,7 @@ resource "aws_lb" "domains_broker_internal" {
   access_logs = {
     bucket = "${var.log_bucket_name}"
     prefix = "${var.stack_description}"
+    enabled = true
   }
 }
 
@@ -90,6 +91,7 @@ resource "aws_lb" "domains_broker" {
   access_logs = {
     bucket = "${var.log_bucket_name}"
     prefix = "${var.stack_description}"
+    enabled = true
   }
 }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -45,6 +45,7 @@ resource "aws_lb" "main" {
   access_logs = {
     bucket = "${var.log_bucket_name}"
     prefix = "${var.stack_description}"
+    enabled = true
   }
 }
 

--- a/terraform/stacks/tooling/elb_uaa.tf
+++ b/terraform/stacks/tooling/elb_uaa.tf
@@ -7,6 +7,7 @@ resource "aws_lb" "opsuaa" {
   access_logs = {
       bucket        = "${var.log_bucket_name}"
       prefix        = "${var.stack_description}"
+      enabled       = true
   }
 }
 

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -30,6 +30,7 @@ resource "aws_lb" "main" {
   access_logs = {
       bucket        = "${var.log_bucket_name}"
       prefix        = "${var.stack_description}"
+      enabled       = true
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Terraform _now_ requires "enable = true" for access logging.

## security considerations

We will have access logs again.
