### PR TITLE
Add CDN ListDistributions to limit_check_user for prometheus CDN cert…

### DIFF
--- a/terraform/modules/iam_user/limit_check_user/policy.json
+++ b/terraform/modules/iam_user/limit_check_user/policy.json
@@ -8,6 +8,7 @@
         "apigateway:OPTIONS",
         "autoscaling:Describe*",
         "cloudformation:Describe*",
+        "cloudfront:ListDistributions",
         "cloudtrail:DescribeTrails",
         "cloudtrail:GetEventSelectors",
         "ds:GetDirectoryLimits",


### PR DESCRIPTION
Updating user to support [Add alert for CDN cert expiration](https://github.com/cloud-gov/cg-deploy-prometheus/pull/146)

## Changes proposed in this pull request:
- Add `cloudfront:ListDistributions` actions to `limit_check_user`

## security considerations
none
