### PR TITLE
Update Terraform-managed RDS instances - cloudfoundry

### DIFF
--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -1,4 +1,4 @@
-module "cf_database_96" {
+module "cf_database" {
   source = "../rds"
 
   stack_description = "${var.stack_description}"

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -23,27 +23,27 @@ output "apps_lb_target_group" {
 }
 
 output "cf_rds_url" {
-  value = "${module.cf_database_96.rds_url}"
+  value = "${module.cf_database.rds_url}"
 }
 
 output "cf_rds_host" {
-  value = "${module.cf_database_96.rds_host}"
+  value = "${module.cf_database.rds_host}"
 }
 
 output "cf_rds_port" {
-  value = "${module.cf_database_96.rds_port}"
+  value = "${module.cf_database.rds_port}"
 }
 
 output "cf_rds_username" {
-  value = "${module.cf_database_96.rds_username}"
+  value = "${module.cf_database.rds_username}"
 }
 
 output "cf_rds_password" {
-  value = "${module.cf_database_96.rds_password}"
+  value = "${module.cf_database.rds_password}"
 }
 
 output "cf_rds_engine" {
-  value = "${module.cf_database_96.rds_engine}"
+  value = "${module.cf_database.rds_engine}"
 }
 
 /* Services network */

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -29,7 +29,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.15"
+    default = "11.1"
 }
 
 variable "rds_username" {


### PR DESCRIPTION
This changeset is part of a multi-step series of actions to upgrade our Terraform-managed RDS instances that are internal to the cloud.gov platform.  When all steps are completed we should see the following:

- All RDS instances running on the latest version available
- RDS instances down-sized to `db.t3.micro` instances where appropriate, or `db.t3.small`/`db.t3.medium` where still necessary

In order to accomplish this, the instances have to be upgraded in phases since you cannot go from a `9.6.x` release straight to a `12.x` release.  Furthermore, the `db.t3.*` instance class is not available for anything below PostgreSQL `11.5` (all internal databases are PostgreSQL instances).  In our other work updating and down-sizing other PostgreSQL instances, we have found that we can upgrade from a `9.6.x` release to `11.1`, then go to the latest `12.x` release (`12.3` at the time this PR was opened), provided there are no extra extensions enabled or `undefined` field types.

## Initial changes proposed in this pull request:
- Change module names to not reference a specific PostgreSQL version
- Update all PostgreSQL instances to version `11.1`

## Future/upcoming proposed changes (separate steps/PRs):
1. Update all PostgreSQL instances to version `12.3`
1. Update PostgreSQL instance classes to `db.t3.micro` where appropriate; `db.t3.small`/`db.t3.medium` where necessary

## Security considerations
None:  these are modifications to existing cloud infrastructure resources defined in a publicly available repository that simply update versions and eventually change instance class designations.

## Maintenance considerations

This will incur some downtime as the instances are upgraded, even those that are set for Multi AZ.  We will need to coordinate when it will be best to go through these updates and changes, especially as we'll have to run through this multiple times to update to the latest version and then apply the instance class changes.