### PR TITLE
Bump postgres to 9.6.20

### DIFF
--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -29,7 +29,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.19"
+    default = "9.6.20"
 }
 
 variable "rds_username" {

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -33,7 +33,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_engine_version" {
-  default = "9.6.19"
+  default = "9.6.20"
 }
 
 variable "rds_username" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -23,7 +23,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "9.6.19"
+  default = "9.6.20"
 }
 
 variable "rds_username" {}

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -61,7 +61,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "9.6.19"
+  default = "9.6.20"
 }
 
 variable "rds_username" {
@@ -128,7 +128,7 @@ variable "credhub_rds_username" {
 variable "credhub_rds_password" {}
 
 variable "credhub_rds_db_engine_version" {
-  default = "9.6.19"
+  default = "9.6.20"
 }
 
 variable "rds_parameter_group_name" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -61,7 +61,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "9.6.19"
+  default = "9.6.20"
 }
 
 variable "rds_username" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- bump all postgres to 9.6.20

## security considerations

None. Bumping for latest security features now available in AWS. 
