### PR TITLE
allow aws broker to access all parameter groups

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -14,7 +14,6 @@
         "rds:CreateDBParameterGroup",
         "rds:ModifyDBParameterGroup",
         "rds:DeleteDBParameterGroup",
-        "rds:DescribeDBParameterGroups",
         "rds:DescribeDBParameters",
         "rds:DescribeDBSnapshots",
         "rds:DeleteDBSnapshot"
@@ -24,6 +23,15 @@
         "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:pg:cg-aws-broker-*",
         "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:snapshot:cg-aws-broker-*",
         "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:subgrp:${rds_subgroup}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "rds:DescribeDBParameterGroups"
+      ],
+      "Resource": [
+        "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:pg:*"
       ]
     },
     {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Allow aws_broker to read all db parameter groups. This is necessary because the broker iterates over the parameter groups, and the iteration can't be filtered.

fixes cloud-gov/product#1405

## security considerations
Gives this broker more read permissions, but not much, and it's necessary for the operation of the broker