### PR TITLE
More bucket permissions

### DIFF
--- a/terraform/modules/external_domain_broker/policy.json
+++ b/terraform/modules/external_domain_broker/policy.json
@@ -15,6 +15,16 @@
     },
     {
       "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketAcl",
+        "s3:PutBucketAcl"
+      ],
+      "Resource": [
+        "arn:${aws_partition}:s3:::${bucket}"
+      ]
+    },
+    {
+      "Effect": "Allow",
       "Action": "cloudfront:*",
       "Resource": "*"
     },

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -65,5 +65,13 @@ resource "aws_s3_bucket" "cloudfrond_log_bucket" {
     # canonical user id of awslogsdelivery
     id          = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
   }
+  server_side_encryption_configuration {
+        rule {
+            apply_server_side_encryption_by_default {
+                sse_algorithm = "AES256"
+            }
+        }
+    }
+
 
 }

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -30,6 +30,7 @@ data "template_file" "policy" {
     account_id        = "${var.account_id}"
     hosted_zone_id    = "${aws_route53_zone.zone.zone_id}"
     stack             = "${var.stack_description}"
+    bucket            = "external-domain-broker-cloudfront-logs-${var.stack_description}"
   }
 }
 
@@ -51,7 +52,7 @@ data "aws_canonical_user_id" "current_user" {}
 
 resource "aws_s3_bucket" "cloudfrond_log_bucket" {
   bucket = "external-domain-broker-cloudfront-logs-${var.stack_description}"
-    grant {
+  grant {
     id          = "${data.aws_canonical_user_id.current_user.id}"
     type        = "CanonicalUser"
     permissions = ["FULL_CONTROL"]


### PR DESCRIPTION
## Changes proposed in this pull request:
- update bucket permissions to match what AWS wants. I _thought_ just setting the end-goal ACL would work, but apparently we need cloudfront to be able to update it.

## security considerations

Allows greater permissions on the cloudfront user, but it's a requirement per AWS