### PR TITLE
Elasticsearch Infrastructure

### DIFF
--- a/terraform/modules/elasticsearch_broker/outputs.tf
+++ b/terraform/modules/elasticsearch_broker/outputs.tf
@@ -1,0 +1,24 @@
+output "elasticsearch_subnet_az1" {
+  value = "${aws_subnet.az1_elasticsearch.id}"
+}
+
+output "elasticsearch_subnet_az2" {
+  value = "${aws_subnet.az2_elasticsearch.id}"
+}
+
+output "elasticsearch_private_cidr_1" {
+  value = "${aws_subnet.az1_elasticsearch.cidr_block}"
+}
+
+output "elasticsearch_private_cidr_2" {
+  value = "${aws_subnet.az2_elasticsearch.cidr_block}"
+}
+
+output "elasticsearch_subnet_group" {
+  value = "${aws_elasticsearch_subnet_group.elasticsearch.id}"
+}
+
+output "elasticsearch_security_group" {
+  value = "${aws_security_group.elasticsearch.id}"
+}
+

--- a/terraform/modules/elasticsearch_broker/security_group.tf
+++ b/terraform/modules/elasticsearch_broker/security_group.tf
@@ -1,0 +1,23 @@
+resource "aws_security_group" "elasticsearch" {
+  description = "Allow access to incoming elasticsearch traffic"
+  vpc_id = "${var.vpc_id}"
+
+  ingress {
+    from_port = 443
+    to_port = 443
+    protocol = "tcp"
+    security_groups = ["${var.security_groups}"]
+  }
+
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    security_groups = ["${var.security_groups}"]
+  }
+
+  tags {
+    Name = "${var.stack_description} - Incoming Elasticsearch Traffic"
+  }
+}
+

--- a/terraform/modules/elasticsearch_broker/subnets.tf
+++ b/terraform/modules/elasticsearch_broker/subnets.tf
@@ -1,0 +1,35 @@
+resource "aws_subnet" "az1_elasticsearch" {
+  vpc_id = "${var.vpc_id}"
+  cidr_block = "${var.elasticsearch_private_cidr_1}"
+  availability_zone = "${var.az1}"
+
+  tags {
+    Name = "${var.stack_description} (elasticsearch Broker AZ1)"
+  }
+}
+
+resource "aws_subnet" "az2_elasticsearch" {
+  vpc_id = "${var.vpc_id}"
+  cidr_block = "${var.elasticsearch_private_cidr_2}"
+  availability_zone = "${var.az2}"
+
+  tags {
+    Name = "${var.stack_description} (elasticsearch Broker AZ2)"
+  }
+}
+
+resource "aws_elasticsearch_subnet_group" "elasticsearch" {
+  name = "${var.stack_description}"
+  description = "${var.stack_description} (Multi-AZ Subnet Group)"
+  subnet_ids = ["${aws_subnet.az1_elasticsearch.id}", "${aws_subnet.az2_elasticsearch.id}"]
+}
+
+resource "aws_route_table_association" "az1_elasticsearch_rta" {
+  subnet_id = "${aws_subnet.az1_elasticsearch.id}"
+  route_table_id = "${var.az1_route_table}"
+}
+
+resource "aws_route_table_association" "az2_elasticsearch_rta" {
+  subnet_id = "${aws_subnet.az2_elasticsearch.id}"
+  route_table_id = "${var.az2_route_table}"
+}

--- a/terraform/modules/elasticsearch_broker/variables.tf
+++ b/terraform/modules/elasticsearch_broker/variables.tf
@@ -1,0 +1,23 @@
+variable "stack_description" {}
+
+variable "az1" {
+  default = "us-gov-west-1a"
+}
+
+variable "az2" {
+  default = "us-gov-west-1b"
+}
+
+variable "elasticsearch_private_cidr_1" {}
+
+variable "elasticsearch_private_cidr_2" {}
+
+variable "az1_route_table" {}
+
+variable "az2_route_table" {}
+
+variable "vpc_id" {}
+
+variable "security_groups" {
+  type = "list"
+}

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -251,6 +251,26 @@ output "elasticache_broker_elb_dns_name" {
   value = "${module.elasticache_broker_network.elasticache_elb_dns_name}"
 }
 
+/* Elasticsearch Network */
+output "elasticsearch_subnet_az1" {
+  value = "${module.elasticsearch_broker.elasticsearch_subnet_az1}"
+}
+output "elasticsearch_subnet_az2" {
+  value = "${module.elasticsearch_broker.elasticsearch_subnet_az2}"
+}
+output "elasticsearch_subnet_cidr_az1" {
+  value = "${module.elasticsearch_broker.elasticsearch_private_cidr_1}"
+}
+output "elasticsearch_subnet_cidr_az2" {
+  value = "${module.elasticsearch_broker.elasticsearch_private_cidr_2}"
+}
+output "elasticsearch_subnet_group" {
+  value = "${module.elasticsearch_broker.elasticsearch_subnet_group}"
+}
+output "elasticsearch_security_group" {
+  value = "${module.elasticsearch_broker.elasticsearch_security_group}"
+}
+
 /* RDS Bosh Instance */
 output "bosh_rds_url_curr" {
   value = "${module.stack.bosh_rds_url_curr}"

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -216,6 +216,17 @@ module "elasticache_broker_network" {
   log_bucket_name            = "${var.log_bucket_name}"
 }
 
+module "elasticsearch_broker" {
+  source                     = "../../modules/elasticsearch_broker"
+  stack_description          = "${var.stack_description}"
+  elasticsearch_private_cidr_1 = "${cidrsubnet(var.vpc_cidr, 8, 40)}"
+  elasticsearch_private_cidr_2 = "${cidrsubnet(var.vpc_cidr, 8, 42)}"
+  az1_route_table            = "${module.stack.private_route_table_az1}"
+  az2_route_table            = "${module.stack.private_route_table_az2}"
+  vpc_id                     = "${module.stack.vpc_id}"
+  security_groups            = ["${module.stack.bosh_security_group}"]
+}
+
 module "external_domain_broker_govcloud" {
   source = "../../modules/external_domain_broker_govcloud"
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Subnets so Elasticsearch can have its own set of IPs to use
- Security Group which will only allow https (443) to elasticsearch endpoint
-

## security considerations
Makes Elasticsearch even more secure