### PR TITLE
Terraform 0.12.30 Upgrade

### DIFF
--- a/terraform/modules/admin/admin_elb_main.tf
+++ b/terraform/modules/admin/admin_elb_main.tf
@@ -1,25 +1,25 @@
 resource "aws_lb" "admin" {
-  name = "${var.stack_description}-admin"
-  subnets = ["${var.public_subnet_az1}", "${var.public_subnet_az2}"]
-  security_groups = ["${var.security_group}"]
+  name            = "${var.stack_description}-admin"
+  subnets         = [var.public_subnet_az1, var.public_subnet_az2]
+  security_groups = [var.security_group]
   ip_address_type = "dualstack"
-  idle_timeout = 3600
-  access_logs = {
-      bucket        = "${var.log_bucket_name}"
-      prefix        = "${var.stack_description}"
-      enabled       = true
+  idle_timeout    = 3600
+  access_logs {
+    bucket  = var.log_bucket_name
+    prefix  = var.stack_description
+    enabled = true
   }
 }
 
 resource "aws_lb_listener" "admin" {
-  load_balancer_arn = "${aws_lb.admin.arn}"
+  load_balancer_arn = aws_lb.admin.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${var.certificate_arn}"
+  certificate_arn   = var.certificate_arn
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.admin.arn}"
+    target_group_arn = aws_lb_target_group.admin.arn
     type             = "forward"
   }
 }
@@ -28,32 +28,41 @@ resource "aws_lb_target_group" "admin" {
   name     = "${var.stack_description}-admin"
   port     = 8080
   protocol = "HTTP"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold = 2
-    interval = 15
-    path = "/health"
-    timeout = 10
+    healthy_threshold   = 2
+    interval            = 15
+    path                = "/health"
+    timeout             = 10
     unhealthy_threshold = 2
-    matcher = 200
+    matcher             = 200
   }
 }
 
 resource "aws_lb_listener_rule" "admin" {
-  count = "${length(var.hosts)}"
+  count = length(var.hosts)
 
-  listener_arn = "${aws_lb_listener.admin.arn}"
-  priority = "${100 + count.index}"
+  listener_arn = aws_lb_listener.admin.arn
+  priority     = 100 + count.index
 
   action {
-    target_group_arn = "${aws_lb_target_group.admin.arn}"
+    target_group_arn = aws_lb_target_group.admin.arn
     type             = "forward"
   }
 
   condition {
     host_header {
-      values = ["${element(var.hosts, count.index)}"]
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
+      values = [element(var.hosts, count.index)]
     }
   }
 }
+

--- a/terraform/modules/admin/admin_elb_main.tf
+++ b/terraform/modules/admin/admin_elb_main.tf
@@ -53,14 +53,6 @@ resource "aws_lb_listener_rule" "admin" {
 
   condition {
     host_header {
-      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-      # force an interpolation expression to be interpreted as a list by wrapping it
-      # in an extra set of list brackets. That form was supported for compatibility in
-      # v0.11, but is no longer supported in Terraform v0.12.
-      #
-      # If the expression in the following list itself returns a list, remove the
-      # brackets to avoid interpretation as a list of lists. If the expression
-      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [element(var.hosts, count.index)]
     }
   }

--- a/terraform/modules/admin/outputs.tf
+++ b/terraform/modules/admin/outputs.tf
@@ -1,9 +1,12 @@
 output "admin_lb_name" {
-  value = "${aws_lb.admin.name}"
+  value = aws_lb.admin.name
 }
+
 output "admin_lb_dns_name" {
-  value = "${aws_lb.admin.dns_name}"
+  value = aws_lb.admin.dns_name
 }
+
 output "admin_lb_target_group" {
-  value = "${aws_lb_target_group.admin.name}"
+  value = aws_lb_target_group.admin.name
 }
+

--- a/terraform/modules/admin/variables.tf
+++ b/terraform/modules/admin/variables.tf
@@ -1,11 +1,25 @@
-variable "stack_description" {}
-
-variable "vpc_id" {}
-variable "security_group" {}
-variable "certificate_arn" {}
-variable "public_subnet_az1" {}
-variable "public_subnet_az2" {}
-variable "hosts" {
-  type = "list"
+variable "stack_description" {
 }
-variable "log_bucket_name" {}
+
+variable "vpc_id" {
+}
+
+variable "security_group" {
+}
+
+variable "certificate_arn" {
+}
+
+variable "public_subnet_az1" {
+}
+
+variable "public_subnet_az2" {
+}
+
+variable "hosts" {
+  type = list(string)
+}
+
+variable "log_bucket_name" {
+}
+

--- a/terraform/modules/admin/versions.tf
+++ b/terraform/modules/admin/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/bootstrap_buckets/buckets.tf
+++ b/terraform/modules/bootstrap_buckets/buckets.tf
@@ -1,59 +1,60 @@
 module "varz" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.varz_bucket}"
-    aws_partition = "${var.aws_partition}"
-    versioning = "true"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = var.varz_bucket
+  aws_partition = var.aws_partition
+  versioning    = "true"
 }
 
 module "varz_staging" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.varz_staging_bucket}"
-    aws_partition = "${var.aws_partition}"
-    versioning = "true"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = var.varz_staging_bucket
+  aws_partition = var.aws_partition
+  versioning    = "true"
 }
 
 module "concourse_credentials" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.concourse_credentials_bucket}"
-    aws_partition = "${var.aws_partition}"
-    versioning = "true"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = var.concourse_credentials_bucket
+  aws_partition = var.aws_partition
+  versioning    = "true"
 }
 
 module "tooling_blobstore" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.tooling_blobstore_bucket}"
-    aws_partition = "${var.aws_partition}"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = var.tooling_blobstore_bucket
+  aws_partition = var.aws_partition
 }
 
 module "development_blobstore" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.development_blobstore_bucket}"
-    aws_partition = "${var.aws_partition}"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = var.development_blobstore_bucket
+  aws_partition = var.aws_partition
 }
 
 module "staging_blobstore" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.staging_blobstore_bucket}"
-    aws_partition = "${var.aws_partition}"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = var.staging_blobstore_bucket
+  aws_partition = var.aws_partition
 }
 
 module "production_blobstore" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.production_blobstore_bucket}"
-    aws_partition = "${var.aws_partition}"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = var.production_blobstore_bucket
+  aws_partition = var.aws_partition
 }
 
 module "bosh_release" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.bosh_release_bucket}"
-    aws_partition = "${var.aws_partition}"
-    versioning = "true"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = var.bosh_release_bucket
+  aws_partition = var.aws_partition
+  versioning    = "true"
 }
 
 module "tmp" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.tmp_bucket}"
-    aws_partition = "${var.aws_partition}"
-    versioning = "true"
-    expiration_days = 1
+  source          = "../s3_bucket/encrypted_bucket"
+  bucket          = var.tmp_bucket
+  aws_partition   = var.aws_partition
+  versioning      = "true"
+  expiration_days = 1
 }
+

--- a/terraform/modules/bootstrap_buckets/variables.tf
+++ b/terraform/modules/bootstrap_buckets/variables.tf
@@ -1,11 +1,30 @@
-variable "aws_partition" {}
+variable "aws_partition" {
+}
 
-variable "varz_bucket" {}
-variable "varz_staging_bucket" {}
-variable "concourse_credentials_bucket" {}
-variable "tooling_blobstore_bucket" {}
-variable "development_blobstore_bucket" {}
-variable "staging_blobstore_bucket" {}
-variable "production_blobstore_bucket" {}
-variable "bosh_release_bucket" {}
-variable "tmp_bucket" {}
+variable "varz_bucket" {
+}
+
+variable "varz_staging_bucket" {
+}
+
+variable "concourse_credentials_bucket" {
+}
+
+variable "tooling_blobstore_bucket" {
+}
+
+variable "development_blobstore_bucket" {
+}
+
+variable "staging_blobstore_bucket" {
+}
+
+variable "production_blobstore_bucket" {
+}
+
+variable "bosh_release_bucket" {
+}
+
+variable "tmp_bucket" {
+}
+

--- a/terraform/modules/bootstrap_buckets/versions.tf
+++ b/terraform/modules/bootstrap_buckets/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/bootstrap_concourse/iam_role_bootstrap.tf
+++ b/terraform/modules/bootstrap_concourse/iam_role_bootstrap.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "bootstrap" {
-  name = "bootstrap-${var.aws_access_key_id}"
+  name               = "bootstrap-${var.aws_access_key_id}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -12,22 +12,23 @@ resource "aws_iam_role" "bootstrap" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_instance_profile" "bootstrap" {
   name = "bootstrap-${element(split("-", uuid()), 4)}"
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
-  role = "${aws_iam_role.bootstrap.name}"
+  role = aws_iam_role.bootstrap.name
 }
 
 resource "aws_iam_role_policy" "bootstrap" {
   name = "bootstrap-${element(split("-", uuid()), 4)}"
   lifecycle {
-    ignore_changes = ["name"]
+    ignore_changes = [name]
   }
-  role = "${aws_iam_role.bootstrap.id}"
+  role   = aws_iam_role.bootstrap.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -41,4 +42,6 @@ resource "aws_iam_role_policy" "bootstrap" {
   ]
 }
 EOF
+
 }
+

--- a/terraform/modules/bootstrap_concourse/instance.tf
+++ b/terraform/modules/bootstrap_concourse/instance.tf
@@ -1,28 +1,28 @@
 resource "template_file" "pipeline" {
-    template = "${file("${path.module}/assets/pipeline.yml")}"
+  template = file("${path.module}/assets/pipeline.yml")
 
-    vars {
-        aws_access_key_id = "${var.aws_access_key_id}"
-        aws_secret_access_key = "${var.aws_secret_access_key}"
-        aws_default_region = "${var.aws_default_region}"
-        account_id = "${var.account_id}"
-        remote_state_bucket = "${var.remote_state_bucket}"
-        credentials_bucket = "${var.credentials_bucket}"
-        concourse_username = "${var.concourse_username}"
-        concourse_password = "${var.concourse_password}"
-        default_vpc_id = "${var.default_vpc_id}"
-        default_vpc_cidr = "${var.default_vpc_cidr}"
-        default_vpc_route_table = "${var.default_vpc_route_table}"
-    }
+  vars = {
+    aws_access_key_id       = var.aws_access_key_id
+    aws_secret_access_key   = var.aws_secret_access_key
+    aws_default_region      = var.aws_default_region
+    account_id              = var.account_id
+    remote_state_bucket     = var.remote_state_bucket
+    credentials_bucket      = var.credentials_bucket
+    concourse_username      = var.concourse_username
+    concourse_password      = var.concourse_password
+    default_vpc_id          = var.default_vpc_id
+    default_vpc_cidr        = var.default_vpc_cidr
+    default_vpc_route_table = var.default_vpc_route_table
+  }
 }
 
 resource "aws_instance" "bootstrap_concourse" {
-  ami = "${var.ami_id}"
-  instance_type = "${var.instance_type}"
+  ami           = var.ami_id
+  instance_type = var.instance_type
 
-  security_groups = ["${aws_security_group.bootstrap.name}"]
+  security_groups = [aws_security_group.bootstrap.name]
 
-  iam_instance_profile = "${aws_iam_instance_profile.bootstrap.id}"
+  iam_instance_profile = aws_iam_instance_profile.bootstrap.id
 
   user_data = <<EOF
 username: ${var.concourse_username}
@@ -31,13 +31,15 @@ pipeline: |
 ${template_file.pipeline.rendered}
 EOF
 
+
   connection {
+    host = coalesce(self.public_ip, self.private_ip)
+    type = "ssh"
     user = "ubuntu"
   }
 
-  tags {
+  tags = {
     Name = "bootstrap-${var.aws_access_key_id}"
   }
-
 }
 

--- a/terraform/modules/bootstrap_concourse/network.tf
+++ b/terraform/modules/bootstrap_concourse/network.tf
@@ -1,6 +1,8 @@
-resource "aws_default_vpc" "default" {}
+resource "aws_default_vpc" "default" {
+}
 
 resource "aws_default_subnet" "default_az1" {
-  vpc_id = "${aws_default_vpc.default.id}"
+  vpc_id            = aws_default_vpc.default.id
   availability_zone = "us-gov-west-1a"
 }
+

--- a/terraform/modules/bootstrap_concourse/ouputs.tf
+++ b/terraform/modules/bootstrap_concourse/ouputs.tf
@@ -1,3 +1,4 @@
 output "endpoint" {
   value = "https://${var.concourse_username}:${var.concourse_password}@${aws_instance.bootstrap_concourse.public_dns}/login/basic"
 }
+

--- a/terraform/modules/bootstrap_concourse/sg_bootstrap.tf
+++ b/terraform/modules/bootstrap_concourse/sg_bootstrap.tf
@@ -2,16 +2,17 @@ resource "aws_security_group" "bootstrap" {
   description = "bootstrap concourse 443"
 
   ingress {
-    from_port = 443
-    to_port = 443
-    protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+

--- a/terraform/modules/bootstrap_concourse/variables.tf
+++ b/terraform/modules/bootstrap_concourse/variables.tf
@@ -1,11 +1,12 @@
-variable "concourse_password" {}
+variable "concourse_password" {
+}
 
 variable "concourse_username" {
   default = "ci"
 }
 
 variable "aws_default_region" {
-    default = "us-gov-west-1"
+  default = "us-gov-west-1"
 }
 
 variable "ami_id" {
@@ -16,20 +17,28 @@ variable "instance_type" {
   default = "t2.micro"
 }
 
-variable "credentials_bucket" {}
+variable "credentials_bucket" {
+}
 
-variable "aws_access_key_id" {}
+variable "aws_access_key_id" {
+}
 
-variable "aws_secret_access_key" {}
+variable "aws_secret_access_key" {
+}
 
 variable "remote_state_bucket" {
   default = "terraform-state"
 }
 
-variable "default_vpc_id" {}
+variable "default_vpc_id" {
+}
 
-variable "default_vpc_cidr" {}
+variable "default_vpc_cidr" {
+}
 
-variable "default_vpc_route_table" {}
+variable "default_vpc_route_table" {
+}
 
-variable "account_id" {}
+variable "account_id" {
+}
+

--- a/terraform/modules/bootstrap_concourse/versions.tf
+++ b/terraform/modules/bootstrap_concourse/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -1,8 +1,8 @@
 resource "aws_vpc_endpoint" "private-s3" {
-    vpc_id = "${aws_vpc.main_vpc.id}"
-    service_name = "com.amazonaws.${var.aws_default_region}.s3"
-    route_table_ids = ["${aws_route_table.az1_private_route_table.id}", "${aws_route_table.az2_private_route_table.id}"]
-    policy = <<EOF
+  vpc_id          = aws_vpc.main_vpc.id
+  service_name    = "com.amazonaws.${var.aws_default_region}.s3"
+  route_table_ids = [aws_route_table.az1_private_route_table.id, aws_route_table.az2_private_route_table.id]
+  policy          = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [{
@@ -14,4 +14,6 @@ resource "aws_vpc_endpoint" "private-s3" {
     }]
 }
 EOF
+
 }
+

--- a/terraform/modules/bosh_vpc/network_private.tf
+++ b/terraform/modules/bosh_vpc/network_private.tf
@@ -12,9 +12,9 @@
  */
 
 resource "aws_subnet" "az1_private" {
-  vpc_id = "${aws_vpc.main_vpc.id}"
-  cidr_block = "${var.private_cidr_1}"
-  availability_zone = "${var.az1}"
+  vpc_id            = aws_vpc.main_vpc.id
+  cidr_block        = var.private_cidr_1
+  availability_zone = var.az1
 
   tags = {
     Name = "${var.stack_description} (Private AZ1)"
@@ -22,9 +22,9 @@ resource "aws_subnet" "az1_private" {
 }
 
 resource "aws_subnet" "az2_private" {
-  vpc_id = "${aws_vpc.main_vpc.id}"
-  cidr_block = "${var.private_cidr_2}"
-  availability_zone = "${var.az2}"
+  vpc_id            = aws_vpc.main_vpc.id
+  cidr_block        = var.private_cidr_2
+  availability_zone = var.az2
 
   tags = {
     Name = "${var.stack_description} (Private AZ2)"
@@ -32,7 +32,7 @@ resource "aws_subnet" "az2_private" {
 }
 
 resource "aws_route_table" "az1_private_route_table" {
-  vpc_id = "${aws_vpc.main_vpc.id}"
+  vpc_id = aws_vpc.main_vpc.id
 
   tags = {
     Name = "${var.stack_description} (Private Route Table AZ1)"
@@ -40,7 +40,7 @@ resource "aws_route_table" "az1_private_route_table" {
 }
 
 resource "aws_route_table" "az2_private_route_table" {
-  vpc_id = "${aws_vpc.main_vpc.id}"
+  vpc_id = aws_vpc.main_vpc.id
 
   tags = {
     Name = "${var.stack_description} (Private Route Table AZ2)"
@@ -48,44 +48,44 @@ resource "aws_route_table" "az2_private_route_table" {
 }
 
 resource "aws_route_table_association" "az1_private_rta" {
-  subnet_id = "${aws_subnet.az1_private.id}"
-  route_table_id = "${aws_route_table.az1_private_route_table.id}"
+  subnet_id      = aws_subnet.az1_private.id
+  route_table_id = aws_route_table.az1_private_route_table.id
 }
 
 resource "aws_route_table_association" "az2_private_rta" {
-  subnet_id = "${aws_subnet.az2_private.id}"
-  route_table_id = "${aws_route_table.az2_private_route_table.id}"
+  subnet_id      = aws_subnet.az2_private.id
+  route_table_id = aws_route_table.az2_private_route_table.id
 }
 
 resource "aws_route" "az1_nat_service_route" {
-  route_table_id         = "${aws_route_table.az1_private_route_table.id}"
+  route_table_id         = aws_route_table.az1_private_route_table.id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${aws_nat_gateway.az1_private_nat_service.id}"
+  nat_gateway_id         = aws_nat_gateway.az1_private_nat_service.id
 }
 
 resource "aws_route" "az2_nat_service_route" {
-  route_table_id         = "${aws_route_table.az2_private_route_table.id}"
+  route_table_id         = aws_route_table.az2_private_route_table.id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${aws_nat_gateway.az2_private_nat_service.id}"
+  nat_gateway_id         = aws_nat_gateway.az2_private_nat_service.id
 }
 
 resource "aws_eip" "az1_nat_eip" {
-  vpc   = true
+  vpc = true
   lifecycle {
     prevent_destroy = true
   }
 }
 
 resource "aws_eip" "az2_nat_eip" {
-  vpc   = true
+  vpc = true
   lifecycle {
     prevent_destroy = true
   }
 }
 
 resource "aws_nat_gateway" "az1_private_nat_service" {
-  allocation_id = "${aws_eip.az1_nat_eip.id}"
-  subnet_id     = "${aws_subnet.az1_public.id}"
+  allocation_id = aws_eip.az1_nat_eip.id
+  subnet_id     = aws_subnet.az1_public.id
 
   tags = {
     Name = "Nat Service AZ1 ${var.stack_description}"
@@ -93,10 +93,11 @@ resource "aws_nat_gateway" "az1_private_nat_service" {
 }
 
 resource "aws_nat_gateway" "az2_private_nat_service" {
-  allocation_id = "${aws_eip.az2_nat_eip.id}"
-  subnet_id     = "${aws_subnet.az2_public.id}"
+  allocation_id = aws_eip.az2_nat_eip.id
+  subnet_id     = aws_subnet.az2_public.id
 
   tags = {
     Name = "Nat Service AZ2 ${var.stack_description}"
   }
 }
+

--- a/terraform/modules/bosh_vpc/network_private.tf
+++ b/terraform/modules/bosh_vpc/network_private.tf
@@ -87,7 +87,7 @@ resource "aws_nat_gateway" "az1_private_nat_service" {
   allocation_id = "${aws_eip.az1_nat_eip.id}"
   subnet_id     = "${aws_subnet.az1_public.id}"
 
-  tags {
+  tags = {
     Name = "Nat Service AZ1 ${var.stack_description}"
   }
 }
@@ -96,7 +96,7 @@ resource "aws_nat_gateway" "az2_private_nat_service" {
   allocation_id = "${aws_eip.az2_nat_eip.id}"
   subnet_id     = "${aws_subnet.az2_public.id}"
 
-  tags {
+  tags = {
     Name = "Nat Service AZ2 ${var.stack_description}"
   }
 }

--- a/terraform/modules/bosh_vpc/network_private.tf
+++ b/terraform/modules/bosh_vpc/network_private.tf
@@ -16,7 +16,7 @@ resource "aws_subnet" "az1_private" {
   cidr_block = "${var.private_cidr_1}"
   availability_zone = "${var.az1}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Private AZ1)"
   }
 }
@@ -26,7 +26,7 @@ resource "aws_subnet" "az2_private" {
   cidr_block = "${var.private_cidr_2}"
   availability_zone = "${var.az2}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Private AZ2)"
   }
 }
@@ -34,7 +34,7 @@ resource "aws_subnet" "az2_private" {
 resource "aws_route_table" "az1_private_route_table" {
   vpc_id = "${aws_vpc.main_vpc.id}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Private Route Table AZ1)"
   }
 }
@@ -42,7 +42,7 @@ resource "aws_route_table" "az1_private_route_table" {
 resource "aws_route_table" "az2_private_route_table" {
   vpc_id = "${aws_vpc.main_vpc.id}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Private Route Table AZ2)"
   }
 }

--- a/terraform/modules/bosh_vpc/network_public.tf
+++ b/terraform/modules/bosh_vpc/network_public.tf
@@ -17,7 +17,7 @@ resource "aws_subnet" "az1_public" {
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.main_vpc.ipv6_cidr_block != "" ? aws_vpc.main_vpc.ipv6_cidr_block : "fd00::/8", 8, 0)}"
   availability_zone = "${var.az1}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Public AZ1)"
   }
 }
@@ -29,7 +29,7 @@ resource "aws_subnet" "az2_public" {
   ipv6_cidr_block = "${cidrsubnet(aws_vpc.main_vpc.ipv6_cidr_block != "" ? aws_vpc.main_vpc.ipv6_cidr_block : "fd00::/8", 8, 1)}"
   availability_zone = "${var.az2}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Public AZ2)"
   }
 }
@@ -37,7 +37,7 @@ resource "aws_subnet" "az2_public" {
 resource "aws_internet_gateway" "gw" {
   vpc_id = "${aws_vpc.main_vpc.id}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Gateway)"
   }
 }
@@ -53,7 +53,7 @@ resource "aws_route_table" "public_network" {
     gateway_id = "${aws_internet_gateway.gw.id}"
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Public Route Table)"
   }
 }

--- a/terraform/modules/bosh_vpc/network_public.tf
+++ b/terraform/modules/bosh_vpc/network_public.tf
@@ -11,11 +11,16 @@
  */
 
 resource "aws_subnet" "az1_public" {
-  vpc_id = "${aws_vpc.main_vpc.id}"
-  cidr_block = "${var.public_cidr_1}"
+  vpc_id     = aws_vpc.main_vpc.id
+  cidr_block = var.public_cidr_1
+
   // Hack: Default to a valid ipv6 cidr to handle empty vpc cidr on initial plan
-  ipv6_cidr_block = "${cidrsubnet(aws_vpc.main_vpc.ipv6_cidr_block != "" ? aws_vpc.main_vpc.ipv6_cidr_block : "fd00::/8", 8, 0)}"
-  availability_zone = "${var.az1}"
+  ipv6_cidr_block = cidrsubnet(
+    aws_vpc.main_vpc.ipv6_cidr_block != "" ? aws_vpc.main_vpc.ipv6_cidr_block : "fd00::/8",
+    8,
+    0,
+  )
+  availability_zone = var.az1
 
   tags = {
     Name = "${var.stack_description} (Public AZ1)"
@@ -23,11 +28,16 @@ resource "aws_subnet" "az1_public" {
 }
 
 resource "aws_subnet" "az2_public" {
-  vpc_id = "${aws_vpc.main_vpc.id}"
-  cidr_block = "${var.public_cidr_2}"
+  vpc_id     = aws_vpc.main_vpc.id
+  cidr_block = var.public_cidr_2
+
   // Hack: Default to a valid ipv6 cidr to handle empty vpc cidr on initial plan
-  ipv6_cidr_block = "${cidrsubnet(aws_vpc.main_vpc.ipv6_cidr_block != "" ? aws_vpc.main_vpc.ipv6_cidr_block : "fd00::/8", 8, 1)}"
-  availability_zone = "${var.az2}"
+  ipv6_cidr_block = cidrsubnet(
+    aws_vpc.main_vpc.ipv6_cidr_block != "" ? aws_vpc.main_vpc.ipv6_cidr_block : "fd00::/8",
+    8,
+    1,
+  )
+  availability_zone = var.az2
 
   tags = {
     Name = "${var.stack_description} (Public AZ2)"
@@ -35,7 +45,7 @@ resource "aws_subnet" "az2_public" {
 }
 
 resource "aws_internet_gateway" "gw" {
-  vpc_id = "${aws_vpc.main_vpc.id}"
+  vpc_id = aws_vpc.main_vpc.id
 
   tags = {
     Name = "${var.stack_description} (Gateway)"
@@ -43,14 +53,14 @@ resource "aws_internet_gateway" "gw" {
 }
 
 resource "aws_route_table" "public_network" {
-  vpc_id = "${aws_vpc.main_vpc.id}"
+  vpc_id = aws_vpc.main_vpc.id
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.gw.id}"
+    gateway_id = aws_internet_gateway.gw.id
   }
   route {
     ipv6_cidr_block = "::/0"
-    gateway_id = "${aws_internet_gateway.gw.id}"
+    gateway_id      = aws_internet_gateway.gw.id
   }
 
   tags = {
@@ -59,11 +69,12 @@ resource "aws_route_table" "public_network" {
 }
 
 resource "aws_route_table_association" "az1_public_rta" {
-  subnet_id = "${aws_subnet.az1_public.id}"
-  route_table_id = "${aws_route_table.public_network.id}"
+  subnet_id      = aws_subnet.az1_public.id
+  route_table_id = aws_route_table.public_network.id
 }
 
 resource "aws_route_table_association" "az2_public_rta" {
-  subnet_id = "${aws_subnet.az2_public.id}"
-  route_table_id = "${aws_route_table.public_network.id}"
+  subnet_id      = aws_subnet.az2_public.id
+  route_table_id = aws_route_table.public_network.id
 }
+

--- a/terraform/modules/bosh_vpc/outputs.tf
+++ b/terraform/modules/bosh_vpc/outputs.tf
@@ -1,80 +1,80 @@
 /* VPC */
 output "vpc_id" {
-    value = "${aws_vpc.main_vpc.id}"
+  value = aws_vpc.main_vpc.id
 }
 
 output "vpc_cidr" {
-    value = "${var.vpc_cidr}"
+  value = var.vpc_cidr
 }
 
 /* Private network */
 output "private_subnet_az1" {
-  value = "${aws_subnet.az1_private.id}"
+  value = aws_subnet.az1_private.id
 }
 
 output "private_subnet_az2" {
-  value = "${aws_subnet.az2_private.id}"
+  value = aws_subnet.az2_private.id
 }
 
 output "private_cidr_az1" {
-  value = "${aws_subnet.az1_private.cidr_block}"
+  value = aws_subnet.az1_private.cidr_block
 }
 
 output "private_cidr_az2" {
-  value = "${aws_subnet.az2_private.cidr_block}"
+  value = aws_subnet.az2_private.cidr_block
 }
 
 output "private_route_table_az1" {
-  value = "${aws_route_table.az1_private_route_table.id}"
+  value = aws_route_table.az1_private_route_table.id
 }
 
 output "private_route_table_az2" {
-  value = "${aws_route_table.az2_private_route_table.id}"
+  value = aws_route_table.az2_private_route_table.id
 }
 
 /* Public network */
 output "public_subnet_az1" {
-  value = "${aws_subnet.az1_public.id}"
+  value = aws_subnet.az1_public.id
 }
 
 output "public_subnet_az2" {
-  value = "${aws_subnet.az2_public.id}"
+  value = aws_subnet.az2_public.id
 }
 
 output "public_cidr_az1" {
-  value = "${aws_subnet.az1_public.cidr_block}"
+  value = aws_subnet.az1_public.cidr_block
 }
 
 output "public_cidr_az2" {
-  value = "${aws_subnet.az2_public.cidr_block}"
+  value = aws_subnet.az2_public.cidr_block
 }
 
 output "public_route_table" {
-  value = "${aws_route_table.public_network.id}"
+  value = aws_route_table.public_network.id
 }
 
 output "nat_egress_ip_az1" {
-  value = "${join(",", aws_eip.az1_nat_eip.*.public_ip)}"
+  value = join(",", aws_eip.az1_nat_eip.*.public_ip)
 }
 
 output "nat_egress_ip_az2" {
-  value = "${join(",", aws_eip.az2_nat_eip.*.public_ip)}"
+  value = join(",", aws_eip.az2_nat_eip.*.public_ip)
 }
 
 /* Security Groups */
 output "bosh_security_group" {
-  value = "${aws_security_group.bosh.id}"
+  value = aws_security_group.bosh.id
 }
 
 output "local_vpc_traffic_security_group" {
-    value = "${aws_security_group.local_vpc_traffic.id}"
+  value = aws_security_group.local_vpc_traffic.id
 }
 
 output "web_traffic_security_group" {
-  value = "${aws_security_group.web_traffic.id}"
+  value = aws_security_group.web_traffic.id
 }
 
 output "restricted_web_traffic_security_group" {
-  value = "${aws_security_group.restricted_web_traffic.id}"
+  value = aws_security_group.restricted_web_traffic.id
 }
 

--- a/terraform/modules/bosh_vpc/sg_bosh.tf
+++ b/terraform/modules/bosh_vpc/sg_bosh.tf
@@ -10,7 +10,7 @@ resource "aws_security_group" "bosh" {
   description = "BOSH security group"
   vpc_id = "${aws_vpc.main_vpc.id}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - BOSH"
   }
 }

--- a/terraform/modules/bosh_vpc/sg_bosh.tf
+++ b/terraform/modules/bosh_vpc/sg_bosh.tf
@@ -8,7 +8,7 @@
 
 resource "aws_security_group" "bosh" {
   description = "BOSH security group"
-  vpc_id = "${aws_vpc.main_vpc.id}"
+  vpc_id      = aws_vpc.main_vpc.id
 
   tags = {
     Name = "${var.stack_description} - BOSH"
@@ -16,158 +16,159 @@ resource "aws_security_group" "bosh" {
 }
 
 resource "aws_security_group_rule" "self_reference" {
-    type = "ingress"
-    self = true
-    from_port = 0
-    to_port = 0
-    protocol = -1
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  self              = true
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "bosh_ssh" {
-    type = "ingress"
-    from_port = 22
-    to_port = 22
-    protocol = "tcp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "dns_tcp" {
-    type = "ingress"
-    from_port = 53
-    to_port = 53
-    protocol = "tcp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "dns_udp" {
-    type = "ingress"
-    from_port = 53
-    to_port = 53
-    protocol = "udp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "ntp_udp" {
-    type = "ingress"
-    from_port = 123
-    to_port = 123
-    protocol = "udp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 123
+  to_port           = 123
+  protocol          = "udp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "http_elb" {
-    type = "ingress"
-    from_port = 80
-    to_port = 81
-    protocol = "tcp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 81
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "http_alt_elb" {
-    type = "ingress"
-    from_port = 8080
-    to_port = 8081
-    protocol = "tcp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 8080
+  to_port           = 8081
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "cf_ssh" {
-    type = "ingress"
-    from_port = 4222
-    to_port = 4222
-    protocol = "tcp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 4222
+  to_port           = 4222
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "diego_ssh" {
-    type = "ingress"
-    from_port = 2222
-    to_port = 2222
-    protocol = "tcp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 2222
+  to_port           = 2222
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "bosh_nats" {
-    type = "ingress"
-    from_port = 6868
-    to_port = 6868
-    protocol = "tcp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 6868
+  to_port           = 6868
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "bosh_director" {
-    type = "ingress"
-    from_port = 25555
-    to_port = 25555
-    protocol = "tcp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 25555
+  to_port           = 25555
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "node_exporter" {
-    count = "${length(var.monitoring_security_groups)}"
-    type = "ingress"
-    from_port = 9100
-    to_port = 9100
-    protocol = "tcp"
-    source_security_group_id = "${element(var.monitoring_security_groups, count.index)}"
-    security_group_id = "${aws_security_group.bosh.id}"
+  count                    = length(var.monitoring_security_groups)
+  type                     = "ingress"
+  from_port                = 9100
+  to_port                  = 9100
+  protocol                 = "tcp"
+  source_security_group_id = element(var.monitoring_security_groups, count.index)
+  security_group_id        = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "platform_kibana" {
-    type = "ingress"
-    from_port = 5600
-    to_port = 5600
-    protocol = "tcp"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "ingress"
+  from_port         = 5600
+  to_port           = 5600
+  protocol          = "tcp"
+  cidr_blocks       = [aws_vpc.main_vpc.cidr_block]
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "monitoring_elasticsearch_exporter" {
-    count = "${length(var.monitoring_security_groups)}"
-    type = "ingress"
-    from_port = 9114
-    to_port = 9114
-    protocol = "tcp"
-    source_security_group_id = "${element(var.monitoring_security_groups, count.index)}"
-    security_group_id = "${aws_security_group.bosh.id}"
+  count                    = length(var.monitoring_security_groups)
+  type                     = "ingress"
+  from_port                = 9114
+  to_port                  = 9114
+  protocol                 = "tcp"
+  source_security_group_id = element(var.monitoring_security_groups, count.index)
+  security_group_id        = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "concourse_logsearch" {
-    count = "${length(var.concourse_security_groups)}"
-    type = "ingress"
-    from_port = 9200
-    to_port = 9200
-    protocol = "tcp"
-    source_security_group_id = "${element(var.concourse_security_groups, count.index)}"
-    security_group_id = "${aws_security_group.bosh.id}"
+  count                    = length(var.concourse_security_groups)
+  type                     = "ingress"
+  from_port                = 9200
+  to_port                  = 9200
+  protocol                 = "tcp"
+  source_security_group_id = element(var.concourse_security_groups, count.index)
+  security_group_id        = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "concourse_secureproxy" {
-    count = "${length(var.concourse_security_groups)}"
-    type = "ingress"
-    from_port = 80
-    to_port = 80
-    protocol = "tcp"
-    source_security_group_id = "${element(var.concourse_security_groups, count.index)}"
-    security_group_id = "${aws_security_group.bosh.id}"
+  count                    = length(var.concourse_security_groups)
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = element(var.concourse_security_groups, count.index)
+  security_group_id        = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "outbound" {
-    type = "egress"
-    from_port = 0
-    to_port = 0
-    protocol = -1
-    cidr_blocks = ["0.0.0.0/0"]
-    security_group_id = "${aws_security_group.bosh.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.bosh.id
 }
+

--- a/terraform/modules/bosh_vpc/sg_local_vpc_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_local_vpc_traffic.tf
@@ -8,23 +8,24 @@
 
 resource "aws_security_group" "local_vpc_traffic" {
   description = "Enable access to all VPC CIDR block ips"
-  vpc_id = "${aws_vpc.main_vpc.id}"
+  vpc_id      = aws_vpc.main_vpc.id
 
   ingress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    cidr_blocks = ["${aws_vpc.main_vpc.cidr_block}"]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [aws_vpc.main_vpc.cidr_block]
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags =  {
+  tags = {
     Name = "${var.stack_description} - Local Traffic ${aws_vpc.main_vpc.cidr_block}"
   }
 }
+

--- a/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
@@ -8,29 +8,29 @@
 
 resource "aws_security_group" "restricted_web_traffic" {
   description = "Restricted web type traffic"
-  vpc_id = "${aws_vpc.main_vpc.id}"
+  vpc_id      = aws_vpc.main_vpc.id
 
   ingress {
-    from_port = 80
-    to_port = 80
-    protocol = "tcp"
-    cidr_blocks = ["${var.restricted_ingress_web_cidrs}"]
-    ipv6_cidr_blocks = ["${var.restricted_ingress_web_ipv6_cidrs}"]
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = var.restricted_ingress_web_cidrs
+    ipv6_cidr_blocks = var.restricted_ingress_web_ipv6_cidrs
   }
 
   ingress {
-    from_port = 443
-    to_port = 443
-    protocol = "tcp"
-    cidr_blocks = ["${var.restricted_ingress_web_cidrs}"]
-    ipv6_cidr_blocks = ["${var.restricted_ingress_web_ipv6_cidrs}"]
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = var.restricted_ingress_web_cidrs
+    ipv6_cidr_blocks = var.restricted_ingress_web_ipv6_cidrs
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 
@@ -38,3 +38,4 @@ resource "aws_security_group" "restricted_web_traffic" {
     Name = "${var.stack_description} - Restricted Incoming Web Traffic"
   }
 }
+

--- a/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
@@ -34,7 +34,7 @@ resource "aws_security_group" "restricted_web_traffic" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Restricted Incoming Web Traffic"
   }
 }

--- a/terraform/modules/bosh_vpc/sg_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_web_traffic.tf
@@ -34,7 +34,7 @@ resource "aws_security_group" "web_traffic" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Incoming Web Traffic"
   }
 }

--- a/terraform/modules/bosh_vpc/sg_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_web_traffic.tf
@@ -8,29 +8,29 @@
 
 resource "aws_security_group" "web_traffic" {
   description = "Allow access to incoming web type traffic"
-  vpc_id = "${aws_vpc.main_vpc.id}"
+  vpc_id      = aws_vpc.main_vpc.id
 
   ingress {
-    from_port = 80
-    to_port = 80
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    from_port = 443
-    to_port = 443
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 
@@ -38,3 +38,4 @@ resource "aws_security_group" "web_traffic" {
     Name = "${var.stack_description} - Incoming Web Traffic"
   }
 }
+

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "vpc_cidr" {
   default = "10.0.0.0/16"
@@ -13,7 +14,7 @@ variable "az2" {
 }
 
 variable "aws_default_region" {
-    default = "us-gov-west-1"
+  default = "us-gov-west-1"
 }
 
 variable "public_cidr_1" {
@@ -33,12 +34,12 @@ variable "private_cidr_2" {
 }
 
 variable "restricted_ingress_web_cidrs" {
-  type = "list"
+  type    = list(string)
   default = ["127.0.0.1/32", "192.168.0.1/24"]
 }
 
 variable "restricted_ingress_web_ipv6_cidrs" {
-  type = "list"
+  type    = list(string)
   default = []
 }
 
@@ -47,11 +48,12 @@ variable "nat_gateway_instance_type" {
 }
 
 variable "monitoring_security_groups" {
-  type = "list"
+  type    = list(string)
   default = []
 }
 
 variable "concourse_security_groups" {
-  type = "list"
+  type    = list(string)
   default = []
 }
+

--- a/terraform/modules/bosh_vpc/versions.tf
+++ b/terraform/modules/bosh_vpc/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/bosh_vpc/vpc.tf
+++ b/terraform/modules/bosh_vpc/vpc.tf
@@ -5,15 +5,14 @@
  */
 
 resource "aws_vpc" "main_vpc" {
-  cidr_block = "${var.vpc_cidr}"
-  enable_dns_support = true
-  enable_dns_hostnames = true
+  cidr_block                       = var.vpc_cidr
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
   assign_generated_ipv6_cidr_block = true
 
   tags = {
-    Name = "${var.stack_description}"
+    Name = var.stack_description
   }
-
 }
 
 # Create CloudWatch log group
@@ -23,8 +22,8 @@ resource "aws_cloudwatch_log_group" "main_vpc_flow_log_cloudwatch_log_group" {
 
 # Create IAM role for sending flow logs
 resource "aws_iam_role" "flow_log_role" {
-    name = "${var.stack_description}-flow-log-role"
-    assume_role_policy = <<EOF
+  name               = "${var.stack_description}-flow-log-role"
+  assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -39,12 +38,13 @@ resource "aws_iam_role" "flow_log_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "flow_log_policy" {
-    name = "${var.stack_description}-flow-log-policy"
-    role = "${aws_iam_role.flow_log_role.id}"
-    policy = <<EOF
+  name   = "${var.stack_description}-flow-log-policy"
+  role   = aws_iam_role.flow_log_role.id
+  policy = <<EOF
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -62,11 +62,13 @@ resource "aws_iam_role_policy" "flow_log_policy" {
   ]
 }
 EOF
+
 }
 
 resource "aws_flow_log" "main_vpc_flow_log" {
-  log_destination = "${aws_cloudwatch_log_group.main_vpc_flow_log_cloudwatch_log_group.arn}"
-  iam_role_arn = "${aws_iam_role.flow_log_role.arn}"
-  vpc_id = "${aws_vpc.main_vpc.id}"
-  traffic_type = "ALL"
+  log_destination = aws_cloudwatch_log_group.main_vpc_flow_log_cloudwatch_log_group.arn
+  iam_role_arn    = aws_iam_role.flow_log_role.arn
+  vpc_id          = aws_vpc.main_vpc.id
+  traffic_type    = "ALL"
 }
+

--- a/terraform/modules/cdn_broker/outputs.tf
+++ b/terraform/modules/cdn_broker/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${var.username}"
+  value = var.username
 }
+
 output "access_key_id_prev" {
   value = ""
 }
+
 output "secret_access_key_prev" {
   value = ""
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.id}"
+  value = aws_iam_access_key.iam_access_key_v3.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.secret}"
+  value = aws_iam_access_key.iam_access_key_v3.secret
 }
+

--- a/terraform/modules/cdn_broker/resources.tf
+++ b/terraform/modules/cdn_broker/resources.tf
@@ -1,35 +1,36 @@
 module "cdn_broker_bucket" {
-  source = "../s3_bucket/public_encrypted_bucket"
-  bucket = "${var.bucket}"
-  aws_partition = "${var.aws_partition}"
+  source        = "../s3_bucket/public_encrypted_bucket"
+  bucket        = var.bucket
+  aws_partition = var.aws_partition
 }
 
 data "aws_route53_zone" "zone" {
-  name = "${var.hosted_zone}"
+  name = var.hosted_zone
 }
 
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
-  vars {
-    aws_partition = "${var.aws_partition}"
-    account_id = "${var.account_id}"
-    cloudfront_prefix = "${var.cloudfront_prefix}"
-    hosted_zone = "${data.aws_route53_zone.zone.zone_id}"
-    bucket = "${var.bucket}"
+  vars = {
+    aws_partition     = var.aws_partition
+    account_id        = var.account_id
+    cloudfront_prefix = var.cloudfront_prefix
+    hosted_zone       = data.aws_route53_zone.zone.zone_id
+    bucket            = var.bucket
   }
 }
 
 resource "aws_iam_user" "iam_user" {
-  name = "${var.username}"
+  name = var.username
 }
 
 resource "aws_iam_access_key" "iam_access_key_v3" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name = "${aws_iam_user.iam_user.name}-policy"
-  user = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/cdn_broker/variables.tf
+++ b/terraform/modules/cdn_broker/variables.tf
@@ -1,6 +1,18 @@
-variable "username" {}
-variable "account_id" {}
-variable "aws_partition" {}
-variable "bucket" {}
-variable "cloudfront_prefix" {}
-variable "hosted_zone" {}
+variable "username" {
+}
+
+variable "account_id" {
+}
+
+variable "aws_partition" {
+}
+
+variable "bucket" {
+}
+
+variable "cloudfront_prefix" {
+}
+
+variable "hosted_zone" {
+}
+

--- a/terraform/modules/cdn_broker/versions.tf
+++ b/terraform/modules/cdn_broker/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/cloudfoundry/buckets.tf
+++ b/terraform/modules/cloudfoundry/buckets.tf
@@ -1,37 +1,38 @@
 module "cc-resoures" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.stack_prefix}-cc-resources"
-    aws_partition = "${var.aws_partition}"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = "${var.stack_prefix}-cc-resources"
+  aws_partition = var.aws_partition
 }
 
 module "buildpacks" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.stack_prefix}-buildpacks"
-    aws_partition = "${var.aws_partition}"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = "${var.stack_prefix}-buildpacks"
+  aws_partition = var.aws_partition
 }
 
 module "cc-packages" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.stack_prefix}-cc-packages"
-    aws_partition = "${var.aws_partition}"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = "${var.stack_prefix}-cc-packages"
+  aws_partition = var.aws_partition
 }
 
 module "droplets" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "${var.stack_prefix}-droplets"
-    aws_partition = "${var.aws_partition}"
+  source        = "../s3_bucket/encrypted_bucket"
+  bucket        = "${var.stack_prefix}-droplets"
+  aws_partition = var.aws_partition
 }
 
 module "logsearch-archive" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "logsearch-${var.stack_prefix}"
-    aws_partition = "${var.aws_partition}"
-    expiration_days = 548
+  source          = "../s3_bucket/encrypted_bucket"
+  bucket          = "logsearch-${var.stack_prefix}"
+  aws_partition   = var.aws_partition
+  expiration_days = 548
 }
 
 module "etcd-backup" {
-    source = "../s3_bucket/encrypted_bucket"
-    bucket = "etcd-backup-${var.stack_prefix}"
-    aws_partition = "${var.aws_partition}"
-    expiration_days = 30
+  source          = "../s3_bucket/encrypted_bucket"
+  bucket          = "etcd-backup-${var.stack_prefix}"
+  aws_partition   = var.aws_partition
+  expiration_days = 30
 }
+

--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -10,6 +10,6 @@ module "cf_database_96" {
   rds_username          = var.rds_username
   rds_password          = var.rds_password
   rds_subnet_group      = var.rds_subnet_group
-  rds_security_groups   = [var.rds_security_groups]
+  rds_security_groups   = var.rds_security_groups
 }
 

--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -1,14 +1,15 @@
 module "cf_database_96" {
   source = "../rds"
 
-  stack_description = "${var.stack_description}"
-  rds_instance_type = "${var.rds_instance_type}"
-  rds_db_size = "${var.rds_db_size}"
-  rds_db_engine = "${var.rds_db_engine}"
-  rds_db_engine_version = "${var.rds_db_engine_version}"
-  rds_db_name = "${var.rds_db_name}"
-  rds_username = "${var.rds_username}"
-  rds_password = "${var.rds_password}"
-  rds_subnet_group = "${var.rds_subnet_group}"
-  rds_security_groups = ["${var.rds_security_groups}"]
+  stack_description     = var.stack_description
+  rds_instance_type     = var.rds_instance_type
+  rds_db_size           = var.rds_db_size
+  rds_db_engine         = var.rds_db_engine
+  rds_db_engine_version = var.rds_db_engine_version
+  rds_db_name           = var.rds_db_name
+  rds_username          = var.rds_username
+  rds_password          = var.rds_password
+  rds_subnet_group      = var.rds_subnet_group
+  rds_security_groups   = [var.rds_security_groups]
 }
+

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -1,13 +1,13 @@
 resource "aws_lb" "cf_apps" {
-  name = "${var.stack_description}-cloudfoundry-apps"
-  subnets = ["${var.elb_subnets}"]
-  security_groups = ["${var.elb_security_groups}"]
+  name            = "${var.stack_description}-cloudfoundry-apps"
+  subnets         = var.elb_subnets
+  security_groups = var.elb_security_groups
   ip_address_type = "dualstack"
-  idle_timeout = 3600
-  access_logs = {
-      bucket        = "${var.log_bucket_name}"
-      prefix        = "${var.stack_description}"
-      enabled       = true
+  idle_timeout    = 3600
+  access_logs {
+    bucket  = var.log_bucket_name
+    prefix  = var.stack_description
+    enabled = true
   }
 }
 
@@ -15,38 +15,39 @@ resource "aws_lb_target_group" "cf_apps_target" {
   name     = "${var.stack_description}-cf-apps"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold = 2
-    interval = 5
-    port = 81
-    timeout = 4
+    healthy_threshold   = 2
+    interval            = 5
+    port                = 81
+    timeout             = 4
     unhealthy_threshold = 3
-    matcher = 200
+    matcher             = 200
   }
 }
 
 resource "aws_lb_listener" "cf_apps" {
-  load_balancer_arn = "${aws_lb.cf_apps.arn}"
+  load_balancer_arn = aws_lb.cf_apps.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${var.elb_apps_cert_id}"
+  certificate_arn   = var.elb_apps_cert_id
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.cf_apps_target.arn}"
+    target_group_arn = aws_lb_target_group.cf_apps_target.arn
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener" "cf_apps_http" {
-  load_balancer_arn = "${aws_lb.cf_apps.arn}"
+  load_balancer_arn = aws_lb.cf_apps.arn
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.cf_apps_target.arn}"
+    target_group_arn = aws_lb_target_group.cf_apps_target.arn
     type             = "forward"
   }
 }
+

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -1,13 +1,13 @@
 resource "aws_lb" "cf" {
-  name = "${var.stack_description}-cloudfoundry"
-  subnets = ["${var.elb_subnets}"]
-  security_groups = ["${var.elb_security_groups}"]
+  name            = "${var.stack_description}-cloudfoundry"
+  subnets         = var.elb_subnets
+  security_groups = var.elb_security_groups
   ip_address_type = "dualstack"
-  idle_timeout = 3600
-  access_logs = {
-      bucket        = "${var.log_bucket_name}"
-      prefix        = "${var.stack_description}"
-      enabled       = true
+  idle_timeout    = 3600
+  access_logs {
+    bucket  = var.log_bucket_name
+    prefix  = var.stack_description
+    enabled = true
   }
 }
 
@@ -15,38 +15,39 @@ resource "aws_lb_target_group" "cf_target" {
   name     = "${var.stack_description}-cf"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold = 2
-    interval = 5
-    port = 81
-    timeout = 4
+    healthy_threshold   = 2
+    interval            = 5
+    port                = 81
+    timeout             = 4
     unhealthy_threshold = 3
-    matcher = 200
+    matcher             = 200
   }
 }
 
 resource "aws_lb_listener" "cf" {
-  load_balancer_arn = "${aws_lb.cf.arn}"
+  load_balancer_arn = aws_lb.cf.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${var.elb_main_cert_id}"
+  certificate_arn   = var.elb_main_cert_id
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.cf_target.arn}"
+    target_group_arn = aws_lb_target_group.cf_target.arn
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener" "cf_http" {
-  load_balancer_arn = "${aws_lb.cf.arn}"
+  load_balancer_arn = aws_lb.cf.arn
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.cf_target.arn}"
+    target_group_arn = aws_lb_target_group.cf_target.arn
     type             = "forward"
   }
 }
+

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -1,83 +1,90 @@
 output "lb_name" {
-  value = "${aws_lb.cf.name}"
+  value = aws_lb.cf.name
 }
 
 output "lb_dns_name" {
-  value = "${aws_lb.cf.dns_name}"
+  value = aws_lb.cf.dns_name
 }
 
 output "apps_lb_name" {
-  value = "${aws_lb.cf_apps.name}"
+  value = aws_lb.cf_apps.name
 }
 
 output "apps_lb_dns_name" {
-  value = "${aws_lb.cf_apps.dns_name}"
+  value = aws_lb.cf_apps.dns_name
 }
 
 output "lb_target_group" {
-  value = "${aws_lb_target_group.cf_target.name}"
+  value = aws_lb_target_group.cf_target.name
 }
 
 output "apps_lb_target_group" {
-  value = "${aws_lb_target_group.cf_apps_target.name}"
+  value = aws_lb_target_group.cf_apps_target.name
 }
 
 output "cf_rds_url" {
-  value = "${module.cf_database_96.rds_url}"
+  value = module.cf_database_96.rds_url
 }
 
 output "cf_rds_host" {
-  value = "${module.cf_database_96.rds_host}"
+  value = module.cf_database_96.rds_host
 }
 
 output "cf_rds_port" {
-  value = "${module.cf_database_96.rds_port}"
+  value = module.cf_database_96.rds_port
 }
 
 output "cf_rds_username" {
-  value = "${module.cf_database_96.rds_username}"
+  value = module.cf_database_96.rds_username
 }
 
 output "cf_rds_password" {
-  value = "${module.cf_database_96.rds_password}"
+  value = module.cf_database_96.rds_password
 }
 
 output "cf_rds_engine" {
-  value = "${module.cf_database_96.rds_engine}"
+  value = module.cf_database_96.rds_engine
 }
 
 /* Services network */
 output "services_subnet_az1" {
-  value = "${aws_subnet.az1_services.id}"
+  value = aws_subnet.az1_services.id
 }
+
 output "services_subnet_az2" {
-  value = "${aws_subnet.az2_services.id}"
+  value = aws_subnet.az2_services.id
 }
 
 output "services_cidr_1" {
-  value = "${aws_subnet.az1_services.cidr_block}"
+  value = aws_subnet.az1_services.cidr_block
 }
 
 output "services_cidr_2" {
-  value = "${aws_subnet.az2_services.cidr_block}"
+  value = aws_subnet.az2_services.cidr_block
 }
 
 /* buckets */
 output "buildpacks_bucket_name" {
-  value = "${module.buildpacks.bucket_name}"
+  value = module.buildpacks.bucket_name
 }
+
 output "packages_bucket_name" {
-  value = "${module.cc-packages.bucket_name}"
+  value = module.cc-packages.bucket_name
 }
+
 output "resources_bucket_name" {
-  value = "${module.cc-resoures.bucket_name}"
+  value = module.cc-resoures.bucket_name
 }
+
 output "droplets_bucket_name" {
-  value = "${module.droplets.bucket_name}"
+  value = module.droplets.bucket_name
 }
+
 output "logsearch_archive_bucket_name" {
-  value = "${module.logsearch-archive.bucket_name}"
+  value = module.logsearch-archive.bucket_name
 }
+
 output "etcd_backup_bucket_name" {
-  value = "${module.etcd-backup.bucket_name}"
+  value = module.etcd-backup.bucket_name
 }
+

--- a/terraform/modules/cloudfoundry/service_subnets.tf
+++ b/terraform/modules/cloudfoundry/service_subnets.tf
@@ -12,33 +12,34 @@
  */
 
 resource "aws_subnet" "az1_services" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.services_cidr_1}"
-  availability_zone = "${var.az1}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.services_cidr_1
+  availability_zone = var.az1
 
   tags = {
-    Name = "${var.stack_description} (Services AZ1)"
-    KubernetesCluster = "${var.kubernetes_cluster_id}"
+    Name              = "${var.stack_description} (Services AZ1)"
+    KubernetesCluster = var.kubernetes_cluster_id
   }
 }
 
 resource "aws_subnet" "az2_services" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.services_cidr_2}"
-  availability_zone = "${var.az2}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.services_cidr_2
+  availability_zone = var.az2
 
   tags = {
-    Name = "${var.stack_description} (Services AZ2)"
-    KubernetesCluster = "${var.kubernetes_cluster_id}"
+    Name              = "${var.stack_description} (Services AZ2)"
+    KubernetesCluster = var.kubernetes_cluster_id
   }
 }
 
 resource "aws_route_table_association" "az1_services_rta" {
-  subnet_id = "${aws_subnet.az1_services.id}"
-  route_table_id = "${var.private_route_table_az1}"
+  subnet_id      = aws_subnet.az1_services.id
+  route_table_id = var.private_route_table_az1
 }
 
 resource "aws_route_table_association" "az2_services_rta" {
-  subnet_id = "${aws_subnet.az2_services.id}"
-  route_table_id = "${var.private_route_table_az2}"
+  subnet_id      = aws_subnet.az2_services.id
+  route_table_id = var.private_route_table_az2
 }
+

--- a/terraform/modules/cloudfoundry/service_subnets.tf
+++ b/terraform/modules/cloudfoundry/service_subnets.tf
@@ -16,7 +16,7 @@ resource "aws_subnet" "az1_services" {
   cidr_block = "${var.services_cidr_1}"
   availability_zone = "${var.az1}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Services AZ1)"
     KubernetesCluster = "${var.kubernetes_cluster_id}"
   }
@@ -27,7 +27,7 @@ resource "aws_subnet" "az2_services" {
   cidr_block = "${var.services_cidr_2}"
   availability_zone = "${var.az2}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Services AZ2)"
     KubernetesCluster = "${var.kubernetes_cluster_id}"
   }

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -1,50 +1,56 @@
-variable "elb_main_cert_id" {}
+variable "elb_main_cert_id" {
+}
 
-variable "elb_apps_cert_id" {}
+variable "elb_apps_cert_id" {
+}
 
 variable "elb_subnets" {
-  type = "list"
+  type = list(string)
 }
 
 variable "elb_security_groups" {
-  type = "list"
+  type = list(string)
 }
 
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "rds_instance_type" {
-    default = "db.m4.large"
+  default = "db.m4.large"
 }
 
 variable "rds_db_size" {
-    default = 100
+  default = 100
 }
 
 variable "rds_db_name" {
-    default = "ccdb"
+  default = "ccdb"
 }
 
 variable "rds_db_engine" {
-    default = "postgres"
+  default = "postgres"
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.19"
+  default = "9.6.19"
 }
 
 variable "rds_username" {
-    default = "cfdb"
+  default = "cfdb"
 }
 
-variable "rds_password" {}
+variable "rds_password" {
+}
 
-variable "rds_subnet_group" {}
+variable "rds_subnet_group" {
+}
 
 variable "rds_security_groups" {
-  type = "list"
+  type = list(string)
 }
 
-variable "stack_prefix" {}
+variable "stack_prefix" {
+}
 
 variable "az1" {
   default = "us-gov-west-1a"
@@ -54,20 +60,30 @@ variable "az2" {
   default = "us-gov-west-1b"
 }
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
-variable "private_route_table_az1" {}
+variable "private_route_table_az1" {
+}
 
-variable "private_route_table_az2" {}
+variable "private_route_table_az2" {
+}
 
-variable "services_cidr_1" {}
+variable "services_cidr_1" {
+}
 
-variable "services_cidr_2" {}
+variable "services_cidr_2" {
+}
 
-variable "aws_partition" {}
+variable "aws_partition" {
+}
 
-variable "kubernetes_cluster_id" {}
+variable "kubernetes_cluster_id" {
+}
 
-variable "bucket_prefix" {}
+variable "bucket_prefix" {
+}
 
-variable "log_bucket_name" {}
+variable "log_bucket_name" {
+}
+

--- a/terraform/modules/cloudfoundry/versions.tf
+++ b/terraform/modules/cloudfoundry/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/concourse/elb.tf
+++ b/terraform/modules/concourse/elb.tf
@@ -30,14 +30,6 @@ resource "aws_lb_listener_rule" "concourse_listener_rule" {
 
   condition {
     host_header {
-      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-      # force an interpolation expression to be interpreted as a list by wrapping it
-      # in an extra set of list brackets. That form was supported for compatibility in
-      # v0.11, but is no longer supported in Terraform v0.12.
-      #
-      # If the expression in the following list itself returns a list, remove the
-      # brackets to avoid interpretation as a list of lists. If the expression
-      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [element(var.hosts, count.index)]
     }
   }

--- a/terraform/modules/concourse/elb.tf
+++ b/terraform/modules/concourse/elb.tf
@@ -2,35 +2,44 @@ resource "aws_lb_target_group" "concourse_target" {
   name     = "${var.stack_description}-concourse-${var.concourse_az}"
   port     = 8080
   protocol = "HTTP"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold = 2
+    healthy_threshold   = 2
     unhealthy_threshold = 10
-    timeout = 5
-    interval = 30
-    matcher = 200
+    timeout             = 5
+    interval            = 30
+    matcher             = 200
   }
 
   stickiness {
-    type = "lb_cookie"
+    type    = "lb_cookie"
     enabled = true
   }
 }
 
 resource "aws_lb_listener_rule" "concourse_listener_rule" {
-  count = "${length(var.hosts)}"
+  count = length(var.hosts)
 
-  listener_arn = "${var.listener_arn}"
+  listener_arn = var.listener_arn
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.concourse_target.arn}"
+    target_group_arn = aws_lb_target_group.concourse_target.arn
   }
 
   condition {
     host_header {
-      values = ["${element(var.hosts, count.index)}"]
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
+      values = [element(var.hosts, count.index)]
     }
   }
 }
+

--- a/terraform/modules/concourse/network.tf
+++ b/terraform/modules/concourse/network.tf
@@ -9,9 +9,9 @@
  */
 
 resource "aws_subnet" "concourse" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.concourse_cidr}"
-  availability_zone = "${var.concourse_az}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.concourse_cidr
+  availability_zone = var.concourse_az
 
   tags = {
     Name = "${var.stack_description} (Concourse - ${var.concourse_cidr})"
@@ -19,6 +19,7 @@ resource "aws_subnet" "concourse" {
 }
 
 resource "aws_route_table_association" "concourse_rta" {
-  subnet_id = "${aws_subnet.concourse.id}"
-  route_table_id = "${var.route_table_id}"
+  subnet_id      = aws_subnet.concourse.id
+  route_table_id = var.route_table_id
 }
+

--- a/terraform/modules/concourse/outputs.tf
+++ b/terraform/modules/concourse/outputs.tf
@@ -1,43 +1,45 @@
 output "concourse_subnet" {
-  value = "${aws_subnet.concourse.id}"
+  value = aws_subnet.concourse.id
 }
+
 output "concourse_subnet_cidr" {
-  value = "${aws_subnet.concourse.cidr_block}"
+  value = aws_subnet.concourse.cidr_block
 }
 
 output "concourse_security_group" {
-  value = "${aws_security_group.concourse.id}"
+  value = aws_security_group.concourse.id
 }
 
 /* RDS Concourse Instance */
 output "concourse_rds_identifier" {
-  value = "${module.rds_96.rds_identifier}"
+  value = module.rds_96.rds_identifier
 }
 
 output "concourse_rds_name" {
-  value = "${module.rds_96.rds_name}"
+  value = module.rds_96.rds_name
 }
 
 output "concourse_rds_host" {
-  value = "${module.rds_96.rds_host}"
+  value = module.rds_96.rds_host
 }
 
 output "concourse_rds_port" {
-  value = "${module.rds_96.rds_port}"
+  value = module.rds_96.rds_port
 }
 
 output "concourse_rds_url" {
-  value = "${module.rds_96.rds_url}"
+  value = module.rds_96.rds_url
 }
 
 output "concourse_rds_username" {
-  value = "${module.rds_96.rds_username}"
+  value = module.rds_96.rds_username
 }
 
 output "concourse_rds_password" {
-  value = "${module.rds_96.rds_password}"
+  value = module.rds_96.rds_password
 }
 
 output "concourse_lb_target_group" {
-  value = "${aws_lb_target_group.concourse_target.name}"
+  value = aws_lb_target_group.concourse_target.name
 }
+

--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -11,7 +11,7 @@ module "rds_96" {
   rds_username                  = var.rds_username
   rds_password                  = var.rds_password
   rds_subnet_group              = var.rds_subnet_group
-  rds_security_groups           = [var.rds_security_groups]
+  rds_security_groups           = var.rds_security_groups
   rds_parameter_group_name      = var.rds_parameter_group_name
   rds_multi_az                  = var.rds_multi_az
   rds_final_snapshot_identifier = var.rds_final_snapshot_identifier

--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -1,18 +1,19 @@
 module "rds_96" {
   source = "../rds"
 
-  stack_description = "${var.stack_description}"
-  rds_db_name = "${var.rds_db_name}"
-  rds_instance_type = "${var.rds_instance_type}"
-  rds_db_size = "${var.rds_db_size}"
-  rds_db_storage_type = "${var.rds_db_storage_type}"
-  rds_db_iops = "${var.rds_db_iops}"
-  rds_db_engine_version = "${var.rds_engine_version}"
-  rds_username = "${var.rds_username}"
-  rds_password = "${var.rds_password}"
-  rds_subnet_group = "${var.rds_subnet_group}"
-  rds_security_groups = ["${var.rds_security_groups}"]
-  rds_parameter_group_name = "${var.rds_parameter_group_name}"
-  rds_multi_az = "${var.rds_multi_az}"
-  rds_final_snapshot_identifier = "${var.rds_final_snapshot_identifier}"
+  stack_description             = var.stack_description
+  rds_db_name                   = var.rds_db_name
+  rds_instance_type             = var.rds_instance_type
+  rds_db_size                   = var.rds_db_size
+  rds_db_storage_type           = var.rds_db_storage_type
+  rds_db_iops                   = var.rds_db_iops
+  rds_db_engine_version         = var.rds_engine_version
+  rds_username                  = var.rds_username
+  rds_password                  = var.rds_password
+  rds_subnet_group              = var.rds_subnet_group
+  rds_security_groups           = [var.rds_security_groups]
+  rds_parameter_group_name      = var.rds_parameter_group_name
+  rds_multi_az                  = var.rds_multi_az
+  rds_final_snapshot_identifier = var.rds_final_snapshot_identifier
 }
+

--- a/terraform/modules/concourse/sg_concourse.tf
+++ b/terraform/modules/concourse/sg_concourse.tf
@@ -6,38 +6,37 @@
 
 resource "aws_security_group" "concourse" {
   description = "Allow access to incoming concourse traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
-  tags =  {
+  tags = {
     Name = "${var.stack_description} - Incoming Concourse Traffic"
   }
-
 }
 
 resource "aws_security_group_rule" "self_reference" {
-    type = "ingress"
-    self = true
-    from_port = 0
-    to_port = 0
-    protocol = -1
-    security_group_id = "${aws_security_group.concourse.id}"
+  type              = "ingress"
+  self              = true
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  security_group_id = aws_security_group.concourse.id
 }
 
 resource "aws_security_group_rule" "concourse_web" {
-    type = "ingress"
-    from_port = 8080
-    to_port = 8080
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    security_group_id = "${aws_security_group.concourse.id}"
+  type              = "ingress"
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.concourse.id
 }
-
 
 resource "aws_security_group_rule" "outbound" {
-    type = "egress"
-    from_port = 0
-    to_port = 0
-    protocol = -1
-    cidr_blocks = ["0.0.0.0/0"]
-    security_group_id = "${aws_security_group.concourse.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.concourse.id
 }
+

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "concourse_cidr" {
   default = "10.0.30.0/24"
@@ -21,7 +22,7 @@ variable "rds_db_size" {
 }
 
 variable "rds_db_iops" {
-	default = 0
+  default = 0
 }
 
 variable "rds_db_storage_type" {
@@ -40,24 +41,32 @@ variable "rds_username" {
   default = "atc"
 }
 
-variable "rds_password" {}
+variable "rds_password" {
+}
 
-variable "rds_subnet_group" {}
+variable "rds_subnet_group" {
+}
 
 variable "rds_security_groups" {
-  type = "list"
+  type = list(string)
 }
 
-variable "rds_multi_az" {}
+variable "rds_multi_az" {
+}
 
-variable "rds_final_snapshot_identifier" {}
+variable "rds_final_snapshot_identifier" {
+}
 
-variable "route_table_id" {}
+variable "route_table_id" {
+}
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
-variable "listener_arn" {}
+variable "listener_arn" {
+}
 
 variable "hosts" {
-  type = "list"
+  type = list(string)
 }
+

--- a/terraform/modules/concourse/versions.tf
+++ b/terraform/modules/concourse/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/diego/diego_elb_main.tf
+++ b/terraform/modules/diego/diego_elb_main.tf
@@ -78,7 +78,7 @@ resource "aws_elb" "diego_elb_main" {
     unhealthy_threshold = 2
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description}-Diego-Proxy-ELB"
   }
 

--- a/terraform/modules/diego/diego_elb_main.tf
+++ b/terraform/modules/diego/diego_elb_main.tf
@@ -6,75 +6,74 @@
  */
 
 resource "aws_security_group" "diego-elb-sg" {
-  name = "${var.stack_description}-diego-elb-sg"
+  name        = "${var.stack_description}-diego-elb-sg"
   description = "ELB Security Group for Diego Proxy"
 
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
   # 2222 is the port in the CF configuration that /v2/info will point users at
   ingress {
-    from_port = 2222
-    to_port = 2222
-    protocol = "tcp"
-    cidr_blocks = ["${var.ingress_cidrs}"]
+    from_port   = 2222
+    to_port     = 2222
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
   }
 
   # 22 / 443 are alternate ports available for manually use by customers with restrictive firewalls
   ingress {
-    from_port = 22
-    to_port = 22
-    protocol = "tcp"
-    cidr_blocks = ["${var.ingress_cidrs}"]
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
   }
 
   ingress {
-    from_port = 443
-    to_port = 443
-    protocol = "tcp"
-    cidr_blocks = ["${var.ingress_cidrs}"]
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
   }
 
   # outbound internet access
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
-
 resource "aws_elb" "diego_elb_main" {
-  name = "${var.stack_description}-diego-proxy"
-  subnets = ["${var.elb_subnets}"]
-  security_groups = ["${aws_security_group.diego-elb-sg.id}"]
+  name            = "${var.stack_description}-diego-proxy"
+  subnets         = var.elb_subnets
+  security_groups = [aws_security_group.diego-elb-sg.id]
 
   listener {
-    lb_port = 2222
-    lb_protocol = "TCP"
-    instance_port = 2222
+    lb_port           = 2222
+    lb_protocol       = "TCP"
+    instance_port     = 2222
     instance_protocol = "TCP"
   }
 
   listener {
-    lb_port = 22
-    lb_protocol = "TCP"
-    instance_port = 2222
+    lb_port           = 22
+    lb_protocol       = "TCP"
+    instance_port     = 2222
     instance_protocol = "TCP"
   }
 
   listener {
-    lb_port = 443
-    lb_protocol = "TCP"
-    instance_port = 2222
+    lb_port           = 443
+    lb_protocol       = "TCP"
+    instance_port     = 2222
     instance_protocol = "TCP"
   }
 
   health_check {
-    healthy_threshold = 10
-    interval = 30
-    target = "TCP:2222"
-    timeout = 5
+    healthy_threshold   = 10
+    interval            = 30
+    target              = "TCP:2222"
+    timeout             = 5
     unhealthy_threshold = 2
   }
 
@@ -82,9 +81,10 @@ resource "aws_elb" "diego_elb_main" {
     Name = "${var.stack_description}-Diego-Proxy-ELB"
   }
 
-   access_logs = {
-      bucket        = "${var.log_bucket_name}"
-      bucket_prefix        = "${var.stack_description}"
-      enabled       = true
-    }
+  access_logs {
+    bucket        = var.log_bucket_name
+    bucket_prefix = var.stack_description
+    enabled       = true
+  }
 }
+

--- a/terraform/modules/diego/outputs.tf
+++ b/terraform/modules/diego/outputs.tf
@@ -1,9 +1,10 @@
 /* Diego Proxy ELB */
 
 output "diego_elb_name" {
-  value = "${aws_elb.diego_elb_main.name}"
+  value = aws_elb.diego_elb_main.name
 }
 
 output "diego_elb_dns_name" {
-  value = "${aws_elb.diego_elb_main.dns_name}"
+  value = aws_elb.diego_elb_main.dns_name
 }
+

--- a/terraform/modules/diego/variables.tf
+++ b/terraform/modules/diego/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "az1" {
   default = "us-gov-west-1a"
@@ -8,15 +9,18 @@ variable "az2" {
   default = "us-gov-west-1b"
 }
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
 variable "elb_subnets" {
-  type = "list"
+  type = list(string)
 }
 
 variable "ingress_cidrs" {
-  type = "list"
+  type    = list(string)
   default = ["0.0.0.0"]
 }
 
-variable "log_bucket_name" {}
+variable "log_bucket_name" {
+}
+

--- a/terraform/modules/diego/versions.tf
+++ b/terraform/modules/diego/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/dns/outputs.tf
+++ b/terraform/modules/dns/outputs.tf
@@ -1,7 +1,8 @@
 output "axfr_security_group" {
-  value = "${aws_security_group.dns_axfr.id}"
+  value = aws_security_group.dns_axfr.id
 }
 
 output "public_security_group" {
-  value = "${aws_security_group.dns_public.id}"
+  value = aws_security_group.dns_public.id
 }
+

--- a/terraform/modules/dns/sg.tf
+++ b/terraform/modules/dns/sg.tf
@@ -1,60 +1,60 @@
 resource "aws_security_group" "dns_axfr" {
   description = "Allow access from public DNS for AXFR"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
-    self = true
+    self      = true
     from_port = 53
-    to_port = 53
-    protocol = "tcp"
+    to_port   = 53
+    protocol  = "tcp"
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - DNS AXFR"
   }
 }
 
 resource "aws_security_group" "dns_public" {
   description = "Allow access to incoming DNS traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
-    from_port = 53
-    to_port = 53
-    protocol = "udp"
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port = 53
-    to_port = 53
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-
-  egress {
-    from_port = 53
-    to_port = 53
-    protocol = "tcp"
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port = 53
-    to_port = 53
-    protocol = "udp"
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
     Name = "${var.stack_description} - Incoming DNS Traffic"
   }
 }
+

--- a/terraform/modules/dns/variables.tf
+++ b/terraform/modules/dns/variables.tf
@@ -1,2 +1,6 @@
-variable "stack_description" {}
-variable "vpc_id" {}
+variable "stack_description" {
+}
+
+variable "vpc_id" {
+}
+

--- a/terraform/modules/dns/versions.tf
+++ b/terraform/modules/dns/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/elasticache_broker_network/elb.tf
+++ b/terraform/modules/elasticache_broker_network/elb.tf
@@ -1,31 +1,32 @@
 resource "aws_elb" "elasticache_elb" {
-  name = "${var.stack_description}-elasticache-broker"
-  subnets = ["${var.elb_subnets}"]
-  security_groups = ["${var.elb_security_groups}"]
-  internal = true
+  name            = "${var.stack_description}-elasticache-broker"
+  subnets         = var.elb_subnets
+  security_groups = var.elb_security_groups
+  internal        = true
 
   listener {
-    lb_port = 80
-    lb_protocol = "HTTP"
-    instance_port = 80
+    lb_port           = 80
+    lb_protocol       = "HTTP"
+    instance_port     = 80
     instance_protocol = "HTTP"
   }
 
   health_check {
-    healthy_threshold = 2
+    healthy_threshold   = 2
     unhealthy_threshold = 3
-    interval = 10
-    timeout = 5
-    target = "HTTP:80/healthcheck"
+    interval            = 10
+    timeout             = 5
+    target              = "HTTP:80/healthcheck"
   }
 
   tags = {
     Name = "${var.stack_description}-elasticache-broker"
   }
 
-   access_logs {
-      bucket        = "${var.log_bucket_name}"
-      bucket_prefix        = "${var.stack_description}"
-      enabled       = true
-    }
+  access_logs {
+    bucket        = var.log_bucket_name
+    bucket_prefix = var.stack_description
+    enabled       = true
+  }
 }
+

--- a/terraform/modules/elasticache_broker_network/elb.tf
+++ b/terraform/modules/elasticache_broker_network/elb.tf
@@ -23,7 +23,7 @@ resource "aws_elb" "elasticache_elb" {
     Name = "${var.stack_description}-elasticache-broker"
   }
 
-   access_logs = {
+   access_logs {
       bucket        = "${var.log_bucket_name}"
       bucket_prefix        = "${var.stack_description}"
       enabled       = true

--- a/terraform/modules/elasticache_broker_network/elb.tf
+++ b/terraform/modules/elasticache_broker_network/elb.tf
@@ -19,7 +19,7 @@ resource "aws_elb" "elasticache_elb" {
     target = "HTTP:80/healthcheck"
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description}-elasticache-broker"
   }
 

--- a/terraform/modules/elasticache_broker_network/outputs.tf
+++ b/terraform/modules/elasticache_broker_network/outputs.tf
@@ -1,31 +1,32 @@
 output "elasticache_subnet_az1" {
-  value = "${aws_subnet.az1_elasticache.id}"
+  value = aws_subnet.az1_elasticache.id
 }
 
 output "elasticache_subnet_az2" {
-  value = "${aws_subnet.az2_elasticache.id}"
+  value = aws_subnet.az2_elasticache.id
 }
 
 output "elasticache_private_cidr_1" {
-  value = "${aws_subnet.az1_elasticache.cidr_block}"
+  value = aws_subnet.az1_elasticache.cidr_block
 }
 
 output "elasticache_private_cidr_2" {
-  value = "${aws_subnet.az2_elasticache.cidr_block}"
+  value = aws_subnet.az2_elasticache.cidr_block
 }
 
 output "elasticache_subnet_group" {
-  value = "${aws_elasticache_subnet_group.elasticache.id}"
+  value = aws_elasticache_subnet_group.elasticache.id
 }
 
 output "elasticache_redis_security_group" {
-  value = "${aws_security_group.elasticache_redis.id}"
+  value = aws_security_group.elasticache_redis.id
 }
 
 output "elasticache_elb_dns_name" {
-  value = "${aws_elb.elasticache_elb.dns_name}"
+  value = aws_elb.elasticache_elb.dns_name
 }
 
 output "elasticache_elb_name" {
-  value = "${aws_elb.elasticache_elb.name}"
+  value = aws_elb.elasticache_elb.name
 }
+

--- a/terraform/modules/elasticache_broker_network/sg_redis.tf
+++ b/terraform/modules/elasticache_broker_network/sg_redis.tf
@@ -1,22 +1,23 @@
 resource "aws_security_group" "elasticache_redis" {
   description = "Allow access to incoming redis traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
-    from_port = 6379
-    to_port = 6379
-    protocol = "tcp"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = var.security_groups
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = var.security_groups
   }
 
   tags = {
     Name = "${var.stack_description} - Incoming Redis Traffic"
   }
 }
+

--- a/terraform/modules/elasticache_broker_network/sg_redis.tf
+++ b/terraform/modules/elasticache_broker_network/sg_redis.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "elasticache_redis" {
     security_groups = ["${var.security_groups}"]
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Incoming Redis Traffic"
   }
 }

--- a/terraform/modules/elasticache_broker_network/subnets.tf
+++ b/terraform/modules/elasticache_broker_network/subnets.tf
@@ -3,7 +3,7 @@ resource "aws_subnet" "az1_elasticache" {
   cidr_block = "${var.elasticache_private_cidr_1}"
   availability_zone = "${var.az1}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Elasticache Broker AZ1)"
   }
 }
@@ -13,7 +13,7 @@ resource "aws_subnet" "az2_elasticache" {
   cidr_block = "${var.elasticache_private_cidr_2}"
   availability_zone = "${var.az2}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (Elasticache Broker AZ2)"
   }
 }

--- a/terraform/modules/elasticache_broker_network/subnets.tf
+++ b/terraform/modules/elasticache_broker_network/subnets.tf
@@ -1,7 +1,7 @@
 resource "aws_subnet" "az1_elasticache" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.elasticache_private_cidr_1}"
-  availability_zone = "${var.az1}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.elasticache_private_cidr_1
+  availability_zone = var.az1
 
   tags = {
     Name = "${var.stack_description} (Elasticache Broker AZ1)"
@@ -9,9 +9,9 @@ resource "aws_subnet" "az1_elasticache" {
 }
 
 resource "aws_subnet" "az2_elasticache" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.elasticache_private_cidr_2}"
-  availability_zone = "${var.az2}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.elasticache_private_cidr_2
+  availability_zone = var.az2
 
   tags = {
     Name = "${var.stack_description} (Elasticache Broker AZ2)"
@@ -19,17 +19,18 @@ resource "aws_subnet" "az2_elasticache" {
 }
 
 resource "aws_elasticache_subnet_group" "elasticache" {
-  name = "${var.stack_description}"
+  name        = var.stack_description
   description = "${var.stack_description} (Multi-AZ Subnet Group)"
-  subnet_ids = ["${aws_subnet.az1_elasticache.id}", "${aws_subnet.az2_elasticache.id}"]
+  subnet_ids  = [aws_subnet.az1_elasticache.id, aws_subnet.az2_elasticache.id]
 }
 
 resource "aws_route_table_association" "az1_elasticache_rta" {
-  subnet_id = "${aws_subnet.az1_elasticache.id}"
-  route_table_id = "${var.az1_route_table}"
+  subnet_id      = aws_subnet.az1_elasticache.id
+  route_table_id = var.az1_route_table
 }
 
 resource "aws_route_table_association" "az2_elasticache_rta" {
-  subnet_id = "${aws_subnet.az2_elasticache.id}"
-  route_table_id = "${var.az2_route_table}"
+  subnet_id      = aws_subnet.az2_elasticache.id
+  route_table_id = var.az2_route_table
 }
+

--- a/terraform/modules/elasticache_broker_network/variables.tf
+++ b/terraform/modules/elasticache_broker_network/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "az1" {
   default = "us-gov-west-1a"
@@ -8,26 +9,33 @@ variable "az2" {
   default = "us-gov-west-1b"
 }
 
-variable "elasticache_private_cidr_1" {}
+variable "elasticache_private_cidr_1" {
+}
 
-variable "elasticache_private_cidr_2" {}
+variable "elasticache_private_cidr_2" {
+}
 
-variable "az1_route_table" {}
+variable "az1_route_table" {
+}
 
-variable "az2_route_table" {}
+variable "az2_route_table" {
+}
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
 variable "security_groups" {
-  type = "list"
+  type = list(string)
 }
 
 variable "elb_subnets" {
-  type = "list"
+  type = list(string)
 }
 
 variable "elb_security_groups" {
-  type = "list"
+  type = list(string)
 }
 
-variable "log_bucket_name" {}
+variable "log_bucket_name" {
+}
+

--- a/terraform/modules/elasticache_broker_network/versions.tf
+++ b/terraform/modules/elasticache_broker_network/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/elasticsearch_broker/outputs.tf
+++ b/terraform/modules/elasticsearch_broker/outputs.tf
@@ -1,20 +1,20 @@
 output "elasticsearch_subnet_az1" {
-  value = "${aws_subnet.az1_elasticsearch.id}"
+  value = aws_subnet.az1_elasticsearch.id
 }
 
 output "elasticsearch_subnet_az2" {
-  value = "${aws_subnet.az2_elasticsearch.id}"
+  value = aws_subnet.az2_elasticsearch.id
 }
 
 output "elasticsearch_private_cidr_1" {
-  value = "${aws_subnet.az1_elasticsearch.cidr_block}"
+  value = aws_subnet.az1_elasticsearch.cidr_block
 }
 
 output "elasticsearch_private_cidr_2" {
-  value = "${aws_subnet.az2_elasticsearch.cidr_block}"
+  value = aws_subnet.az2_elasticsearch.cidr_block
 }
 
 output "elasticsearch_security_group" {
-  value = "${aws_security_group.elasticsearch.id}"
+  value = aws_security_group.elasticsearch.id
 }
 

--- a/terraform/modules/elasticsearch_broker/security_group.tf
+++ b/terraform/modules/elasticsearch_broker/security_group.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "elasticsearch" {
     security_groups = ["${var.security_groups}"]
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Incoming Elasticsearch Traffic"
   }
 }

--- a/terraform/modules/elasticsearch_broker/security_group.tf
+++ b/terraform/modules/elasticsearch_broker/security_group.tf
@@ -1,19 +1,19 @@
 resource "aws_security_group" "elasticsearch" {
   description = "Allow access to incoming elasticsearch traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
-    from_port = 443
-    to_port = 443
-    protocol = "tcp"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = var.security_groups
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = var.security_groups
   }
 
   tags = {

--- a/terraform/modules/elasticsearch_broker/subnets.tf
+++ b/terraform/modules/elasticsearch_broker/subnets.tf
@@ -3,7 +3,7 @@ resource "aws_subnet" "az1_elasticsearch" {
   cidr_block = "${var.elasticsearch_private_cidr_1}"
   availability_zone = "${var.az1}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (elasticsearch Broker AZ1)"
   }
 }
@@ -13,7 +13,7 @@ resource "aws_subnet" "az2_elasticsearch" {
   cidr_block = "${var.elasticsearch_private_cidr_2}"
   availability_zone = "${var.az2}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (elasticsearch Broker AZ2)"
   }
 }

--- a/terraform/modules/elasticsearch_broker/subnets.tf
+++ b/terraform/modules/elasticsearch_broker/subnets.tf
@@ -1,7 +1,7 @@
 resource "aws_subnet" "az1_elasticsearch" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.elasticsearch_private_cidr_1}"
-  availability_zone = "${var.az1}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.elasticsearch_private_cidr_1
+  availability_zone = var.az1
 
   tags = {
     Name = "${var.stack_description} (elasticsearch Broker AZ1)"
@@ -9,9 +9,9 @@ resource "aws_subnet" "az1_elasticsearch" {
 }
 
 resource "aws_subnet" "az2_elasticsearch" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.elasticsearch_private_cidr_2}"
-  availability_zone = "${var.az2}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.elasticsearch_private_cidr_2
+  availability_zone = var.az2
 
   tags = {
     Name = "${var.stack_description} (elasticsearch Broker AZ2)"
@@ -19,11 +19,12 @@ resource "aws_subnet" "az2_elasticsearch" {
 }
 
 resource "aws_route_table_association" "az1_elasticsearch_rta" {
-  subnet_id = "${aws_subnet.az1_elasticsearch.id}"
-  route_table_id = "${var.az1_route_table}"
+  subnet_id      = aws_subnet.az1_elasticsearch.id
+  route_table_id = var.az1_route_table
 }
 
 resource "aws_route_table_association" "az2_elasticsearch_rta" {
-  subnet_id = "${aws_subnet.az2_elasticsearch.id}"
-  route_table_id = "${var.az2_route_table}"
+  subnet_id      = aws_subnet.az2_elasticsearch.id
+  route_table_id = var.az2_route_table
 }
+

--- a/terraform/modules/elasticsearch_broker/variables.tf
+++ b/terraform/modules/elasticsearch_broker/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "az1" {
   default = "us-gov-west-1a"
@@ -8,16 +9,22 @@ variable "az2" {
   default = "us-gov-west-1b"
 }
 
-variable "elasticsearch_private_cidr_1" {}
+variable "elasticsearch_private_cidr_1" {
+}
 
-variable "elasticsearch_private_cidr_2" {}
+variable "elasticsearch_private_cidr_2" {
+}
 
-variable "az1_route_table" {}
+variable "az1_route_table" {
+}
 
-variable "az2_route_table" {}
+variable "az2_route_table" {
+}
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
 variable "security_groups" {
-  type = "list"
+  type = list(string)
 }
+

--- a/terraform/modules/elasticsearch_broker/versions.tf
+++ b/terraform/modules/elasticsearch_broker/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/external_domain_broker/outputs.tf
+++ b/terraform/modules/external_domain_broker/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${aws_iam_user.iam_user.name}"
+  value = aws_iam_user.iam_user.name
 }
+
 output "access_key_id_prev" {
   value = ""
 }
+
 output "secret_access_key_prev" {
   value = ""
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.id}"
+  value = aws_iam_access_key.iam_access_key_v3.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.secret}"
+  value = aws_iam_access_key.iam_access_key_v3.secret
 }
+

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -10,28 +10,28 @@ data "aws_route53_zone" "cloud_gov" {
 }
 
 resource "aws_route53_record" "record" {
-  name    = "${aws_route53_zone.zone.name}"
-  zone_id = "${data.aws_route53_zone.cloud_gov.zone_id}"
+  name    = aws_route53_zone.zone.name
+  zone_id = data.aws_route53_zone.cloud_gov.zone_id
   type    = "NS"
   ttl     = "60"
 
   records = [
-    "${aws_route53_zone.zone.name_servers.0}",
-    "${aws_route53_zone.zone.name_servers.1}",
-    "${aws_route53_zone.zone.name_servers.2}",
-    "${aws_route53_zone.zone.name_servers.3}",
+    aws_route53_zone.zone.name_servers[0],
+    aws_route53_zone.zone.name_servers[1],
+    aws_route53_zone.zone.name_servers[2],
+    aws_route53_zone.zone.name_servers[3],
   ]
 }
 
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
-  vars {
-    account_id        = "${var.account_id}"
-    hosted_zone_id    = "${aws_route53_zone.zone.zone_id}"
-    stack             = "${var.stack_description}"
-    bucket            = "external-domain-broker-cloudfront-logs-${var.stack_description}"
-    aws_partition     = "${var.aws_partition}"
+  vars = {
+    account_id     = var.account_id
+    hosted_zone_id = aws_route53_zone.zone.zone_id
+    stack          = var.stack_description
+    bucket         = "external-domain-broker-cloudfront-logs-${var.stack_description}"
+    aws_partition  = var.aws_partition
   }
 }
 
@@ -40,21 +40,22 @@ resource "aws_iam_user" "iam_user" {
 }
 
 resource "aws_iam_access_key" "iam_access_key_v3" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
   name   = "${aws_iam_user.iam_user.name}-policy"
-  user   = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
 
-data "aws_canonical_user_id" "current_user" {}
+data "aws_canonical_user_id" "current_user" {
+}
 
 resource "aws_s3_bucket" "cloudfrond_log_bucket" {
   bucket = "external-domain-broker-cloudfront-logs-${var.stack_description}"
   grant {
-    id          = "${data.aws_canonical_user_id.current_user.id}"
+    id          = data.aws_canonical_user_id.current_user.id
     type        = "CanonicalUser"
     permissions = ["FULL_CONTROL"]
   }
@@ -62,17 +63,17 @@ resource "aws_s3_bucket" "cloudfrond_log_bucket" {
   grant {
     type        = "CanonicalUser"
     permissions = ["FULL_CONTROL"]
+
     # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
     # canonical user id of awslogsdelivery
-    id          = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+    id = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
   }
   server_side_encryption_configuration {
-        rule {
-            apply_server_side_encryption_by_default {
-                sse_algorithm = "AES256"
-            }
-        }
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
     }
-
-
+  }
 }
+

--- a/terraform/modules/external_domain_broker/variables.tf
+++ b/terraform/modules/external_domain_broker/variables.tf
@@ -1,4 +1,9 @@
-variable "account_id" {}
-variable "stack_description" {}
+variable "account_id" {
+}
 
-variable "aws_partition" {}
+variable "stack_description" {
+}
+
+variable "aws_partition" {
+}
+

--- a/terraform/modules/external_domain_broker/versions.tf
+++ b/terraform/modules/external_domain_broker/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/external_domain_broker_govcloud/outputs.tf
+++ b/terraform/modules/external_domain_broker_govcloud/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${aws_iam_user.iam_user.name}"
+  value = aws_iam_user.iam_user.name
 }
+
 output "access_key_id_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v1.id}"
+  value = aws_iam_access_key.iam_access_key_v1.id
 }
+
 output "secret_access_key_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v1.secret}"
+  value = aws_iam_access_key.iam_access_key_v1.secret
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v2.id}"
+  value = aws_iam_access_key.iam_access_key_v2.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v2.secret}"
+  value = aws_iam_access_key.iam_access_key_v2.secret
 }
+

--- a/terraform/modules/external_domain_broker_govcloud/resources.tf
+++ b/terraform/modules/external_domain_broker_govcloud/resources.tf
@@ -3,11 +3,11 @@
 # on both commercial (cloudfront, route53) and govcloud (alb) resources
 
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    account_id        = "${var.account_id}"
-    stack             = "${var.stack_description}"
+    account_id = var.account_id
+    stack      = var.stack_description
   }
 }
 
@@ -16,14 +16,16 @@ resource "aws_iam_user" "iam_user" {
 }
 
 resource "aws_iam_access_key" "iam_access_key_v1" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
+
 resource "aws_iam_access_key" "iam_access_key_v2" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
   name   = "${aws_iam_user.iam_user.name}-policy"
-  user   = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/external_domain_broker_govcloud/variables.tf
+++ b/terraform/modules/external_domain_broker_govcloud/variables.tf
@@ -1,2 +1,6 @@
-variable "account_id" {}
-variable "stack_description" {}
+variable "account_id" {
+}
+
+variable "stack_description" {
+}
+

--- a/terraform/modules/external_domain_broker_govcloud/versions.tf
+++ b/terraform/modules/external_domain_broker_govcloud/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/external_domain_broker_tests/outputs.tf
+++ b/terraform/modules/external_domain_broker_tests/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${aws_iam_user.iam_user.name}"
+  value = aws_iam_user.iam_user.name
 }
+
 output "access_key_id_prev" {
   value = ""
 }
+
 output "secret_access_key_prev" {
   value = ""
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v1.id}"
+  value = aws_iam_access_key.iam_access_key_v1.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v1.secret}"
+  value = aws_iam_access_key.iam_access_key_v1.secret
 }
+

--- a/terraform/modules/external_domain_broker_tests/resources.tf
+++ b/terraform/modules/external_domain_broker_tests/resources.tf
@@ -6,17 +6,18 @@ resource "aws_route53_zone" "zone" {
 data "aws_route53_zone" "cloud_gov" {
   name = "cloud.gov"
 }
+
 resource "aws_route53_record" "record" {
-  name    = "${aws_route53_zone.zone.name}"
-  zone_id = "${data.aws_route53_zone.cloud_gov.zone_id}"
+  name    = aws_route53_zone.zone.name
+  zone_id = data.aws_route53_zone.cloud_gov.zone_id
   type    = "NS"
   ttl     = "60"
 
   records = [
-    "${aws_route53_zone.zone.name_servers.0}",
-    "${aws_route53_zone.zone.name_servers.1}",
-    "${aws_route53_zone.zone.name_servers.2}",
-    "${aws_route53_zone.zone.name_servers.3}",
+    aws_route53_zone.zone.name_servers[0],
+    aws_route53_zone.zone.name_servers[1],
+    aws_route53_zone.zone.name_servers[2],
+    aws_route53_zone.zone.name_servers[3],
   ]
 }
 
@@ -28,17 +29,18 @@ resource "aws_route53_zone" "stack_test_0" {
 data "aws_route53_zone" "test_0" {
   name = "cloud-gov-test-domain-0.com"
 }
+
 resource "aws_route53_record" "test_record_0" {
-  name    = "${aws_route53_zone.stack_test_0.name}"
-  zone_id = "${data.aws_route53_zone.test_0.zone_id}"
+  name    = aws_route53_zone.stack_test_0.name
+  zone_id = data.aws_route53_zone.test_0.zone_id
   type    = "NS"
   ttl     = "60"
 
   records = [
-    "${aws_route53_zone.stack_test_0.name_servers.0}",
-    "${aws_route53_zone.stack_test_0.name_servers.1}",
-    "${aws_route53_zone.stack_test_0.name_servers.2}",
-    "${aws_route53_zone.stack_test_0.name_servers.3}",
+    aws_route53_zone.stack_test_0.name_servers[0],
+    aws_route53_zone.stack_test_0.name_servers[1],
+    aws_route53_zone.stack_test_0.name_servers[2],
+    aws_route53_zone.stack_test_0.name_servers[3],
   ]
 }
 
@@ -50,17 +52,18 @@ resource "aws_route53_zone" "stack_test_1" {
 data "aws_route53_zone" "test_1" {
   name = "cloud-gov-test-domain-1.com"
 }
+
 resource "aws_route53_record" "test_record_1" {
-  name    = "${aws_route53_zone.stack_test_1.name}"
-  zone_id = "${data.aws_route53_zone.test_1.zone_id}"
+  name    = aws_route53_zone.stack_test_1.name
+  zone_id = data.aws_route53_zone.test_1.zone_id
   type    = "NS"
   ttl     = "60"
 
   records = [
-    "${aws_route53_zone.stack_test_1.name_servers.0}",
-    "${aws_route53_zone.stack_test_1.name_servers.1}",
-    "${aws_route53_zone.stack_test_1.name_servers.2}",
-    "${aws_route53_zone.stack_test_1.name_servers.3}",
+    aws_route53_zone.stack_test_1.name_servers[0],
+    aws_route53_zone.stack_test_1.name_servers[1],
+    aws_route53_zone.stack_test_1.name_servers[2],
+    aws_route53_zone.stack_test_1.name_servers[3],
   ]
 }
 
@@ -72,17 +75,18 @@ resource "aws_route53_zone" "stack_test_2" {
 data "aws_route53_zone" "test_2" {
   name = "cloud-gov-test-domain-2.com"
 }
+
 resource "aws_route53_record" "test_record_2" {
-  name    = "${aws_route53_zone.stack_test_2.name}"
-  zone_id = "${data.aws_route53_zone.test_2.zone_id}"
+  name    = aws_route53_zone.stack_test_2.name
+  zone_id = data.aws_route53_zone.test_2.zone_id
   type    = "NS"
   ttl     = "60"
 
   records = [
-    "${aws_route53_zone.stack_test_2.name_servers.0}",
-    "${aws_route53_zone.stack_test_2.name_servers.1}",
-    "${aws_route53_zone.stack_test_2.name_servers.2}",
-    "${aws_route53_zone.stack_test_2.name_servers.3}",
+    aws_route53_zone.stack_test_2.name_servers[0],
+    aws_route53_zone.stack_test_2.name_servers[1],
+    aws_route53_zone.stack_test_2.name_servers[2],
+    aws_route53_zone.stack_test_2.name_servers[3],
   ]
 }
 
@@ -94,30 +98,31 @@ resource "aws_route53_zone" "stack_test_3" {
 data "aws_route53_zone" "test_3" {
   name = "cloud-gov-test-domain-3.com"
 }
+
 resource "aws_route53_record" "test_record_3" {
-  name    = "${aws_route53_zone.stack_test_3.name}"
-  zone_id = "${data.aws_route53_zone.test_3.zone_id}"
+  name    = aws_route53_zone.stack_test_3.name
+  zone_id = data.aws_route53_zone.test_3.zone_id
   type    = "NS"
   ttl     = "60"
 
   records = [
-    "${aws_route53_zone.stack_test_3.name_servers.0}",
-    "${aws_route53_zone.stack_test_3.name_servers.1}",
-    "${aws_route53_zone.stack_test_3.name_servers.2}",
-    "${aws_route53_zone.stack_test_3.name_servers.3}",
+    aws_route53_zone.stack_test_3.name_servers[0],
+    aws_route53_zone.stack_test_3.name_servers[1],
+    aws_route53_zone.stack_test_3.name_servers[2],
+    aws_route53_zone.stack_test_3.name_servers[3],
   ]
 }
 
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
-  vars {
-    aws_partition = "${var.aws_partition}"
-    hosted_zone_0 = "${aws_route53_zone.zone.zone_id}"
-    hosted_zone_1 = "${aws_route53_zone.stack_test_0.zone_id}"
-    hosted_zone_2 = "${aws_route53_zone.stack_test_1.zone_id}"
-    hosted_zone_3 = "${aws_route53_zone.stack_test_2.zone_id}"
-    hosted_zone_4 = "${aws_route53_zone.stack_test_3.zone_id}"
+  vars = {
+    aws_partition = var.aws_partition
+    hosted_zone_0 = aws_route53_zone.zone.zone_id
+    hosted_zone_1 = aws_route53_zone.stack_test_0.zone_id
+    hosted_zone_2 = aws_route53_zone.stack_test_1.zone_id
+    hosted_zone_3 = aws_route53_zone.stack_test_2.zone_id
+    hosted_zone_4 = aws_route53_zone.stack_test_3.zone_id
   }
 }
 
@@ -126,11 +131,12 @@ resource "aws_iam_user" "iam_user" {
 }
 
 resource "aws_iam_access_key" "iam_access_key_v1" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name = "${aws_iam_user.iam_user.name}-policy"
-  user = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/external_domain_broker_tests/variables.tf
+++ b/terraform/modules/external_domain_broker_tests/variables.tf
@@ -1,2 +1,6 @@
-variable "aws_partition" {}
-variable "stack_description" {}
+variable "aws_partition" {
+}
+
+variable "stack_description" {
+}
+

--- a/terraform/modules/external_domain_broker_tests/versions.tf
+++ b/terraform/modules/external_domain_broker_tests/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role/kubernetes_logger/outputs.tf
+++ b/terraform/modules/iam_role/kubernetes_logger/outputs.tf
@@ -1,7 +1,8 @@
 output "role_name" {
-  value = "${module.kubernetes_logger.role_name}"
+  value = module.kubernetes_logger.role_name
 }
 
 output "profile_name" {
-  value = "${module.kubernetes_logger.profile_name}"
+  value = module.kubernetes_logger.profile_name
 }
+

--- a/terraform/modules/iam_role/kubernetes_logger/role.tf
+++ b/terraform/modules/iam_role/kubernetes_logger/role.tf
@@ -1,7 +1,7 @@
 module "kubernetes_logger" {
   source = "../"
 
-  role_name = "${var.role_name}"
+  role_name  = var.role_name
   iam_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -30,6 +30,8 @@ module "kubernetes_logger" {
   ]
 }
 EOF
+
+
   iam_assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -56,4 +58,6 @@ EOF
   ]
 }
 EOF
+
 }
+

--- a/terraform/modules/iam_role/kubernetes_logger/variables.tf
+++ b/terraform/modules/iam_role/kubernetes_logger/variables.tf
@@ -1,9 +1,22 @@
-variable "aws_partition" {}
-variable "aws_default_region" {}
-variable "account_id" {}
-variable "role_name" {}
+variable "aws_partition" {
+}
+
+variable "aws_default_region" {
+}
+
+variable "account_id" {
+}
+
+variable "role_name" {
+}
+
 variable "assume_role_path" {
   default = "/"
 }
-variable "master_role" {}
-variable "minion_role" {}
+
+variable "master_role" {
+}
+
+variable "minion_role" {
+}
+

--- a/terraform/modules/iam_role/kubernetes_logger/versions.tf
+++ b/terraform/modules/iam_role/kubernetes_logger/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role/kubernetes_node/outputs.tf
+++ b/terraform/modules/iam_role/kubernetes_node/outputs.tf
@@ -1,7 +1,8 @@
 output "role_name" {
-  value = "${module.kubernetes_node.role_name}"
+  value = module.kubernetes_node.role_name
 }
 
 output "profile_name" {
-  value = "${module.kubernetes_node.profile_name}"
+  value = module.kubernetes_node.profile_name
 }
+

--- a/terraform/modules/iam_role/kubernetes_node/role.tf
+++ b/terraform/modules/iam_role/kubernetes_node/role.tf
@@ -1,7 +1,7 @@
 module "kubernetes_node" {
   source = "../"
 
-  role_name = "${var.role_name}"
+  role_name  = var.role_name
   iam_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -16,6 +16,8 @@ module "kubernetes_node" {
   }
 }
 EOF
+
+
   iam_assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -42,4 +44,6 @@ EOF
   ]
 }
 EOF
+
 }
+

--- a/terraform/modules/iam_role/kubernetes_node/variables.tf
+++ b/terraform/modules/iam_role/kubernetes_node/variables.tf
@@ -1,8 +1,19 @@
-variable "role_name" {}
+variable "role_name" {
+}
+
 variable "assume_role_path" {
   default = "/"
 }
-variable "account_id" {}
-variable "aws_partition" {}
-variable "master_role" {}
-variable "minion_role" {}
+
+variable "account_id" {
+}
+
+variable "aws_partition" {
+}
+
+variable "master_role" {
+}
+
+variable "minion_role" {
+}
+

--- a/terraform/modules/iam_role/kubernetes_node/versions.tf
+++ b/terraform/modules/iam_role/kubernetes_node/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role/outputs.tf
+++ b/terraform/modules/iam_role/outputs.tf
@@ -1,7 +1,8 @@
 output "role_name" {
-  value = "${aws_iam_role.iam_role.name}"
+  value = aws_iam_role.iam_role.name
 }
 
 output "profile_name" {
-  value = "${aws_iam_instance_profile.iam_profile.name}"
+  value = aws_iam_instance_profile.iam_profile.name
 }
+

--- a/terraform/modules/iam_role/role.tf
+++ b/terraform/modules/iam_role/role.tf
@@ -1,17 +1,18 @@
 resource "aws_iam_role" "iam_role" {
-  name = "${var.role_name}"
-  path = "${var.role_path}"
-  assume_role_policy = "${var.iam_assume_role_policy}"
+  name               = var.role_name
+  path               = var.role_path
+  assume_role_policy = var.iam_assume_role_policy
 }
 
 resource "aws_iam_instance_profile" "iam_profile" {
-  name = "${var.role_name}"
-  role = "${aws_iam_role.iam_role.name}"
+  name = var.role_name
+  role = aws_iam_role.iam_role.name
 }
 
 resource "aws_iam_role_policy" "iam_policy" {
-  count = "${var.iam_policy != "" ? 1 : 0}"
-  name = "${var.role_name}"
-  policy = "${var.iam_policy}"
-  role = "${aws_iam_role.iam_role.name}"
+  count  = var.iam_policy != "" ? 1 : 0
+  name   = var.role_name
+  policy = var.iam_policy
+  role   = aws_iam_role.iam_role.name
 }
+

--- a/terraform/modules/iam_role/variables.tf
+++ b/terraform/modules/iam_role/variables.tf
@@ -1,4 +1,5 @@
-variable "role_name" {}
+variable "role_name" {
+}
 
 variable "role_path" {
   default = "/bosh-passed/"
@@ -23,4 +24,6 @@ variable "iam_assume_role_policy" {
   ]
 }
 EOF
+
 }
+

--- a/terraform/modules/iam_role/versions.tf
+++ b/terraform/modules/iam_role/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/aws_broker/outputs.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/aws_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.tf
@@ -1,17 +1,18 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    account_id = "${var.account_id}"
-    aws_default_region = "${var.aws_default_region}"
-    aws_partition = "${var.aws_partition}"
-    remote_state_bucket = "${var.remote_state_bucket}"
-    rds_subgroup = "${var.rds_subgroup}"
-    iam_path = "${var.iam_path}"
+    account_id          = var.account_id
+    aws_default_region  = var.aws_default_region
+    aws_partition       = var.aws_partition
+    remote_state_bucket = var.remote_state_bucket
+    rds_subgroup        = var.rds_subgroup
+    iam_path            = var.iam_path
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/aws_broker/variables.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/variables.tf
@@ -1,9 +1,21 @@
-variable "policy_name" {}
-variable "account_id" {}
-variable "aws_partition" {}
-variable "aws_default_region" {}
-variable "remote_state_bucket" {}
-variable "rds_subgroup" {}
+variable "policy_name" {
+}
+
+variable "account_id" {
+}
+
+variable "aws_partition" {
+}
+
+variable "aws_default_region" {
+}
+
+variable "remote_state_bucket" {
+}
+
+variable "rds_subgroup" {
+}
+
 variable "iam_path" {
   default = "/"
 }

--- a/terraform/modules/iam_role_policy/aws_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/blobstore/outputs.tf
+++ b/terraform/modules/iam_role_policy/blobstore/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/blobstore/policy.tf
+++ b/terraform/modules/iam_role_policy/blobstore/policy.tf
@@ -1,13 +1,14 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    aws_partition = "${var.aws_partition}"
-    bucket_name = "${var.bucket_name}"
+    aws_partition = var.aws_partition
+    bucket_name   = var.bucket_name
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/blobstore/variables.tf
+++ b/terraform/modules/iam_role_policy/blobstore/variables.tf
@@ -1,3 +1,9 @@
-variable "policy_name" {}
-variable "aws_partition" {}
-variable "bucket_name" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+
+variable "bucket_name" {
+}
+

--- a/terraform/modules/iam_role_policy/blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/blobstore/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/bosh/outputs.tf
+++ b/terraform/modules/iam_role_policy/bosh/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/bosh/policy.tf
+++ b/terraform/modules/iam_role_policy/bosh/policy.tf
@@ -1,14 +1,15 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    aws_partition = "${var.aws_partition}"
-    account_id = "${var.account_id}"
-    bucket_name = "${var.bucket_name}"
+    aws_partition = var.aws_partition
+    account_id    = var.account_id
+    bucket_name   = var.bucket_name
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/bosh/variables.tf
+++ b/terraform/modules/iam_role_policy/bosh/variables.tf
@@ -1,4 +1,12 @@
-variable "policy_name" {}
-variable "aws_partition" {}
-variable "account_id" {}
-variable "bucket_name" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+
+variable "account_id" {
+}
+
+variable "bucket_name" {
+}
+

--- a/terraform/modules/iam_role_policy/bosh/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/bosh_compilation/outputs.tf
+++ b/terraform/modules/iam_role_policy/bosh_compilation/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/bosh_compilation/policy.tf
+++ b/terraform/modules/iam_role_policy/bosh_compilation/policy.tf
@@ -1,13 +1,14 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    aws_partition = "${var.aws_partition}"
-    bucket_name = "${var.bucket_name}"
+    aws_partition = var.aws_partition
+    bucket_name   = var.bucket_name
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/bosh_compilation/variables.tf
+++ b/terraform/modules/iam_role_policy/bosh_compilation/variables.tf
@@ -1,3 +1,9 @@
-variable "policy_name" {}
-variable "aws_partition" {}
-variable "bucket_name" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+
+variable "bucket_name" {
+}
+

--- a/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/cf_blobstore/outputs.tf
+++ b/terraform/modules/iam_role_policy/cf_blobstore/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/cf_blobstore/policy.tf
+++ b/terraform/modules/iam_role_policy/cf_blobstore/policy.tf
@@ -1,16 +1,17 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    aws_partition = "${var.aws_partition}"
-    buildpacks_bucket = "${var.buildpacks_bucket}"
-    packages_bucket = "${var.packages_bucket}"
-    resources_bucket = "${var.resources_bucket}"
-    droplets_bucket = "${var.droplets_bucket}"
+    aws_partition     = var.aws_partition
+    buildpacks_bucket = var.buildpacks_bucket
+    packages_bucket   = var.packages_bucket
+    resources_bucket  = var.resources_bucket
+    droplets_bucket   = var.droplets_bucket
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/cf_blobstore/variables.tf
+++ b/terraform/modules/iam_role_policy/cf_blobstore/variables.tf
@@ -1,6 +1,18 @@
-variable "policy_name" {}
-variable "aws_partition" {}
-variable "buildpacks_bucket" {}
-variable "packages_bucket" {}
-variable "resources_bucket" {}
-variable "droplets_bucket" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+
+variable "buildpacks_bucket" {
+}
+
+variable "packages_bucket" {
+}
+
+variable "resources_bucket" {
+}
+
+variable "droplets_bucket" {
+}
+

--- a/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/cloudwatch/outputs.tf
+++ b/terraform/modules/iam_role_policy/cloudwatch/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/cloudwatch/policy.tf
+++ b/terraform/modules/iam_role_policy/cloudwatch/policy.tf
@@ -1,8 +1,9 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/cloudwatch/variables.tf
+++ b/terraform/modules/iam_role_policy/cloudwatch/variables.tf
@@ -1,1 +1,3 @@
-variable "policy_name" {}
+variable "policy_name" {
+}
+

--- a/terraform/modules/iam_role_policy/cloudwatch/versions.tf
+++ b/terraform/modules/iam_role_policy/cloudwatch/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/compliance_role/outputs.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/compliance_role/policy.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/policy.tf
@@ -1,11 +1,12 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
-  vars {
-    aws_partition = "${var.aws_partition}"
+  template = file("${path.module}/policy.json")
+  vars = {
+    aws_partition = var.aws_partition
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/compliance_role/variables.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/variables.tf
@@ -1,2 +1,6 @@
-variable "policy_name" {}
-variable "aws_partition" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+

--- a/terraform/modules/iam_role_policy/compliance_role/versions.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/concourse_iaas_worker/outputs.tf
+++ b/terraform/modules/iam_role_policy/concourse_iaas_worker/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/concourse_iaas_worker/policy.tf
+++ b/terraform/modules/iam_role_policy/concourse_iaas_worker/policy.tf
@@ -1,10 +1,11 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 }
 
 // Grant IAAS worker admin permissions without using predefined `AdministratorAccess` policy
 // so that terraform errors won't affect operator permissions
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/concourse_iaas_worker/variables.tf
+++ b/terraform/modules/iam_role_policy/concourse_iaas_worker/variables.tf
@@ -1,1 +1,3 @@
-variable "policy_name" {}
+variable "policy_name" {
+}
+

--- a/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/concourse_worker/outputs.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/concourse_worker/policy.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.tf
@@ -1,23 +1,24 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
-  vars {
-    aws_partition           = "${var.aws_partition}"
-    varz_bucket             = "${var.varz_bucket}"
-    varz_staging_bucket     = "${var.varz_staging_bucket}"
-    bosh_release_bucket     = "${var.bosh_release_bucket}"
-    build_artifacts_bucket  = "${var.build_artifacts_bucket}"
-    terraform_state_bucket  = "${var.terraform_state_bucket}"
-    semver_bucket           = "${var.semver_bucket}"
-    buildpack_notify_bucket = "${var.buildpack_notify_bucket}"
-    billing_bucket          = "${var.billing_bucket}"
-    cg_binaries_bucket      = "${var.cg_binaries_bucket}"
-    log_bucket              = "${var.log_bucket}"
-    concourse_varz_bucket   = "${var.concourse_varz_bucket}"
+  vars = {
+    aws_partition           = var.aws_partition
+    varz_bucket             = var.varz_bucket
+    varz_staging_bucket     = var.varz_staging_bucket
+    bosh_release_bucket     = var.bosh_release_bucket
+    build_artifacts_bucket  = var.build_artifacts_bucket
+    terraform_state_bucket  = var.terraform_state_bucket
+    semver_bucket           = var.semver_bucket
+    buildpack_notify_bucket = var.buildpack_notify_bucket
+    billing_bucket          = var.billing_bucket
+    cg_binaries_bucket      = var.cg_binaries_bucket
+    log_bucket              = var.log_bucket
+    concourse_varz_bucket   = var.concourse_varz_bucket
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name   = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/concourse_worker/variables.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/variables.tf
@@ -1,13 +1,39 @@
-variable "policy_name" {}
-variable "aws_partition" {}
-variable "varz_bucket" {}
-variable "varz_staging_bucket" {}
-variable "bosh_release_bucket" {}
-variable "terraform_state_bucket" {}
-variable "semver_bucket" {}
-variable "buildpack_notify_bucket" {}
-variable "billing_bucket" {}
-variable "cg_binaries_bucket" {}
-variable "log_bucket" {}
-variable "build_artifacts_bucket" {}
-variable "concourse_varz_bucket" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+
+variable "varz_bucket" {
+}
+
+variable "varz_staging_bucket" {
+}
+
+variable "bosh_release_bucket" {
+}
+
+variable "terraform_state_bucket" {
+}
+
+variable "semver_bucket" {
+}
+
+variable "buildpack_notify_bucket" {
+}
+
+variable "billing_bucket" {
+}
+
+variable "cg_binaries_bucket" {
+}
+
+variable "log_bucket" {
+}
+
+variable "build_artifacts_bucket" {
+}
+
+variable "concourse_varz_bucket" {
+}
+

--- a/terraform/modules/iam_role_policy/concourse_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/elasticache_broker/outputs.tf
+++ b/terraform/modules/iam_role_policy/elasticache_broker/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/elasticache_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/elasticache_broker/policy.tf
@@ -1,8 +1,9 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/elasticache_broker/variables.tf
+++ b/terraform/modules/iam_role_policy/elasticache_broker/variables.tf
@@ -1,1 +1,3 @@
-variable "policy_name" {}
+variable "policy_name" {
+}
+

--- a/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/etcd_backup/outputs.tf
+++ b/terraform/modules/iam_role_policy/etcd_backup/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/etcd_backup/policy.tf
+++ b/terraform/modules/iam_role_policy/etcd_backup/policy.tf
@@ -1,13 +1,14 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    aws_partition = "${var.aws_partition}"
-    bucket_name = "${var.bucket_name}"
+    aws_partition = var.aws_partition
+    bucket_name   = var.bucket_name
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/etcd_backup/variables.tf
+++ b/terraform/modules/iam_role_policy/etcd_backup/variables.tf
@@ -1,3 +1,9 @@
-variable "policy_name" {}
-variable "aws_partition" {}
-variable "bucket_name" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+
+variable "bucket_name" {
+}
+

--- a/terraform/modules/iam_role_policy/etcd_backup/versions.tf
+++ b/terraform/modules/iam_role_policy/etcd_backup/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/kubernetes_master/outputs.tf
+++ b/terraform/modules/iam_role_policy/kubernetes_master/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/kubernetes_master/policy.tf
+++ b/terraform/modules/iam_role_policy/kubernetes_master/policy.tf
@@ -1,12 +1,13 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    aws_partition = "${var.aws_partition}"
+    aws_partition = var.aws_partition
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/kubernetes_master/variables.tf
+++ b/terraform/modules/iam_role_policy/kubernetes_master/variables.tf
@@ -1,2 +1,6 @@
-variable "policy_name" {}
-variable "aws_partition" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+

--- a/terraform/modules/iam_role_policy/kubernetes_master/versions.tf
+++ b/terraform/modules/iam_role_policy/kubernetes_master/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/kubernetes_minion/outputs.tf
+++ b/terraform/modules/iam_role_policy/kubernetes_minion/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/kubernetes_minion/policy.tf
+++ b/terraform/modules/iam_role_policy/kubernetes_minion/policy.tf
@@ -1,12 +1,13 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    aws_partition = "${var.aws_partition}"
+    aws_partition = var.aws_partition
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/kubernetes_minion/variables.tf
+++ b/terraform/modules/iam_role_policy/kubernetes_minion/variables.tf
@@ -1,2 +1,6 @@
-variable "policy_name" {}
-variable "aws_partition" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+

--- a/terraform/modules/iam_role_policy/kubernetes_minion/versions.tf
+++ b/terraform/modules/iam_role_policy/kubernetes_minion/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/logsearch_ingestor/outputs.tf
+++ b/terraform/modules/iam_role_policy/logsearch_ingestor/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/logsearch_ingestor/policy.tf
+++ b/terraform/modules/iam_role_policy/logsearch_ingestor/policy.tf
@@ -1,14 +1,15 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    account_id = "${var.account_id}"
-    aws_partition = "${var.aws_partition}"
-    aws_default_region = "${var.aws_default_region}"
+    account_id         = var.account_id
+    aws_partition      = var.aws_partition
+    aws_default_region = var.aws_default_region
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/logsearch_ingestor/variables.tf
+++ b/terraform/modules/iam_role_policy/logsearch_ingestor/variables.tf
@@ -1,4 +1,12 @@
-variable "policy_name" {}
-variable "account_id" {}
-variable "aws_partition" {}
-variable "aws_default_region" {}
+variable "policy_name" {
+}
+
+variable "account_id" {
+}
+
+variable "aws_partition" {
+}
+
+variable "aws_default_region" {
+}
+

--- a/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
+++ b/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/riemann_monitoring/outputs.tf
+++ b/terraform/modules/iam_role_policy/riemann_monitoring/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/riemann_monitoring/policy.tf
+++ b/terraform/modules/iam_role_policy/riemann_monitoring/policy.tf
@@ -1,14 +1,15 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
-  vars {
-    account_id = "${var.account_id}"
-    aws_partition = "${var.aws_partition}"
-    aws_default_region = "${var.aws_default_region}"
+  vars = {
+    account_id         = var.account_id
+    aws_partition      = var.aws_partition
+    aws_default_region = var.aws_default_region
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/riemann_monitoring/variables.tf
+++ b/terraform/modules/iam_role_policy/riemann_monitoring/variables.tf
@@ -1,4 +1,12 @@
-variable "policy_name" {}
-variable "account_id" {}
-variable "aws_partition" {}
-variable "aws_default_region" {}
+variable "policy_name" {
+}
+
+variable "account_id" {
+}
+
+variable "aws_partition" {
+}
+
+variable "aws_default_region" {
+}
+

--- a/terraform/modules/iam_role_policy/riemann_monitoring/versions.tf
+++ b/terraform/modules/iam_role_policy/riemann_monitoring/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/s3_broker/outputs.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/s3_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/policy.tf
@@ -1,15 +1,16 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
   vars = {
-    account_id = "${var.account_id}"
-    aws_partition = "${var.aws_partition}"
-    bucket_prefix = "${var.bucket_prefix}"
-    iam_path = "${var.iam_path}"
+    account_id    = var.account_id
+    aws_partition = var.aws_partition
+    bucket_prefix = var.bucket_prefix
+    iam_path      = var.iam_path
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/s3_broker/variables.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/variables.tf
@@ -1,7 +1,16 @@
-variable "policy_name" {}
-variable "account_id" {}
-variable "aws_partition" {}
-variable "bucket_prefix" {}
+variable "policy_name" {
+}
+
+variable "account_id" {
+}
+
+variable "aws_partition" {
+}
+
+variable "bucket_prefix" {
+}
+
 variable "iam_path" {
   default = "/"
 }
+

--- a/terraform/modules/iam_role_policy/s3_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_role_policy/self_managed_credentials/outputs.tf
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/outputs.tf
@@ -1,6 +1,8 @@
 output "name" {
-  value = "${aws_iam_policy.iam_policy.name}"
+  value = aws_iam_policy.iam_policy.name
 }
+
 output "arn" {
-  value = "${aws_iam_policy.iam_policy.arn}"
+  value = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/modules/iam_role_policy/self_managed_credentials/policy.tf
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/policy.tf
@@ -2,13 +2,14 @@ data "template_file" "policy" {
   # from https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-pass-accesskeys-ssh.html
   # and  https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.html
   # and  https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_iam_credentials_console.html
-  template = "${file("${path.module}/policy.json")}"
-  vars {
-    aws_partition = "${var.aws_partition}"
+  template = file("${path.module}/policy.json")
+  vars = {
+    aws_partition = var.aws_partition
   }
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${var.policy_name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = var.policy_name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_role_policy/self_managed_credentials/variables.tf
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/variables.tf
@@ -1,2 +1,6 @@
-variable "policy_name" {}
-variable "aws_partition" {}
+variable "policy_name" {
+}
+
+variable "aws_partition" {
+}
+

--- a/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_user/billing_user/outputs.tf
+++ b/terraform/modules/iam_user/billing_user/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${var.username}"
+  value = var.username
 }
+
 output "access_key_id_prev" {
   value = ""
 }
+
 output "secret_access_key_prev" {
   value = ""
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v2.id}"
+  value = aws_iam_access_key.iam_access_key_v2.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v2.secret}"
+  value = aws_iam_access_key.iam_access_key_v2.secret
 }
+

--- a/terraform/modules/iam_user/billing_user/user.tf
+++ b/terraform/modules/iam_user/billing_user/user.tf
@@ -1,22 +1,23 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 
-  vars {
-    aws_partition = "${var.aws_partition}"
-    billing_bucket = "${var.billing_bucket}"
+  vars = {
+    aws_partition  = var.aws_partition
+    billing_bucket = var.billing_bucket
   }
 }
 
 resource "aws_iam_user" "iam_user" {
-  name = "${var.username}"
+  name = var.username
 }
 
 resource "aws_iam_access_key" "iam_access_key_v2" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name = "${aws_iam_user.iam_user.name}-policy"
-  user = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_user/billing_user/variables.tf
+++ b/terraform/modules/iam_user/billing_user/variables.tf
@@ -1,3 +1,9 @@
-variable "username" {}
-variable "billing_bucket" {}
-variable "aws_partition" {}
+variable "username" {
+}
+
+variable "billing_bucket" {
+}
+
+variable "aws_partition" {
+}
+

--- a/terraform/modules/iam_user/billing_user/versions.tf
+++ b/terraform/modules/iam_user/billing_user/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_user/federalist_auditor/outputs.tf
+++ b/terraform/modules/iam_user/federalist_auditor/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${var.username}"
+  value = var.username
 }
+
 output "access_key_id_prev" {
   value = ""
 }
+
 output "secret_access_key_prev" {
   value = ""
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.id}"
+  value = aws_iam_access_key.iam_access_key_v3.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.secret}"
+  value = aws_iam_access_key.iam_access_key_v3.secret
 }
+

--- a/terraform/modules/iam_user/federalist_auditor/user.tf
+++ b/terraform/modules/iam_user/federalist_auditor/user.tf
@@ -8,15 +8,16 @@
 # credentials.
 
 resource "aws_iam_user" "iam_user" {
-  name = "${var.username}"
+  name = var.username
 }
 
 resource "aws_iam_access_key" "iam_access_key_v3" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name = "${aws_iam_user.iam_user.name}-policy"
-  user = "${aws_iam_user.iam_user.name}"
-  policy = "${file("${path.module}/policy.json")}"
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = file("${path.module}/policy.json")
 }
+

--- a/terraform/modules/iam_user/federalist_auditor/variables.tf
+++ b/terraform/modules/iam_user/federalist_auditor/variables.tf
@@ -1,1 +1,3 @@
-variable "username" {}
+variable "username" {
+}
+

--- a/terraform/modules/iam_user/federalist_auditor/versions.tf
+++ b/terraform/modules/iam_user/federalist_auditor/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_user/iam_cert_provision/outputs.tf
+++ b/terraform/modules/iam_user/iam_cert_provision/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${var.username}"
+  value = var.username
 }
+
 output "access_key_id_prev" {
   value = ""
 }
+
 output "secret_access_key_prev" {
   value = ""
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.id}"
+  value = aws_iam_access_key.iam_access_key_v3.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.secret}"
+  value = aws_iam_access_key.iam_access_key_v3.secret
 }
+

--- a/terraform/modules/iam_user/iam_cert_provision/user.tf
+++ b/terraform/modules/iam_user/iam_cert_provision/user.tf
@@ -1,21 +1,22 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
-  vars {
-    account_id = "${var.account_id}"
-    aws_partition = "${var.aws_partition}"
+  template = file("${path.module}/policy.json")
+  vars = {
+    account_id    = var.account_id
+    aws_partition = var.aws_partition
   }
 }
 
 resource "aws_iam_user" "iam_user" {
-  name = "${var.username}"
+  name = var.username
 }
 
 resource "aws_iam_access_key" "iam_access_key_v3" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name = "${aws_iam_user.iam_user.name}-policy"
-  user = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_user/iam_cert_provision/variables.tf
+++ b/terraform/modules/iam_user/iam_cert_provision/variables.tf
@@ -1,3 +1,9 @@
-variable "account_id" {}
-variable "aws_partition" {}
-variable "username" {}
+variable "account_id" {
+}
+
+variable "aws_partition" {
+}
+
+variable "username" {
+}
+

--- a/terraform/modules/iam_user/iam_cert_provision/versions.tf
+++ b/terraform/modules/iam_user/iam_cert_provision/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_user/lets_encrypt/outputs.tf
+++ b/terraform/modules/iam_user/lets_encrypt/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${var.username}"
+  value = var.username
 }
+
 output "access_key_id_prev" {
   value = ""
 }
+
 output "secret_access_key_prev" {
   value = ""
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.id}"
+  value = aws_iam_access_key.iam_access_key_v3.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.secret}"
+  value = aws_iam_access_key.iam_access_key_v3.secret
 }
+

--- a/terraform/modules/iam_user/lets_encrypt/user.tf
+++ b/terraform/modules/iam_user/lets_encrypt/user.tf
@@ -1,25 +1,26 @@
 data "aws_route53_zone" "zone" {
-  name = "${var.hosted_zone}"
+  name = var.hosted_zone
 }
 
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
-  vars {
-    aws_partition = "${var.aws_partition}"
-    hosted_zone = "${data.aws_route53_zone.zone.zone_id}"
+  template = file("${path.module}/policy.json")
+  vars = {
+    aws_partition = var.aws_partition
+    hosted_zone   = data.aws_route53_zone.zone.zone_id
   }
 }
 
 resource "aws_iam_user" "iam_user" {
-  name = "${var.username}"
+  name = var.username
 }
 
 resource "aws_iam_access_key" "iam_access_key_v3" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name = "${aws_iam_user.iam_user.name}-policy"
-  user = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_user/lets_encrypt/variables.tf
+++ b/terraform/modules/iam_user/lets_encrypt/variables.tf
@@ -1,3 +1,9 @@
-variable "aws_partition" {}
-variable "hosted_zone" {}
-variable "username" {}
+variable "aws_partition" {
+}
+
+variable "hosted_zone" {
+}
+
+variable "username" {
+}
+

--- a/terraform/modules/iam_user/lets_encrypt/versions.tf
+++ b/terraform/modules/iam_user/lets_encrypt/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_user/limit_check_user/outputs.tf
+++ b/terraform/modules/iam_user/limit_check_user/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${var.username}"
+  value = var.username
 }
+
 output "access_key_id_prev" {
   value = ""
 }
+
 output "secret_access_key_prev" {
   value = ""
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.id}"
+  value = aws_iam_access_key.iam_access_key_v3.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v3.secret}"
+  value = aws_iam_access_key.iam_access_key_v3.secret
 }
+

--- a/terraform/modules/iam_user/limit_check_user/user.tf
+++ b/terraform/modules/iam_user/limit_check_user/user.tf
@@ -1,17 +1,18 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 }
 
 resource "aws_iam_user" "iam_user" {
-  name = "${var.username}"
+  name = var.username
 }
 
 resource "aws_iam_access_key" "iam_access_key_v3" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name = "${aws_iam_user.iam_user.name}-policy"
-  user = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_user/limit_check_user/variables.tf
+++ b/terraform/modules/iam_user/limit_check_user/variables.tf
@@ -1,1 +1,3 @@
-variable "username" {}
+variable "username" {
+}
+

--- a/terraform/modules/iam_user/limit_check_user/versions.tf
+++ b/terraform/modules/iam_user/limit_check_user/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_user/rds_storage_alert/outputs.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/outputs.tf
@@ -1,9 +1,12 @@
 output "username" {
-  value = "${var.username}"
+  value = var.username
 }
+
 output "access_key_id" {
-  value = "${aws_iam_access_key.iam_access_key.id}"
+  value = aws_iam_access_key.iam_access_key.id
 }
+
 output "secret_access_key" {
-  value = "${aws_iam_access_key.iam_access_key.secret}"
+  value = aws_iam_access_key.iam_access_key.secret
 }
+

--- a/terraform/modules/iam_user/rds_storage_alert/user.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/user.tf
@@ -1,17 +1,18 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
+  template = file("${path.module}/policy.json")
 }
 
 resource "aws_iam_user" "iam_user" {
-  name = "${var.username}"
+  name = var.username
 }
 
 resource "aws_iam_access_key" "iam_access_key" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name = "${aws_iam_user.iam_user.name}-policy"
-  user = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_user/rds_storage_alert/variables.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/variables.tf
@@ -1,1 +1,3 @@
-variable "username" {}
+variable "username" {
+}
+

--- a/terraform/modules/iam_user/rds_storage_alert/versions.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/iam_user/s3_logstash/outputs.tf
+++ b/terraform/modules/iam_user/s3_logstash/outputs.tf
@@ -1,15 +1,20 @@
 output "username" {
-  value = "${var.username}"
+  value = var.username
 }
+
 output "access_key_id_prev" {
   value = ""
 }
+
 output "secret_access_key_prev" {
   value = ""
 }
+
 output "access_key_id_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v1.id}"
+  value = aws_iam_access_key.iam_access_key_v1.id
 }
+
 output "secret_access_key_curr" {
-  value = "${aws_iam_access_key.iam_access_key_v1.secret}"
+  value = aws_iam_access_key.iam_access_key_v1.secret
 }
+

--- a/terraform/modules/iam_user/s3_logstash/user.tf
+++ b/terraform/modules/iam_user/s3_logstash/user.tf
@@ -1,21 +1,22 @@
 data "template_file" "policy" {
-  template = "${file("${path.module}/policy.json")}"
-  vars {
-    aws_partition = "${var.aws_partition}"
-    log_bucket = "${var.log_bucket}"
+  template = file("${path.module}/policy.json")
+  vars = {
+    aws_partition = var.aws_partition
+    log_bucket    = var.log_bucket
   }
 }
 
 resource "aws_iam_user" "iam_user" {
-  name = "${var.username}"
+  name = var.username
 }
 
 resource "aws_iam_access_key" "iam_access_key_v1" {
-  user = "${aws_iam_user.iam_user.name}"
+  user = aws_iam_user.iam_user.name
 }
 
 resource "aws_iam_user_policy" "iam_policy" {
-  name = "${aws_iam_user.iam_user.name}-policy"
-  user = "${aws_iam_user.iam_user.name}"
-  policy = "${data.template_file.policy.rendered}"
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
 }
+

--- a/terraform/modules/iam_user/s3_logstash/variables.tf
+++ b/terraform/modules/iam_user/s3_logstash/variables.tf
@@ -1,3 +1,9 @@
-variable "aws_partition" {}
-variable "username" {}
-variable "log_bucket" {}
+variable "aws_partition" {
+}
+
+variable "username" {
+}
+
+variable "log_bucket" {
+}
+

--- a/terraform/modules/iam_user/s3_logstash/versions.tf
+++ b/terraform/modules/iam_user/s3_logstash/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/kubernetes/elb.tf
+++ b/terraform/modules/kubernetes/elb.tf
@@ -1,32 +1,33 @@
 resource "aws_elb" "kubernetes_elb" {
-  name = "${var.stack_description}-kubernetes"
-  subnets = ["${var.elb_subnets}"]
-  security_groups = ["${aws_security_group.kubernetes_elb.id}"]
-  idle_timeout = 3600
-  internal = true
+  name            = "${var.stack_description}-kubernetes"
+  subnets         = var.elb_subnets
+  security_groups = [aws_security_group.kubernetes_elb.id]
+  idle_timeout    = 3600
+  internal        = true
 
   listener {
-    instance_port = 6443
+    instance_port     = 6443
     instance_protocol = "tcp"
-    lb_port = 6443
-    lb_protocol = "tcp"
+    lb_port           = 6443
+    lb_protocol       = "tcp"
   }
 
   health_check {
-    healthy_threshold = 2
+    healthy_threshold   = 2
     unhealthy_threshold = 10
-    timeout = 5
-    target = "HTTP:8080/healthz"
-    interval = 30
+    timeout             = 5
+    target              = "HTTP:8080/healthz"
+    interval            = 30
   }
 
   tags = {
     Name = "${var.stack_description}-kubernetes"
   }
 
-   access_logs {
-      bucket        = "${var.log_bucket_name}"
-      bucket_prefix        = "${var.stack_description}"
-      enabled       = true
-    }
+  access_logs {
+    bucket        = var.log_bucket_name
+    bucket_prefix = var.stack_description
+    enabled       = true
+  }
 }
+

--- a/terraform/modules/kubernetes/elb.tf
+++ b/terraform/modules/kubernetes/elb.tf
@@ -24,7 +24,7 @@ resource "aws_elb" "kubernetes_elb" {
     Name = "${var.stack_description}-kubernetes"
   }
 
-   access_logs = {
+   access_logs {
       bucket        = "${var.log_bucket_name}"
       bucket_prefix        = "${var.stack_description}"
       enabled       = true

--- a/terraform/modules/kubernetes/elb.tf
+++ b/terraform/modules/kubernetes/elb.tf
@@ -20,7 +20,7 @@ resource "aws_elb" "kubernetes_elb" {
     interval = 30
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description}-kubernetes"
   }
 

--- a/terraform/modules/kubernetes/outputs.tf
+++ b/terraform/modules/kubernetes/outputs.tf
@@ -1,17 +1,18 @@
 /* Kubernetes ELB */
 output "kubernetes_elb_name" {
-  value = "${aws_elb.kubernetes_elb.name}"
+  value = aws_elb.kubernetes_elb.name
 }
 
 output "kubernetes_elb_dns_name" {
-  value = "${aws_elb.kubernetes_elb.dns_name}"
+  value = aws_elb.kubernetes_elb.dns_name
 }
 
 /* Kubernetes security groups */
 output "kubernetes_elb_security_group" {
-  value = "${aws_security_group.kubernetes_elb.id}"
+  value = aws_security_group.kubernetes_elb.id
 }
 
 output "kubernetes_ec2_security_group" {
-  value = "${aws_security_group.kubernetes_ec2.id}"
+  value = aws_security_group.kubernetes_ec2.id
 }
+

--- a/terraform/modules/kubernetes/sg_ec2.tf
+++ b/terraform/modules/kubernetes/sg_ec2.tf
@@ -2,7 +2,7 @@ resource "aws_security_group" "kubernetes_ec2" {
   description = "Allow access to incoming kubernetes traffic"
   vpc_id = "${var.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Kubernetes EC2"
   }
 }

--- a/terraform/modules/kubernetes/sg_ec2.tf
+++ b/terraform/modules/kubernetes/sg_ec2.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "kubernetes_ec2" {
   description = "Allow access to incoming kubernetes traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   tags = {
     Name = "${var.stack_description} - Kubernetes EC2"
@@ -8,121 +8,122 @@ resource "aws_security_group" "kubernetes_ec2" {
 }
 
 resource "aws_security_group_rule" "self_reference" {
-  type = "ingress"
-  self = true
-  from_port = 0
-  to_port = 0
-  protocol = -1
-  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type              = "ingress"
+  self              = true
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  security_group_id = aws_security_group.kubernetes_ec2.id
 }
 
 resource "aws_security_group_rule" "kubernetes_elb" {
-  type = "ingress"
-  from_port = 0
-  to_port = 0
-  protocol = -1
-  source_security_group_id = "${aws_security_group.kubernetes_elb.id}"
-  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = -1
+  source_security_group_id = aws_security_group.kubernetes_elb.id
+  security_group_id        = aws_security_group.kubernetes_ec2.id
 }
 
 resource "aws_security_group_rule" "consul_dns" {
-  type = "ingress"
-  from_port = 53
-  to_port = 53
-  protocol = "udp"
-  source_security_group_id = "${var.target_bosh_security_group}"
-  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type                     = "ingress"
+  from_port                = 53
+  to_port                  = 53
+  protocol                 = "udp"
+  source_security_group_id = var.target_bosh_security_group
+  security_group_id        = aws_security_group.kubernetes_ec2.id
 }
 
 resource "aws_security_group_rule" "node_ports" {
-  type = "ingress"
-  from_port = 30000
-  to_port = 32767
-  protocol = "tcp"
-  source_security_group_id = "${var.target_bosh_security_group}"
-  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type                     = "ingress"
+  from_port                = 30000
+  to_port                  = 32767
+  protocol                 = "tcp"
+  source_security_group_id = var.target_bosh_security_group
+  security_group_id        = aws_security_group.kubernetes_ec2.id
 }
 
 resource "aws_security_group_rule" "node_exporter" {
-    type = "ingress"
-    from_port = 9100
-    to_port = 9100
-    protocol = "tcp"
-    source_security_group_id = "${var.target_monitoring_security_group}"
-    security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type                     = "ingress"
+  from_port                = 9100
+  to_port                  = 9100
+  protocol                 = "tcp"
+  source_security_group_id = var.target_monitoring_security_group
+  security_group_id        = aws_security_group.kubernetes_ec2.id
 }
 
 resource "aws_security_group_rule" "outbound" {
-  type = "egress"
-  from_port = 0
-  to_port = 0
-  protocol = -1
-  cidr_blocks = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.kubernetes_ec2.id
 }
 
 // TODO: Drop BOSH-related rules use BOSH security group after https://github.com/kubernetes/kubernetes/issues/26787 is resolved
 // TODO: Lock down 8080 in BOSH security group and/or change Kubernetes insecure port
 
 resource "aws_security_group_rule" "bosh_ssh" {
-  type = "ingress"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["${var.vpc_cidr}"]
-  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.vpc_cidr]
+  security_group_id = aws_security_group.kubernetes_ec2.id
 }
 
 resource "aws_security_group_rule" "bosh_ssh_tooling" {
-  type = "ingress"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["${var.tooling_vpc_cidr}"]
-  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.tooling_vpc_cidr]
+  security_group_id = aws_security_group.kubernetes_ec2.id
 }
 
 resource "aws_security_group_rule" "bosh_ntp" {
-  type = "ingress"
-  from_port = 123
-  to_port = 123
-  protocol = "udp"
-  source_security_group_id = "${aws_security_group.kubernetes_ec2.id}"
-  security_group_id = "${var.target_bosh_security_group}"
+  type                     = "ingress"
+  from_port                = 123
+  to_port                  = 123
+  protocol                 = "udp"
+  source_security_group_id = aws_security_group.kubernetes_ec2.id
+  security_group_id        = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "bosh_nats" {
-  type = "ingress"
-  from_port = 6868
-  to_port = 6868
-  protocol = "tcp"
-  cidr_blocks = ["${var.vpc_cidr}"]
-  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type              = "ingress"
+  from_port         = 6868
+  to_port           = 6868
+  protocol          = "tcp"
+  cidr_blocks       = [var.vpc_cidr]
+  security_group_id = aws_security_group.kubernetes_ec2.id
 }
 
 resource "aws_security_group_rule" "bosh_director" {
-  type = "ingress"
-  from_port = 25555
-  to_port = 25555
-  protocol = "tcp"
-  cidr_blocks = ["${var.vpc_cidr}"]
-  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  type              = "ingress"
+  from_port         = 25555
+  to_port           = 25555
+  protocol          = "tcp"
+  cidr_blocks       = [var.vpc_cidr]
+  security_group_id = aws_security_group.kubernetes_ec2.id
 }
 
 resource "aws_security_group_rule" "bosh_registry" {
-  type = "ingress"
-  from_port = 25777
-  to_port = 25777
-  protocol = "tcp"
-  source_security_group_id = "${aws_security_group.kubernetes_ec2.id}"
-  security_group_id = "${var.target_bosh_security_group}"
+  type                     = "ingress"
+  from_port                = 25777
+  to_port                  = 25777
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.kubernetes_ec2.id
+  security_group_id        = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "logsearch_syslog" {
-  type = "ingress"
-  from_port = 5514
-  to_port = 5514
-  protocol = "tcp"
-  source_security_group_id = "${aws_security_group.kubernetes_ec2.id}"
-  security_group_id = "${var.target_bosh_security_group}"
+  type                     = "ingress"
+  from_port                = 5514
+  to_port                  = 5514
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.kubernetes_ec2.id
+  security_group_id        = var.target_bosh_security_group
 }
+

--- a/terraform/modules/kubernetes/sg_elb.tf
+++ b/terraform/modules/kubernetes/sg_elb.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "kubernetes_elb" {
   description = "Allow access to incoming kubernetes traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   tags = {
     Name = "${var.stack_description} - Kubernetes ELB"
@@ -8,37 +8,38 @@ resource "aws_security_group" "kubernetes_elb" {
 }
 
 resource "aws_security_group_rule" "kubernetes_inbound_api" {
-  type = "ingress"
-  from_port = 6443
-  to_port = 6443
-  protocol = "tcp"
-  cidr_blocks = ["${var.vpc_cidr}"]
-  security_group_id = "${aws_security_group.kubernetes_elb.id}"
+  type              = "ingress"
+  from_port         = 6443
+  to_port           = 6443
+  protocol          = "tcp"
+  cidr_blocks       = [var.vpc_cidr]
+  security_group_id = aws_security_group.kubernetes_elb.id
 }
 
 resource "aws_security_group_rule" "kubernetes_inbound_custom" {
-  type = "ingress"
-  from_port = 6443
-  to_port = 6443
-  protocol = "tcp"
-  source_security_group_id = "${var.target_monitoring_security_group}"
-  security_group_id = "${aws_security_group.kubernetes_elb.id}"
+  type                     = "ingress"
+  from_port                = 6443
+  to_port                  = 6443
+  protocol                 = "tcp"
+  source_security_group_id = var.target_monitoring_security_group
+  security_group_id        = aws_security_group.kubernetes_elb.id
 }
 
 resource "aws_security_group_rule" "kubernetes_inbound_from_concourse" {
-  type = "ingress"
-  from_port = 6443
-  to_port = 6443
-  protocol = "tcp"
-  source_security_group_id = "${var.target_concourse_security_group}"
-  security_group_id = "${aws_security_group.kubernetes_elb.id}"
+  type                     = "ingress"
+  from_port                = 6443
+  to_port                  = 6443
+  protocol                 = "tcp"
+  source_security_group_id = var.target_concourse_security_group
+  security_group_id        = aws_security_group.kubernetes_elb.id
 }
 
 resource "aws_security_group_rule" "kubernetes_outbound" {
-  type = "egress"
-  from_port = 0
-  to_port = 0
-  protocol = -1
-  cidr_blocks = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.kubernetes_elb.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.kubernetes_elb.id
 }
+

--- a/terraform/modules/kubernetes/sg_elb.tf
+++ b/terraform/modules/kubernetes/sg_elb.tf
@@ -2,7 +2,7 @@ resource "aws_security_group" "kubernetes_elb" {
   description = "Allow access to incoming kubernetes traffic"
   vpc_id = "${var.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Kubernetes ELB"
   }
 }

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -1,14 +1,31 @@
-variable "stack_description" {}
-variable "aws_default_region" {}
-
-variable "vpc_id" {}
-variable "vpc_cidr" {}
-variable "tooling_vpc_cidr" {}
-variable "elb_subnets" {
-  type = "list"
+variable "stack_description" {
 }
-variable "target_bosh_security_group" {}
-variable "target_monitoring_security_group" {}
-variable "target_concourse_security_group" {}
 
-variable "log_bucket_name" {}
+variable "aws_default_region" {
+}
+
+variable "vpc_id" {
+}
+
+variable "vpc_cidr" {
+}
+
+variable "tooling_vpc_cidr" {
+}
+
+variable "elb_subnets" {
+  type = list(string)
+}
+
+variable "target_bosh_security_group" {
+}
+
+variable "target_monitoring_security_group" {
+}
+
+variable "target_concourse_security_group" {
+}
+
+variable "log_bucket_name" {
+}
+

--- a/terraform/modules/kubernetes/versions.tf
+++ b/terraform/modules/kubernetes/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/log_bucket/log_bucket.tf
+++ b/terraform/modules/log_bucket/log_bucket.tf
@@ -1,48 +1,49 @@
 locals {
-# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
-    aws_alb_account_ids = {
-        us-east-1 = "127311923021",
-        us-east-2 = "033677994240",
-        us-west-1 = "027434742980",
-        us-west-2 = "797873946194",
-        ca-central-1 = "985666609251",
-        eu-central-1 = "054676820928",
-        eu-west-1 = "156460612806",
-        eu-west-2 = "652711504416",
-        eu-west-3 = "009996457667",
-        eu-north-1 = "897822967062",
-        ap-east-1 = "754344448648",
-        ap-northeast-1 = "582318560864",
-        ap-northeast-2 = "600734575887",
-        ap-northeast-3 = "383597477331",
-        ap-southeast-1 = "114774131450",
-        ap-southeast-2 = "783225319266",
-        ap-south-1 = "718504428378",
-        sa-east-1 = "507241528517",
-        us-gov-west-1 = "048591011584",
-        us-gov-east-1 = "190560391635",
-        cn-north-1 = "638102146993",
-        cn-northwest-1 = "037604701340"
-    }
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+  aws_alb_account_ids = {
+    us-east-1      = "127311923021"
+    us-east-2      = "033677994240"
+    us-west-1      = "027434742980"
+    us-west-2      = "797873946194"
+    ca-central-1   = "985666609251"
+    eu-central-1   = "054676820928"
+    eu-west-1      = "156460612806"
+    eu-west-2      = "652711504416"
+    eu-west-3      = "009996457667"
+    eu-north-1     = "897822967062"
+    ap-east-1      = "754344448648"
+    ap-northeast-1 = "582318560864"
+    ap-northeast-2 = "600734575887"
+    ap-northeast-3 = "383597477331"
+    ap-southeast-1 = "114774131450"
+    ap-southeast-2 = "783225319266"
+    ap-south-1     = "718504428378"
+    sa-east-1      = "507241528517"
+    us-gov-west-1  = "048591011584"
+    us-gov-east-1  = "190560391635"
+    cn-north-1     = "638102146993"
+    cn-northwest-1 = "037604701340"
+  }
 }
+
 resource "aws_s3_bucket" "log_bucket" {
-    bucket = "${var.log_bucket_name}"
-    acl = "${var.log_bucket_acl}"
-    force_destroy = "${var.log_bucket_force_destroy}"
+  bucket        = var.log_bucket_name
+  acl           = var.log_bucket_acl
+  force_destroy = var.log_bucket_force_destroy
 
-    lifecycle_rule {
-        prefix = ""
-        enabled = true
-        transition {
-            days = 90
-            storage_class = "ONEZONE_IA"
-        }
-        expiration {
-            days = 180
-        }
+  lifecycle_rule {
+    prefix  = ""
+    enabled = true
+    transition {
+      days          = 90
+      storage_class = "ONEZONE_IA"
     }
+    expiration {
+      days = 180
+    }
+  }
 
-    policy = <<EOF
+  policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -57,4 +58,6 @@ resource "aws_s3_bucket" "log_bucket" {
     ]
 }
 EOF
+
 }
+

--- a/terraform/modules/log_bucket/variables.tf
+++ b/terraform/modules/log_bucket/variables.tf
@@ -1,13 +1,17 @@
-variable "log_bucket_name" {}
+variable "log_bucket_name" {
+}
 
 variable "log_bucket_force_destroy" {
-    default = false
+  default = false
 }
 
 variable "log_bucket_acl" {
-    default = "private"
+  default = "private"
 }
 
-variable "aws_partition" {}
+variable "aws_partition" {
+}
 
-variable "aws_region" {}
+variable "aws_region" {
+}
+

--- a/terraform/modules/log_bucket/versions.tf
+++ b/terraform/modules/log_bucket/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/logsearch/elb.tf
+++ b/terraform/modules/logsearch/elb.tf
@@ -1,32 +1,33 @@
 resource "aws_elb" "logsearch_elb" {
-  name = "${var.stack_description}-logsearch"
-  subnets = ["${var.private_elb_subnets}"]
-  security_groups = ["${var.bosh_security_group}"]
-  idle_timeout = 3600
-  internal = true
+  name            = "${var.stack_description}-logsearch"
+  subnets         = var.private_elb_subnets
+  security_groups = [var.bosh_security_group]
+  idle_timeout    = 3600
+  internal        = true
 
   listener {
-    instance_port = 9200
+    instance_port     = 9200
     instance_protocol = "tcp"
-    lb_port = 9200
-    lb_protocol = "tcp"
+    lb_port           = 9200
+    lb_protocol       = "tcp"
   }
 
   health_check {
-    healthy_threshold = 2
+    healthy_threshold   = 2
     unhealthy_threshold = 10
-    timeout = 5
-    target = "HTTP:9200/_cluster/health?local"
-    interval = 30
+    timeout             = 5
+    target              = "HTTP:9200/_cluster/health?local"
+    interval            = 30
   }
 
   tags = {
     Name = "${var.stack_description}-logsearch"
   }
 
-   access_logs {
-      bucket        = "${var.log_bucket_name}"
-      bucket_prefix        = "${var.stack_description}"
-      enabled       = true
-    }
+  access_logs {
+    bucket        = var.log_bucket_name
+    bucket_prefix = var.stack_description
+    enabled       = true
+  }
 }
+

--- a/terraform/modules/logsearch/elb.tf
+++ b/terraform/modules/logsearch/elb.tf
@@ -20,7 +20,7 @@ resource "aws_elb" "logsearch_elb" {
     interval = 30
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description}-logsearch"
   }
 

--- a/terraform/modules/logsearch/elb.tf
+++ b/terraform/modules/logsearch/elb.tf
@@ -24,7 +24,7 @@ resource "aws_elb" "logsearch_elb" {
     Name = "${var.stack_description}-logsearch"
   }
 
-   access_logs = {
+   access_logs {
       bucket        = "${var.log_bucket_name}"
       bucket_prefix        = "${var.stack_description}"
       enabled       = true

--- a/terraform/modules/logsearch/elb_platform_kibana.tf
+++ b/terraform/modules/logsearch/elb_platform_kibana.tf
@@ -26,14 +26,6 @@ resource "aws_lb_listener_rule" "platform_kibana" {
 
   condition {
     host_header {
-      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-      # force an interpolation expression to be interpreted as a list by wrapping it
-      # in an extra set of list brackets. That form was supported for compatibility in
-      # v0.11, but is no longer supported in Terraform v0.12.
-      #
-      # If the expression in the following list itself returns a list, remove the
-      # brackets to avoid interpretation as a list of lists. If the expression
-      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [element(var.hosts, count.index)]
     }
   }

--- a/terraform/modules/logsearch/elb_platform_kibana.tf
+++ b/terraform/modules/logsearch/elb_platform_kibana.tf
@@ -2,31 +2,40 @@ resource "aws_lb_target_group" "platform_kibana" {
   name     = "${var.stack_description}-platform-kibana"
   port     = 5600
   protocol = "HTTP"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold = 2
+    healthy_threshold   = 2
     unhealthy_threshold = 10
-    timeout = 5
-    interval = 30
-    matcher = 403
+    timeout             = 5
+    interval            = 30
+    matcher             = 403
   }
 }
 
 resource "aws_lb_listener_rule" "platform_kibana" {
-  count = "${length(var.hosts)}"
+  count = length(var.hosts)
 
-  listener_arn = "${var.listener_arn}"
-  priority = "${200 + count.index}"
+  listener_arn = var.listener_arn
+  priority     = 200 + count.index
 
   action {
-    target_group_arn = "${aws_lb_target_group.platform_kibana.arn}"
+    target_group_arn = aws_lb_target_group.platform_kibana.arn
     type             = "forward"
   }
 
   condition {
     host_header {
-      values = ["${element(var.hosts, count.index)}"]
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
+      values = [element(var.hosts, count.index)]
     }
   }
 }
+

--- a/terraform/modules/logsearch/elb_platform_syslog.tf
+++ b/terraform/modules/logsearch/elb_platform_syslog.tf
@@ -20,7 +20,7 @@ resource "aws_elb" "platform_syslog_elb" {
     interval = 30
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description}-platform-syslog"
   }
 

--- a/terraform/modules/logsearch/elb_platform_syslog.tf
+++ b/terraform/modules/logsearch/elb_platform_syslog.tf
@@ -1,32 +1,33 @@
 resource "aws_elb" "platform_syslog_elb" {
-  name = "${var.stack_description}-platform-syslog"
-  subnets = ["${var.private_elb_subnets}"]
-  security_groups = ["${var.bosh_security_group}"]
-  idle_timeout = 60
-  internal = true
+  name            = "${var.stack_description}-platform-syslog"
+  subnets         = var.private_elb_subnets
+  security_groups = [var.bosh_security_group]
+  idle_timeout    = 60
+  internal        = true
 
   listener {
-    lb_port = 5514
-    lb_protocol = "tcp"
-    instance_port = 5514
+    lb_port           = 5514
+    lb_protocol       = "tcp"
+    instance_port     = 5514
     instance_protocol = "tcp"
   }
 
   health_check {
-    healthy_threshold = 2
+    healthy_threshold   = 2
     unhealthy_threshold = 10
-    timeout = 5
-    target = "TCP:5514"
-    interval = 30
+    timeout             = 5
+    target              = "TCP:5514"
+    interval            = 30
   }
 
   tags = {
     Name = "${var.stack_description}-platform-syslog"
   }
 
-   access_logs {
-      bucket        = "${var.log_bucket_name}"
-      bucket_prefix        = "${var.stack_description}"
-      enabled       = true
-    }
+  access_logs {
+    bucket        = var.log_bucket_name
+    bucket_prefix = var.stack_description
+    enabled       = true
+  }
 }
+

--- a/terraform/modules/logsearch/elb_platform_syslog.tf
+++ b/terraform/modules/logsearch/elb_platform_syslog.tf
@@ -24,7 +24,7 @@ resource "aws_elb" "platform_syslog_elb" {
     Name = "${var.stack_description}-platform-syslog"
   }
 
-   access_logs = {
+   access_logs {
       bucket        = "${var.log_bucket_name}"
       bucket_prefix        = "${var.stack_description}"
       enabled       = true

--- a/terraform/modules/logsearch/outputs.tf
+++ b/terraform/modules/logsearch/outputs.tf
@@ -1,18 +1,21 @@
 /* Logsearch ELB */
 output "logsearch_elb_name" {
-  value = "${aws_elb.logsearch_elb.name}"
+  value = aws_elb.logsearch_elb.name
 }
+
 output "logsearch_elb_dns_name" {
-  value = "${aws_elb.logsearch_elb.dns_name}"
+  value = aws_elb.logsearch_elb.dns_name
 }
 
 output "platform_syslog_elb_name" {
-  value = "${aws_elb.platform_syslog_elb.name}"
+  value = aws_elb.platform_syslog_elb.name
 }
+
 output "platform_syslog_elb_dns_name" {
-  value = "${aws_elb.platform_syslog_elb.dns_name}"
+  value = aws_elb.platform_syslog_elb.dns_name
 }
 
 output "platform_kibana_lb_target_group" {
-  value = "${aws_lb_target_group.platform_kibana.name}"
+  value = aws_lb_target_group.platform_kibana.name
 }
+

--- a/terraform/modules/logsearch/variables.tf
+++ b/terraform/modules/logsearch/variables.tf
@@ -1,9 +1,23 @@
-variable "stack_description" {}
-variable "vpc_id" {}
-variable "private_elb_subnets" {type = "list"}
-variable "bosh_security_group" {}
-variable "listener_arn" {}
-variable "hosts" {
-  type = "list"
+variable "stack_description" {
 }
-variable "log_bucket_name" {}
+
+variable "vpc_id" {
+}
+
+variable "private_elb_subnets" {
+  type = list(string)
+}
+
+variable "bosh_security_group" {
+}
+
+variable "listener_arn" {
+}
+
+variable "hosts" {
+  type = list(string)
+}
+
+variable "log_bucket_name" {
+}
+

--- a/terraform/modules/logsearch/versions.tf
+++ b/terraform/modules/logsearch/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/monitoring/elb.tf
+++ b/terraform/modules/monitoring/elb.tf
@@ -2,31 +2,39 @@ resource "aws_lb_target_group" "prometheus_target" {
   name     = "${var.stack_description}-prometheus"
   port     = 8080
   protocol = "HTTP"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold = 2
-    interval = 5
-    path = "/ping"
-    timeout = 4
+    healthy_threshold   = 2
+    interval            = 5
+    path                = "/ping"
+    timeout             = 4
     unhealthy_threshold = 3
-    matcher = 200
+    matcher             = 200
   }
 }
 
 resource "aws_lb_listener_rule" "prometheus_listener_rule" {
-  count = "${length(var.hosts)}"
+  count = length(var.hosts)
 
-  listener_arn = "${var.listener_arn}"
+  listener_arn = var.listener_arn
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.prometheus_target.arn}"
+    target_group_arn = aws_lb_target_group.prometheus_target.arn
   }
 
   condition {
     host_header {
-      values = ["${element(var.hosts, count.index)}"]
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
+      values = [element(var.hosts, count.index)]
     }
   }
 }
@@ -35,38 +43,38 @@ resource "aws_lb_target_group" "doomsday_target" {
   name     = "${var.stack_description}-doomsday"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold = 2
-    interval = 5
-    path = "/"
-    timeout = 4
+    healthy_threshold   = 2
+    interval            = 5
+    path                = "/"
+    timeout             = 4
     unhealthy_threshold = 3
-    matcher = 200
+    matcher             = 200
   }
 }
 
 resource "aws_lb_listener_rule" "doomsday_listener_rule" {
-  listener_arn = "${var.listener_arn}"
+  listener_arn = var.listener_arn
 
   action {
     type = "authenticate-oidc"
     authenticate_oidc {
       # https://opslogin.fr.cloud.gov/.well-known/openid-configuration
-      authorization_endpoint = "https://opslogin.fr.cloud.gov/oauth/authorize"
-      client_id = "${var.oidc_client}"
-      client_secret = "${var.oidc_client_secret}"
-      issuer = "https://opslogin.fr.cloud.gov/oauth/token"
-      token_endpoint = "https://opslogin.fr.cloud.gov/oauth/token"
-      user_info_endpoint = "https://opslogin.fr.cloud.gov/userinfo"
+      authorization_endpoint     = "https://opslogin.fr.cloud.gov/oauth/authorize"
+      client_id                  = var.oidc_client
+      client_secret              = var.oidc_client_secret
+      issuer                     = "https://opslogin.fr.cloud.gov/oauth/token"
+      token_endpoint             = "https://opslogin.fr.cloud.gov/oauth/token"
+      user_info_endpoint         = "https://opslogin.fr.cloud.gov/userinfo"
       on_unauthenticated_request = "authenticate"
     }
   }
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.doomsday_target.arn}"
+    target_group_arn = aws_lb_target_group.doomsday_target.arn
   }
 
   condition {
@@ -75,3 +83,4 @@ resource "aws_lb_listener_rule" "doomsday_listener_rule" {
     }
   }
 }
+

--- a/terraform/modules/monitoring/elb.tf
+++ b/terraform/modules/monitoring/elb.tf
@@ -26,14 +26,6 @@ resource "aws_lb_listener_rule" "prometheus_listener_rule" {
 
   condition {
     host_header {
-      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-      # force an interpolation expression to be interpreted as a list by wrapping it
-      # in an extra set of list brackets. That form was supported for compatibility in
-      # v0.11, but is no longer supported in Terraform v0.12.
-      #
-      # If the expression in the following list itself returns a list, remove the
-      # brackets to avoid interpretation as a list of lists. If the expression
-      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [element(var.hosts, count.index)]
     }
   }

--- a/terraform/modules/monitoring/network.tf
+++ b/terraform/modules/monitoring/network.tf
@@ -9,17 +9,17 @@
  */
 
 resource "aws_subnet" "monitoring" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.monitoring_cidr}"
-  availability_zone = "${var.monitoring_az}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.monitoring_cidr
+  availability_zone = var.monitoring_az
 
-
-  tags =  {
+  tags = {
     Name = "${var.stack_description} (Monitoring - ${var.monitoring_cidr})"
   }
 }
 
 resource "aws_route_table_association" "monitoring_rta" {
-  subnet_id = "${aws_subnet.monitoring.id}"
-  route_table_id = "${var.route_table_id}"
+  subnet_id      = aws_subnet.monitoring.id
+  route_table_id = var.route_table_id
 }
+

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -1,24 +1,25 @@
 output "monitoring_subnet" {
-  value = "${aws_subnet.monitoring.id}"
+  value = aws_subnet.monitoring.id
 }
 
 output "monitoring_cidr" {
-  value = "${aws_subnet.monitoring.cidr_block}"
+  value = aws_subnet.monitoring.cidr_block
 }
 
 output "monitoring_az" {
-  value = "${var.monitoring_az}"
+  value = var.monitoring_az
 }
 
 output "monitoring_security_group" {
-  value = "${aws_security_group.monitoring.id}"
+  value = aws_security_group.monitoring.id
 }
 
 output "lb_target_group" {
-  value = "${aws_lb_target_group.prometheus_target.name}"
+  value = aws_lb_target_group.prometheus_target.name
 }
 
 # doomsday lb target.
 output "doomsday_lb_target_group" {
-  value = "${aws_lb_target_group.doomsday_target.name}"
+  value = aws_lb_target_group.doomsday_target.name
 }
+

--- a/terraform/modules/monitoring/sg_monitoring.tf
+++ b/terraform/modules/monitoring/sg_monitoring.tf
@@ -6,36 +6,37 @@
 
 resource "aws_security_group" "monitoring" {
   description = "Allow access to incoming monitoring traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Incoming Monitoring Traffic"
   }
 }
 
 resource "aws_security_group_rule" "self_reference" {
-  type = "ingress"
-  self = true
-  from_port = 0
-  to_port = 0
-  protocol = -1
-  security_group_id = "${aws_security_group.monitoring.id}"
+  type              = "ingress"
+  self              = true
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  security_group_id = aws_security_group.monitoring.id
 }
 
 resource "aws_security_group_rule" "monitoring_nginx" {
-  type = "ingress"
-  from_port = 8080
-  to_port = 8080
-  protocol = "all"
-  cidr_blocks = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.monitoring.id}"
+  type              = "ingress"
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "all"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.monitoring.id
 }
 
 resource "aws_security_group_rule" "outbound" {
-  type = "egress"
-  from_port = 0
-  to_port = 0
-  protocol = -1
-  cidr_blocks = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.monitoring.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.monitoring.id
 }
+

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "monitoring_cidr" {
   default = "10.99.30.0/24"
@@ -8,16 +9,22 @@ variable "monitoring_az" {
   default = "us-gov-west-1a"
 }
 
-variable "route_table_id" {}
-
-variable "vpc_id" {}
-
-variable "listener_arn" {}
-
-variable "hosts" {
-  type = "list"
+variable "route_table_id" {
 }
 
-variable "oidc_client" {}
+variable "vpc_id" {
+}
 
-variable "oidc_client_secret" {}
+variable "listener_arn" {
+}
+
+variable "hosts" {
+  type = list(string)
+}
+
+variable "oidc_client" {
+}
+
+variable "oidc_client_secret" {
+}
+

--- a/terraform/modules/monitoring/versions.tf
+++ b/terraform/modules/monitoring/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -40,7 +40,7 @@ resource "aws_db_instance" "rds_database" {
   allow_major_version_upgrade = "${var.rds_allow_major_version_upgrade}"
   apply_immediately           = "${var.rds_apply_immediately}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description}"
   }
 }

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -1,46 +1,43 @@
 resource "aws_db_instance" "rds_database" {
-  engine         = "${var.rds_db_engine}"
-  engine_version = "${var.rds_db_engine_version}"
+  engine         = var.rds_db_engine
+  engine_version = var.rds_db_engine_version
 
-  multi_az = "${var.rds_multi_az}"
+  multi_az = var.rds_multi_az
 
   lifecycle {
-    ignore_changes  = ["identifier"]
+    ignore_changes  = [identifier]
     prevent_destroy = true
   }
 
-  identifier = "${var.stack_description}-${element(split("-", uuid()),4)}"
+  identifier = "${var.stack_description}-${element(split("-", uuid()), 4)}"
 
-  final_snapshot_identifier = "${var.rds_final_snapshot_identifier == "" ?
-    "final-snapshot-${var.rds_db_name}-${var.stack_description}" :
-    var.rds_final_snapshot_identifier}"
+  final_snapshot_identifier = var.rds_final_snapshot_identifier == "" ? "final-snapshot-${var.rds_db_name}-${var.stack_description}" : var.rds_final_snapshot_identifier
 
   backup_retention_period = 35
 
   auto_minor_version_upgrade = true
 
-  name              = "${var.rds_db_name}"
-  allocated_storage = "${var.rds_db_size}"
-  storage_type      = "${var.rds_db_storage_type}"
-  iops              = "${var.rds_db_iops}"
-  instance_class    = "${var.rds_instance_type}"
+  name              = var.rds_db_name
+  allocated_storage = var.rds_db_size
+  storage_type      = var.rds_db_storage_type
+  iops              = var.rds_db_iops
+  instance_class    = var.rds_instance_type
 
-  username = "${var.rds_username}"
-  password = "${var.rds_password}"
+  username = var.rds_username
+  password = var.rds_password
 
   storage_encrypted = true
 
-  db_subnet_group_name   = "${var.rds_subnet_group}"
-  vpc_security_group_ids = ["${var.rds_security_groups}"]
+  db_subnet_group_name   = var.rds_subnet_group
+  vpc_security_group_ids = var.rds_security_groups
 
-  parameter_group_name = "${var.rds_db_engine == "postgres" ?
-    "${join("", aws_db_parameter_group.parameter_group_postgres.*.id)}" :
-    "${join("", aws_db_parameter_group.parameter_group_mysql.*.id)}"}"
+  parameter_group_name = var.rds_db_engine == "postgres" ? join("", aws_db_parameter_group.parameter_group_postgres.*.id) : join("", aws_db_parameter_group.parameter_group_mysql.*.id)
 
-  allow_major_version_upgrade = "${var.rds_allow_major_version_upgrade}"
-  apply_immediately           = "${var.rds_apply_immediately}"
+  allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  apply_immediately           = var.rds_apply_immediately
 
   tags = {
-    Name = "${var.stack_description}"
+    Name = var.stack_description
   }
 }
+

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,31 +1,32 @@
 output "rds_identifier" {
-  value = "${aws_db_instance.rds_database.identifier}"
+  value = aws_db_instance.rds_database.identifier
 }
 
 output "rds_name" {
-  value = "${aws_db_instance.rds_database.name}"
+  value = aws_db_instance.rds_database.name
 }
 
 output "rds_url" {
-  value = "${aws_db_instance.rds_database.endpoint}"
+  value = aws_db_instance.rds_database.endpoint
 }
 
 output "rds_host" {
-  value = "${aws_db_instance.rds_database.address}"
+  value = aws_db_instance.rds_database.address
 }
 
 output "rds_port" {
-  value = "${aws_db_instance.rds_database.port}"
+  value = aws_db_instance.rds_database.port
 }
 
 output "rds_username" {
-  value = "${aws_db_instance.rds_database.username}"
+  value = aws_db_instance.rds_database.username
 }
 
 output "rds_password" {
-  value = "${aws_db_instance.rds_database.password}"
+  value = aws_db_instance.rds_database.password
 }
 
 output "rds_engine" {
-  value = "${aws_db_instance.rds_database.engine}"
+  value = aws_db_instance.rds_database.engine
 }
+

--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -1,9 +1,12 @@
 resource "aws_db_parameter_group" "parameter_group_postgres" {
-  count = "${var.rds_db_engine == "postgres" ? 1 : 0}"
-  name = "${var.rds_parameter_group_name != "" ?
-    var.rds_parameter_group_name :
-    "${replace("${var.stack_description}-${var.rds_db_name}", "/[^a-zA-Z-]+/", "-")}"}"
-  family = "${var.rds_parameter_group_family}"
+  count = var.rds_db_engine == "postgres" ? 1 : 0
+  name = var.rds_parameter_group_name != "" ? var.rds_parameter_group_name : replace(
+    "${var.stack_description}-${var.rds_db_name}",
+    "/[^a-zA-Z-]+/",
+    "-",
+  )
+
+  family = var.rds_parameter_group_family
 
   parameter {
     name  = "log_connections"
@@ -26,24 +29,28 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
   }
 
   parameter {
-    name = "rds.force_ssl"
-    value = "${var.rds_force_ssl}"
+    name         = "rds.force_ssl"
+    value        = var.rds_force_ssl
     apply_method = "pending-reboot"
   }
 }
 
 resource "aws_db_parameter_group" "parameter_group_mysql" {
-  count = "${var.rds_db_engine == "mysql" ? 1 : 0}"
-  name = "${var.rds_parameter_group_name != "" ?
-    var.rds_parameter_group_name :
-    "${replace("${var.stack_description}-${var.rds_db_name}", "/[^a-zA-Z-]+/", "-")}"}"
-  family = "${var.rds_parameter_group_family}"
+  count = var.rds_db_engine == "mysql" ? 1 : 0
+  name = var.rds_parameter_group_name != "" ? var.rds_parameter_group_name : replace(
+    "${var.stack_description}-${var.rds_db_name}",
+    "/[^a-zA-Z-]+/",
+    "-",
+  )
+
+  family = var.rds_parameter_group_family
   parameter {
-    name = "general_log"
+    name  = "general_log"
     value = 1
   }
   parameter {
-    name = "log_output"
+    name  = "log_output"
     value = "FILE"
   }
 }
+

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -77,10 +77,10 @@ variable "rds_final_snapshot_identifier" {
 variable "rds_apply_immediately" {
   # Even though the documentation says these default to "false", `terraform
   # plan` shows otherwise.
-  default = ""
+  default = "false"
 }
 
 variable "rds_allow_major_version_upgrade" {
-  default = ""
+  default = "false"
 }
 

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "rds_instance_type" {
   default = "db.m4.large"
@@ -16,7 +17,8 @@ variable "rds_db_iops" {
   default = 0
 }
 
-variable "rds_db_name" {}
+variable "rds_db_name" {
+}
 
 variable "rds_db_engine" {
   default = "postgres"
@@ -26,14 +28,17 @@ variable "rds_db_engine_version" {
   default = "9.6.19"
 }
 
-variable "rds_username" {}
+variable "rds_username" {
+}
 
-variable "rds_password" {}
+variable "rds_password" {
+}
 
-variable "rds_subnet_group" {}
+variable "rds_subnet_group" {
+}
 
 variable "rds_security_groups" {
-  type = "list"
+  type = list(string)
 }
 
 variable "rds_force_ssl" {
@@ -78,3 +83,4 @@ variable "rds_apply_immediately" {
 variable "rds_allow_major_version_upgrade" {
   default = ""
 }
+

--- a/terraform/modules/rds/versions.tf
+++ b/terraform/modules/rds/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/rds_network/network.tf
+++ b/terraform/modules/rds_network/network.tf
@@ -9,9 +9,9 @@
  */
 
 resource "aws_subnet" "az1_rds" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.rds_private_cidr_1}"
-  availability_zone = "${var.az1}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.rds_private_cidr_1
+  availability_zone = var.az1
 
   tags = {
     Name = "${var.stack_description} (RDS AZ1)"
@@ -19,9 +19,9 @@ resource "aws_subnet" "az1_rds" {
 }
 
 resource "aws_subnet" "az2_rds" {
-  vpc_id = "${var.vpc_id}"
-  cidr_block = "${var.rds_private_cidr_2}"
-  availability_zone = "${var.az2}"
+  vpc_id            = var.vpc_id
+  cidr_block        = var.rds_private_cidr_2
+  availability_zone = var.az2
 
   tags = {
     Name = "${var.stack_description} (RDS AZ2)"
@@ -29,17 +29,18 @@ resource "aws_subnet" "az2_rds" {
 }
 
 resource "aws_db_subnet_group" "rds" {
-  name = "${var.stack_description}"
+  name        = var.stack_description
   description = "${var.stack_description} (Multi-AZ Subnet Group)"
-  subnet_ids = ["${aws_subnet.az1_rds.id}", "${aws_subnet.az2_rds.id}"]
+  subnet_ids  = [aws_subnet.az1_rds.id, aws_subnet.az2_rds.id]
 }
 
 resource "aws_route_table_association" "az1_rds_rta" {
-  subnet_id = "${aws_subnet.az1_rds.id}"
-  route_table_id = "${var.az1_route_table}"
+  subnet_id      = aws_subnet.az1_rds.id
+  route_table_id = var.az1_route_table
 }
 
 resource "aws_route_table_association" "az2_rds_rta" {
-  subnet_id = "${aws_subnet.az2_rds.id}"
-  route_table_id = "${var.az2_route_table}"
+  subnet_id      = aws_subnet.az2_rds.id
+  route_table_id = var.az2_route_table
 }
+

--- a/terraform/modules/rds_network/network.tf
+++ b/terraform/modules/rds_network/network.tf
@@ -13,7 +13,7 @@ resource "aws_subnet" "az1_rds" {
   cidr_block = "${var.rds_private_cidr_1}"
   availability_zone = "${var.az1}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (RDS AZ1)"
   }
 }
@@ -23,7 +23,7 @@ resource "aws_subnet" "az2_rds" {
   cidr_block = "${var.rds_private_cidr_2}"
   availability_zone = "${var.az2}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} (RDS AZ2)"
   }
 }

--- a/terraform/modules/rds_network/outputs.tf
+++ b/terraform/modules/rds_network/outputs.tf
@@ -1,35 +1,36 @@
 output "rds_subnet_az1" {
-    value = "${aws_subnet.az1_rds.id}"
+  value = aws_subnet.az1_rds.id
 }
 
 output "rds_subnet_az2" {
-    value = "${aws_subnet.az2_rds.id}"
+  value = aws_subnet.az2_rds.id
 }
 
-output "rds_private_cidr_1"{
-    value = "${aws_subnet.az1_rds.cidr_block}"
-}
-output "rds_private_cidr_2"{
-    value = "${aws_subnet.az2_rds.cidr_block}"
+output "rds_private_cidr_1" {
+  value = aws_subnet.az1_rds.cidr_block
 }
 
+output "rds_private_cidr_2" {
+  value = aws_subnet.az2_rds.cidr_block
+}
 
 output "rds_subnet_group" {
-    value = "${aws_db_subnet_group.rds.id}"
+  value = aws_db_subnet_group.rds.id
 }
 
 output "rds_mysql_security_group" {
-  value = "${aws_security_group.rds_mysql.id}"
+  value = aws_security_group.rds_mysql.id
 }
 
 output "rds_postgres_security_group" {
-  value = "${aws_security_group.rds_postgres.id}"
+  value = aws_security_group.rds_postgres.id
 }
 
 output "rds_mssql_security_group" {
-  value = "${aws_security_group.rds_mssql.id}"
+  value = aws_security_group.rds_mssql.id
 }
 
 output "rds_oracle_security_group" {
-  value = "${aws_security_group.rds_oracle.id}"
+  value = aws_security_group.rds_oracle.id
 }
+

--- a/terraform/modules/rds_network/sg_mssql.tf
+++ b/terraform/modules/rds_network/sg_mssql.tf
@@ -6,23 +6,24 @@
 
 resource "aws_security_group" "rds_mssql" {
   description = "Allow access to incoming mssql traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
-    from_port = 1433
-    to_port = 1433
-    protocol = "tcp"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 1433
+    to_port         = 1433
+    protocol        = "tcp"
+    security_groups = var.security_groups
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = var.security_groups
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Incoming SQL Server Traffic"
   }
 }
+

--- a/terraform/modules/rds_network/sg_mysql.tf
+++ b/terraform/modules/rds_network/sg_mysql.tf
@@ -6,23 +6,24 @@
 
 resource "aws_security_group" "rds_mysql" {
   description = "Allow access to incoming mysql traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
-    from_port = 3306
-    to_port = 3306
-    protocol = "tcp"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = var.security_groups
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = var.security_groups
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Incoming MySQL Traffic"
   }
 }
+

--- a/terraform/modules/rds_network/sg_oracle.tf
+++ b/terraform/modules/rds_network/sg_oracle.tf
@@ -6,23 +6,24 @@
 
 resource "aws_security_group" "rds_oracle" {
   description = "Allow access to incoming Oracle traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
-    from_port = 1521
-    to_port = 1521
-    protocol = "tcp"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 1521
+    to_port         = 1521
+    protocol        = "tcp"
+    security_groups = var.security_groups
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    security_groups = ["${var.security_groups}"]
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = var.security_groups
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Incoming Oracle Traffic"
   }
 }
+

--- a/terraform/modules/rds_network/sg_postgres.tf
+++ b/terraform/modules/rds_network/sg_postgres.tf
@@ -6,7 +6,7 @@
 
 resource "aws_security_group" "rds_postgres" {
   description = "Allow access to incoming postgresql traffic"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   tags = {
     Name = "${var.stack_description} - Incoming PostGreSQL Traffic"
@@ -14,23 +14,24 @@ resource "aws_security_group" "rds_postgres" {
 }
 
 resource "aws_security_group_rule" "ingress_default" {
-  count = "${var.security_groups_count}"
+  count = var.security_groups_count
 
-  type = "ingress"
-  from_port = 5432
-  to_port = 5432
-  protocol = "tcp"
-  source_security_group_id = "${element(var.security_groups, count.index)}"
-  security_group_id = "${aws_security_group.rds_postgres.id}"
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = element(var.security_groups, count.index)
+  security_group_id        = aws_security_group.rds_postgres.id
 }
 
 resource "aws_security_group_rule" "egress_default" {
-  count = "${var.security_groups_count}"
+  count = var.security_groups_count
 
-  type = "egress"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  source_security_group_id = "${element(var.security_groups, count.index)}"
-  security_group_id = "${aws_security_group.rds_postgres.id}"
+  type                     = "egress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = element(var.security_groups, count.index)
+  security_group_id        = aws_security_group.rds_postgres.id
 }
+

--- a/terraform/modules/rds_network/sg_postgres.tf
+++ b/terraform/modules/rds_network/sg_postgres.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "rds_postgres" {
   description = "Allow access to incoming postgresql traffic"
   vpc_id = "${var.vpc_id}"
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Incoming PostGreSQL Traffic"
   }
 }

--- a/terraform/modules/rds_network/variables.tf
+++ b/terraform/modules/rds_network/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "az1" {
   default = "us-gov-west-1a"
@@ -8,19 +9,25 @@ variable "az2" {
   default = "us-gov-west-1b"
 }
 
-variable "rds_private_cidr_1" {}
+variable "rds_private_cidr_1" {
+}
 
-variable "rds_private_cidr_2" {}
+variable "rds_private_cidr_2" {
+}
 
-variable "az1_route_table" {}
+variable "az1_route_table" {
+}
 
-variable "az2_route_table" {}
+variable "az2_route_table" {
+}
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
 variable "security_groups" {
-  type = "list"
+  type = list(string)
 }
 
 variable "security_groups_count" {
 }
+

--- a/terraform/modules/rds_network/versions.tf
+++ b/terraform/modules/rds_network/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -1,30 +1,30 @@
 resource "aws_s3_bucket" "encrypted_bucket" {
-    bucket = "${var.bucket}"
-    acl = "${var.acl}"
-    force_destroy = "${var.force_destroy}"
-    versioning {
-        enabled = "${var.versioning}"
-    }
+  bucket        = var.bucket
+  acl           = var.acl
+  force_destroy = var.force_destroy
+  versioning {
+    enabled = var.versioning
+  }
 
-    server_side_encryption_configuration {
-        rule {
-            apply_server_side_encryption_by_default {
-                sse_algorithm = "AES256"
-            }
-        }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
     }
+  }
 
-    lifecycle_rule {
-        prefix = ""
-        enabled = "${var.expiration_days == 0 ? "false" : "true"}"
-        expiration {
-            # Hack: Set expiration days to 30 if unset; objects won't actually be expired because the rule will be disabled
-            # See https://github.com/terraform-providers/terraform-provider-aws/issues/1402
-            days = "${var.expiration_days == 0 ? 30 : var.expiration_days}"
-        }
+  lifecycle_rule {
+    prefix  = ""
+    enabled = var.expiration_days == 0 ? "false" : "true"
+    expiration {
+      # Hack: Set expiration days to 30 if unset; objects won't actually be expired because the rule will be disabled
+      # See https://github.com/terraform-providers/terraform-provider-aws/issues/1402
+      days = var.expiration_days == 0 ? 30 : var.expiration_days
     }
+  }
 
-    policy = <<EOF
+  policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [{
@@ -43,4 +43,6 @@ resource "aws_s3_bucket" "encrypted_bucket" {
     }]
 }
 EOF
+
 }
+

--- a/terraform/modules/s3_bucket/encrypted_bucket/outputs.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/outputs.tf
@@ -1,3 +1,4 @@
 output "bucket_name" {
-  value = "${aws_s3_bucket.encrypted_bucket.bucket}"
+  value = aws_s3_bucket.encrypted_bucket.bucket
 }
+

--- a/terraform/modules/s3_bucket/encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/variables.tf
@@ -1,19 +1,22 @@
-variable "bucket" {}
+variable "bucket" {
+}
 
 variable "acl" {
-    default = "private"
+  default = "private"
 }
 
 variable "versioning" {
-    default = "false"
+  default = "false"
 }
 
 variable "force_destroy" {
-    default = "false"
+  default = "false"
 }
 
-variable "aws_partition" {}
+variable "aws_partition" {
+}
 
 variable "expiration_days" {
-    default = 0
+  default = 0
 }
+

--- a/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/public_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/public_encrypted_bucket.tf
@@ -1,19 +1,19 @@
 resource "aws_s3_bucket" "public_encrypted_bucket" {
-    bucket = "${var.bucket}"
-    force_destroy = "${var.force_destroy}"
-    versioning {
-        enabled = "${var.versioning}"
-    }
+  bucket        = var.bucket
+  force_destroy = var.force_destroy
+  versioning {
+    enabled = var.versioning
+  }
 
-    server_side_encryption_configuration {
-        rule {
-            apply_server_side_encryption_by_default {
-                sse_algorithm = "AES256"
-            }
-        }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
     }
+  }
 
-    policy = <<EOF
+  policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -43,4 +43,6 @@ resource "aws_s3_bucket" "public_encrypted_bucket" {
     ]
 }
 EOF
+
 }
+

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/variables.tf
@@ -1,11 +1,14 @@
-variable "bucket" {}
+variable "bucket" {
+}
 
 variable "versioning" {
-    default = "false"
+  default = "false"
 }
 
 variable "force_destroy" {
-    default = "false"
+  default = "false"
 }
 
-variable "aws_partition" {}
+variable "aws_partition" {
+}
+

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/shibboleth/outputs.tf
+++ b/terraform/modules/shibboleth/outputs.tf
@@ -1,3 +1,4 @@
 output "shibboleth_lb_target_group" {
-  value = "${aws_lb_target_group.shibboleth.name}"
+  value = aws_lb_target_group.shibboleth.name
 }
+

--- a/terraform/modules/shibboleth/shibboleth_elb_main.tf
+++ b/terraform/modules/shibboleth/shibboleth_elb_main.tf
@@ -2,37 +2,46 @@ resource "aws_lb_target_group" "shibboleth" {
   name     = "${var.stack_description}-shibboleth"
   port     = 8080
   protocol = "HTTP"
-  vpc_id   = "${var.vpc_id}"
+  vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold = 2
-    interval = 15
-    path = "/shibboleth"
-    timeout = 10
+    healthy_threshold   = 2
+    interval            = 15
+    path                = "/shibboleth"
+    timeout             = 10
     unhealthy_threshold = 2
-    matcher = 200
+    matcher             = 200
   }
 
   stickiness {
-    type = "lb_cookie"
+    type    = "lb_cookie"
     enabled = true
   }
 }
 
 resource "aws_lb_listener_rule" "shibboleth" {
-  count = "${length(var.hosts)}"
+  count = length(var.hosts)
 
-  listener_arn = "${var.listener_arn}"
-  priority = "${100 + count.index}"
+  listener_arn = var.listener_arn
+  priority     = 100 + count.index
 
   action {
-    target_group_arn = "${aws_lb_target_group.shibboleth.arn}"
+    target_group_arn = aws_lb_target_group.shibboleth.arn
     type             = "forward"
   }
 
   condition {
     host_header {
-      values = ["${element(var.hosts, count.index)}"]
+      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+      # force an interpolation expression to be interpreted as a list by wrapping it
+      # in an extra set of list brackets. That form was supported for compatibility in
+      # v0.11, but is no longer supported in Terraform v0.12.
+      #
+      # If the expression in the following list itself returns a list, remove the
+      # brackets to avoid interpretation as a list of lists. If the expression
+      # returns a single list item then leave it as-is and remove this TODO comment.
+      values = [element(var.hosts, count.index)]
     }
   }
 }
+

--- a/terraform/modules/shibboleth/shibboleth_elb_main.tf
+++ b/terraform/modules/shibboleth/shibboleth_elb_main.tf
@@ -32,14 +32,6 @@ resource "aws_lb_listener_rule" "shibboleth" {
 
   condition {
     host_header {
-      # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-      # force an interpolation expression to be interpreted as a list by wrapping it
-      # in an extra set of list brackets. That form was supported for compatibility in
-      # v0.11, but is no longer supported in Terraform v0.12.
-      #
-      # If the expression in the following list itself returns a list, remove the
-      # brackets to avoid interpretation as a list of lists. If the expression
-      # returns a single list item then leave it as-is and remove this TODO comment.
       values = [element(var.hosts, count.index)]
     }
   }

--- a/terraform/modules/shibboleth/variables.tf
+++ b/terraform/modules/shibboleth/variables.tf
@@ -1,8 +1,13 @@
-variable "stack_description" {}
-
-variable "vpc_id" {}
-
-variable "listener_arn" {}
-variable "hosts" {
-  type = "list"
+variable "stack_description" {
 }
+
+variable "vpc_id" {
+}
+
+variable "listener_arn" {
+}
+
+variable "hosts" {
+  type = list(string)
+}
+

--- a/terraform/modules/shibboleth/versions.tf
+++ b/terraform/modules/shibboleth/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/smtp/outputs.tf
+++ b/terraform/modules/smtp/outputs.tf
@@ -1,3 +1,4 @@
 output "smtp_security_group" {
-  value = "${aws_security_group.smtp.id}"
+  value = aws_security_group.smtp.id
 }
+

--- a/terraform/modules/smtp/sg.tf
+++ b/terraform/modules/smtp/sg.tf
@@ -1,22 +1,23 @@
 resource "aws_security_group" "smtp" {
   description = "Allow access to smtp service from all our internal hosts, and outbound access to 587 too"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
   ingress {
-    from_port = 25
-    to_port = 25
-    protocol = "tcp"
-    cidr_blocks = ["${var.ingress_cidr_blocks}"]
+    from_port   = 25
+    to_port     = 25
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidr_blocks
   }
 
   egress {
-    from_port = 587
-    to_port = 587
-    protocol = "tcp"
+    from_port   = 587
+    to_port     = 587
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - smtp"
   }
 }
+

--- a/terraform/modules/smtp/variables.tf
+++ b/terraform/modules/smtp/variables.tf
@@ -1,5 +1,10 @@
-variable "stack_description" {}
-variable "vpc_id" {}
-variable "ingress_cidr_blocks" {
-  type = "list"
+variable "stack_description" {
 }
+
+variable "vpc_id" {
+}
+
+variable "ingress_cidr_blocks" {
+  type = list(string)
+}
+

--- a/terraform/modules/smtp/versions.tf
+++ b/terraform/modules/smtp/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -1,68 +1,69 @@
 module "vpc" {
   source = "../../bosh_vpc"
 
-  stack_description                 = "${var.stack_description}"
-  vpc_cidr                          = "${var.vpc_cidr}"
-  az1                               = "${var.az1}"
-  az2                               = "${var.az2}"
-  aws_default_region                = "${var.aws_default_region}"
-  private_cidr_1                    = "${var.private_cidr_1}"
-  private_cidr_2                    = "${var.private_cidr_2}"
-  public_cidr_1                     = "${var.public_cidr_1}"
-  public_cidr_2                     = "${var.public_cidr_2}"
-  restricted_ingress_web_cidrs      = "${var.restricted_ingress_web_cidrs}"
-  restricted_ingress_web_ipv6_cidrs = "${var.restricted_ingress_web_ipv6_cidrs}"
-  nat_gateway_instance_type         = "${var.nat_gateway_instance_type}"
-  monitoring_security_groups        = "${var.target_monitoring_security_groups}"
-  concourse_security_groups         = "${var.target_concourse_security_groups}"
+  stack_description                 = var.stack_description
+  vpc_cidr                          = var.vpc_cidr
+  az1                               = var.az1
+  az2                               = var.az2
+  aws_default_region                = var.aws_default_region
+  private_cidr_1                    = var.private_cidr_1
+  private_cidr_2                    = var.private_cidr_2
+  public_cidr_1                     = var.public_cidr_1
+  public_cidr_2                     = var.public_cidr_2
+  restricted_ingress_web_cidrs      = var.restricted_ingress_web_cidrs
+  restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
+  nat_gateway_instance_type         = var.nat_gateway_instance_type
+  monitoring_security_groups        = var.target_monitoring_security_groups
+  concourse_security_groups         = var.target_concourse_security_groups
 }
 
 module "rds_network" {
   source = "../../rds_network"
 
-  stack_description     = "${var.stack_description}"
-  az1                   = "${var.az1}"
-  az2                   = "${var.az2}"
-  vpc_id                = "${module.vpc.vpc_id}"
-  security_groups       = "${var.rds_security_groups}"
-  security_groups_count = "${var.rds_security_groups_count}"
-  rds_private_cidr_1    = "${var.rds_private_cidr_1}"
-  rds_private_cidr_2    = "${var.rds_private_cidr_2}"
-  az1_route_table       = "${module.vpc.private_route_table_az1}"
-  az2_route_table       = "${module.vpc.private_route_table_az2}"
+  stack_description     = var.stack_description
+  az1                   = var.az1
+  az2                   = var.az2
+  vpc_id                = module.vpc.vpc_id
+  security_groups       = var.rds_security_groups
+  security_groups_count = var.rds_security_groups_count
+  rds_private_cidr_1    = var.rds_private_cidr_1
+  rds_private_cidr_2    = var.rds_private_cidr_2
+  az1_route_table       = module.vpc.private_route_table_az1
+  az2_route_table       = module.vpc.private_route_table_az2
 }
 
 module "rds" {
   source = "../../rds"
 
-  stack_description               = "${var.stack_description}"
-  rds_instance_type               = "${var.rds_instance_type}"
-  rds_db_size                     = "${var.rds_db_size}"
-  rds_db_engine                   = "${var.rds_db_engine}"
-  rds_db_engine_version           = "${var.rds_db_engine_version}"
-  rds_db_name                     = "${var.rds_db_name}"
-  rds_username                    = "${var.rds_username}"
-  rds_password                    = "${var.rds_password}"
-  rds_multi_az                    = "${var.rds_multi_az}"
-  rds_apply_immediately           = "${var.rds_apply_immediately}"
-  rds_allow_major_version_upgrade = "${var.rds_allow_major_version_upgrade}"
-  rds_subnet_group                = "${module.rds_network.rds_subnet_group}"
-  rds_security_groups             = ["${module.rds_network.rds_postgres_security_group}"]
+  stack_description               = var.stack_description
+  rds_instance_type               = var.rds_instance_type
+  rds_db_size                     = var.rds_db_size
+  rds_db_engine                   = var.rds_db_engine
+  rds_db_engine_version           = var.rds_db_engine_version
+  rds_db_name                     = var.rds_db_name
+  rds_username                    = var.rds_username
+  rds_password                    = var.rds_password
+  rds_multi_az                    = var.rds_multi_az
+  rds_apply_immediately           = var.rds_apply_immediately
+  rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  rds_subnet_group                = module.rds_network.rds_subnet_group
+  rds_security_groups             = [module.rds_network.rds_postgres_security_group]
 }
 
 module "credhub_rds" {
   source = "../../rds"
 
-  stack_description        = "${var.stack_description}"
-  rds_db_name              = "${var.credhub_rds_db_name}"
-  rds_instance_type        = "${var.credhub_rds_instance_type}"
-  rds_db_size              = "${var.credhub_rds_db_size}"
-  rds_db_storage_type      = "${var.credhub_rds_db_storage_type}"
-  rds_db_engine_version    = "${var.credhub_rds_db_engine_version}"
-  rds_username             = "${var.credhub_rds_username}"
-  rds_password             = "${var.credhub_rds_password}"
-  rds_subnet_group         = "${module.rds_network.rds_subnet_group}"
-  rds_security_groups      = ["${module.rds_network.rds_postgres_security_group}"]
-  rds_parameter_group_name = "${var.rds_parameter_group_name}"
-  rds_force_ssl            = "${var.credhub_rds_force_ssl}"
+  stack_description        = var.stack_description
+  rds_db_name              = var.credhub_rds_db_name
+  rds_instance_type        = var.credhub_rds_instance_type
+  rds_db_size              = var.credhub_rds_db_size
+  rds_db_storage_type      = var.credhub_rds_db_storage_type
+  rds_db_engine_version    = var.credhub_rds_db_engine_version
+  rds_username             = var.credhub_rds_username
+  rds_password             = var.credhub_rds_password
+  rds_subnet_group         = module.rds_network.rds_subnet_group
+  rds_security_groups      = [module.rds_network.rds_postgres_security_group]
+  rds_parameter_group_name = var.rds_parameter_group_name
+  rds_force_ssl            = var.credhub_rds_force_ssl
 }
+

--- a/terraform/modules/stack/base/outputs.tf
+++ b/terraform/modules/stack/base/outputs.tf
@@ -1,121 +1,147 @@
-
 /* VPC */
 output "vpc_id" {
-    value = "${module.vpc.vpc_id}"
+  value = module.vpc.vpc_id
 }
+
 output "vpc_cidr" {
-    value = "${module.vpc.vpc_cidr}"
+  value = module.vpc.vpc_cidr
 }
 
 /* Private network */
 output "private_subnet_az1" {
-  value = "${module.vpc.private_subnet_az1}"
+  value = module.vpc.private_subnet_az1
 }
+
 output "private_subnet_az2" {
-  value = "${module.vpc.private_subnet_az2}"
+  value = module.vpc.private_subnet_az2
 }
+
 output "private_route_table_az1" {
-  value = "${module.vpc.private_route_table_az1}"
+  value = module.vpc.private_route_table_az1
 }
+
 output "private_route_table_az2" {
-  value = "${module.vpc.private_route_table_az2}"
+  value = module.vpc.private_route_table_az2
 }
+
 output "private_cidr_az1" {
-  value = "${module.vpc.private_cidr_az1}"
+  value = module.vpc.private_cidr_az1
 }
+
 output "private_cidr_az2" {
-  value = "${module.vpc.private_cidr_az2}"
+  value = module.vpc.private_cidr_az2
 }
 
 /* Public network */
 output "public_subnet_az1" {
-  value = "${module.vpc.public_subnet_az1}"
+  value = module.vpc.public_subnet_az1
 }
+
 output "public_subnet_az2" {
-  value = "${module.vpc.public_subnet_az2}"
+  value = module.vpc.public_subnet_az2
 }
+
 output "public_route_table" {
-  value = "${module.vpc.public_route_table}"
+  value = module.vpc.public_route_table
 }
+
 output "public_cidr_az1" {
-  value = "${module.vpc.public_cidr_az1}"
+  value = module.vpc.public_cidr_az1
 }
+
 output "public_cidr_az2" {
-  value = "${module.vpc.public_cidr_az2}"
+  value = module.vpc.public_cidr_az2
 }
 
 output "nat_egress_ip_az1" {
-  value = "${module.vpc.nat_egress_ip_az1}"
+  value = module.vpc.nat_egress_ip_az1
 }
 
 output "nat_egress_ip_az2" {
-  value = "${module.vpc.nat_egress_ip_az2}"
+  value = module.vpc.nat_egress_ip_az2
 }
 
 /* Security Groups */
 output "bosh_security_group" {
-  value = "${module.vpc.bosh_security_group}"
+  value = module.vpc.bosh_security_group
 }
+
 output "local_vpc_traffic_security_group" {
-    value = "${module.vpc.local_vpc_traffic_security_group}"
+  value = module.vpc.local_vpc_traffic_security_group
 }
+
 output "web_traffic_security_group" {
-  value = "${module.vpc.web_traffic_security_group}"
+  value = module.vpc.web_traffic_security_group
 }
+
 output "restricted_web_traffic_security_group" {
-  value = "${module.vpc.restricted_web_traffic_security_group}"
+  value = module.vpc.restricted_web_traffic_security_group
 }
 
 /* RDS Network */
 output "rds_subnet_az1" {
-    value = "${module.rds_network.rds_subnet_az1}"
+  value = module.rds_network.rds_subnet_az1
 }
+
 output "rds_subnet_az2" {
-    value = "${module.rds_network.rds_subnet_az2}"
+  value = module.rds_network.rds_subnet_az2
 }
-output "rds_private_cidr_1"{
-    value = "${module.rds_network.rds_private_cidr_1}"
+
+output "rds_private_cidr_1" {
+  value = module.rds_network.rds_private_cidr_1
 }
-output "rds_private_cidr_2"{
-    value = "${module.rds_network.rds_private_cidr_2}"
+
+output "rds_private_cidr_2" {
+  value = module.rds_network.rds_private_cidr_2
 }
+
 output "rds_subnet_group" {
-    value = "${module.rds_network.rds_subnet_group}"
+  value = module.rds_network.rds_subnet_group
 }
+
 output "rds_mysql_security_group" {
-  value = "${module.rds_network.rds_mysql_security_group}"
+  value = module.rds_network.rds_mysql_security_group
 }
+
 output "rds_postgres_security_group" {
-  value = "${module.rds_network.rds_postgres_security_group}"
+  value = module.rds_network.rds_postgres_security_group
 }
+
 output "rds_mssql_security_group" {
-  value = "${module.rds_network.rds_mssql_security_group}"
+  value = module.rds_network.rds_mssql_security_group
 }
+
 output "rds_oracle_security_group" {
-  value = "${module.rds_network.rds_oracle_security_group}"
+  value = module.rds_network.rds_oracle_security_group
 }
 
 /* RDS Bosh Instance */
 output "bosh_rds_url_curr" {
-  value = "${module.rds.rds_url}"
+  value = module.rds.rds_url
 }
+
 output "bosh_rds_host_curr" {
-  value = "${module.rds.rds_host}"
+  value = module.rds.rds_host
 }
+
 output "bosh_rds_url_prev" {
   value = ""
 }
+
 output "bosh_rds_host_prev" {
   value = ""
 }
+
 output "bosh_rds_port" {
-  value = "${module.rds.rds_port}"
+  value = module.rds.rds_port
 }
+
 output "bosh_rds_username" {
-  value = "${module.rds.rds_username}"
+  value = module.rds.rds_username
 }
+
 output "bosh_rds_password" {
-  value = "${module.rds.rds_password}"
+  value = module.rds.rds_password
 }
 
 /*
@@ -123,30 +149,30 @@ output "bosh_rds_password" {
  */
 
 output "credhub_rds_identifier" {
-  value = "${module.credhub_rds.rds_identifier}"
+  value = module.credhub_rds.rds_identifier
 }
 
 output "credhub_rds_name" {
-  value = "${module.credhub_rds.rds_name}"
+  value = module.credhub_rds.rds_name
 }
 
 output "credhub_rds_host" {
-  value = "${module.credhub_rds.rds_host}"
+  value = module.credhub_rds.rds_host
 }
 
 output "credhub_rds_port" {
-  value = "${module.credhub_rds.rds_port}"
+  value = module.credhub_rds.rds_port
 }
 
 output "credhub_rds_url" {
-  value = "${module.credhub_rds.rds_url}"
+  value = module.credhub_rds.rds_url
 }
 
 output "credhub_rds_username" {
-  value = "${module.credhub_rds.rds_username}"
+  value = module.credhub_rds.rds_username
 }
 
 output "credhub_rds_password" {
-  value = "${module.credhub_rds.rds_password}"
+  value = module.credhub_rds.rds_password
 }
 

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "vpc_cidr" {
   default = "10.0.0.0/16"
@@ -24,17 +25,21 @@ variable "public_cidr_2" {
   default = "10.0.101.0/24"
 }
 
-variable "private_cidr_1" {}
+variable "private_cidr_1" {
+}
 
-variable "private_cidr_2" {}
+variable "private_cidr_2" {
+}
 
 variable "nat_gateway_instance_type" {
   default = "c3.2xlarge"
 }
 
-variable "rds_private_cidr_1" {}
+variable "rds_private_cidr_1" {
+}
 
-variable "rds_private_cidr_2" {}
+variable "rds_private_cidr_2" {
+}
 
 variable "rds_instance_type" {
   default = "db.m4.large"
@@ -68,20 +73,21 @@ variable "rds_username" {
   default = "bosh"
 }
 
-variable "rds_password" {}
+variable "rds_password" {
+}
 
 variable "restricted_ingress_web_cidrs" {
-  type    = "list"
+  type    = list(string)
   default = ["127.0.0.1/32", "192.168.0.1/24"]
 }
 
 variable "restricted_ingress_web_ipv6_cidrs" {
-  type    = "list"
+  type    = list(string)
   default = []
 }
 
 variable "rds_security_groups" {
-  type = "list"
+  type = list(string)
 }
 
 variable "rds_security_groups_count" {
@@ -89,12 +95,12 @@ variable "rds_security_groups_count" {
 }
 
 variable "target_monitoring_security_groups" {
-  type    = "list"
+  type    = list(string)
   default = []
 }
 
 variable "target_concourse_security_groups" {
-  type    = "list"
+  type    = list(string)
   default = []
 }
 
@@ -125,7 +131,8 @@ variable "credhub_rds_username" {
   default = "credhub"
 }
 
-variable "credhub_rds_password" {}
+variable "credhub_rds_password" {
+}
 
 variable "credhub_rds_db_engine_version" {
   default = "9.6.19"
@@ -138,3 +145,4 @@ variable "rds_parameter_group_name" {
 variable "credhub_rds_force_ssl" {
   default = 1
 }
+

--- a/terraform/modules/stack/base/versions.tf
+++ b/terraform/modules/stack/base/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/stack/spoke/outputs.tf
+++ b/terraform/modules/stack/spoke/outputs.tf
@@ -1,121 +1,147 @@
 /* VPC */
 output "vpc_id" {
-    value = "${module.base.vpc_id}"
+  value = module.base.vpc_id
 }
+
 output "vpc_cidr" {
-    value = "${module.base.vpc_cidr}"
+  value = module.base.vpc_cidr
 }
 
 /* Private network */
 output "private_subnet_az1" {
-  value = "${module.base.private_subnet_az1}"
+  value = module.base.private_subnet_az1
 }
+
 output "private_subnet_az2" {
-  value = "${module.base.private_subnet_az2}"
+  value = module.base.private_subnet_az2
 }
+
 output "private_route_table_az1" {
-  value = "${module.base.private_route_table_az1}"
+  value = module.base.private_route_table_az1
 }
+
 output "private_route_table_az2" {
-  value = "${module.base.private_route_table_az2}"
+  value = module.base.private_route_table_az2
 }
+
 output "private_cidr_az1" {
-  value = "${module.base.private_cidr_az1}"
+  value = module.base.private_cidr_az1
 }
+
 output "private_cidr_az2" {
-  value = "${module.base.private_cidr_az2}"
+  value = module.base.private_cidr_az2
 }
 
 /* Public network */
 output "public_subnet_az1" {
-  value = "${module.base.public_subnet_az1}"
+  value = module.base.public_subnet_az1
 }
+
 output "public_subnet_az2" {
-  value = "${module.base.public_subnet_az2}"
+  value = module.base.public_subnet_az2
 }
+
 output "public_route_table" {
-  value = "${module.base.public_route_table}"
+  value = module.base.public_route_table
 }
+
 output "public_cidr_az1" {
-  value = "${module.base.public_cidr_az1}"
+  value = module.base.public_cidr_az1
 }
+
 output "public_cidr_az2" {
-  value = "${module.base.public_cidr_az2}"
+  value = module.base.public_cidr_az2
 }
 
 output "nat_egress_ip_az1" {
-  value = "${module.base.nat_egress_ip_az1}"
+  value = module.base.nat_egress_ip_az1
 }
 
 output "nat_egress_ip_az2" {
-  value = "${module.base.nat_egress_ip_az2}"
+  value = module.base.nat_egress_ip_az2
 }
 
 /* Security Groups */
 output "bosh_security_group" {
-  value = "${module.base.bosh_security_group}"
-}
-output "local_vpc_traffic_security_group" {
-    value = "${module.base.local_vpc_traffic_security_group}"
-}
-output "web_traffic_security_group" {
-  value = "${module.base.web_traffic_security_group}"
-}
-output "restricted_web_traffic_security_group" {
-  value = "${module.base.restricted_web_traffic_security_group}"
+  value = module.base.bosh_security_group
 }
 
+output "local_vpc_traffic_security_group" {
+  value = module.base.local_vpc_traffic_security_group
+}
+
+output "web_traffic_security_group" {
+  value = module.base.web_traffic_security_group
+}
+
+output "restricted_web_traffic_security_group" {
+  value = module.base.restricted_web_traffic_security_group
+}
 
 /* RDS Network */
 output "rds_subnet_az1" {
-    value = "${module.base.rds_subnet_az1}"
+  value = module.base.rds_subnet_az1
 }
+
 output "rds_subnet_az2" {
-    value = "${module.base.rds_subnet_az2}"
+  value = module.base.rds_subnet_az2
 }
-output "rds_private_cidr_1"{
-    value = "${module.base.rds_private_cidr_1}"
+
+output "rds_private_cidr_1" {
+  value = module.base.rds_private_cidr_1
 }
-output "rds_private_cidr_2"{
-    value = "${module.base.rds_private_cidr_2}"
+
+output "rds_private_cidr_2" {
+  value = module.base.rds_private_cidr_2
 }
+
 output "rds_subnet_group" {
-    value = "${module.base.rds_subnet_group}"
+  value = module.base.rds_subnet_group
 }
+
 output "rds_mysql_security_group" {
-  value = "${module.base.rds_mysql_security_group}"
+  value = module.base.rds_mysql_security_group
 }
+
 output "rds_postgres_security_group" {
-  value = "${module.base.rds_postgres_security_group}"
+  value = module.base.rds_postgres_security_group
 }
+
 output "rds_mssql_security_group" {
-  value = "${module.base.rds_mssql_security_group}"
+  value = module.base.rds_mssql_security_group
 }
+
 output "rds_oracle_security_group" {
-  value = "${module.base.rds_oracle_security_group}"
+  value = module.base.rds_oracle_security_group
 }
 
 /* RDS Bosh Instance */
 output "bosh_rds_url_curr" {
-  value = "${module.base.bosh_rds_url_curr}"
+  value = module.base.bosh_rds_url_curr
 }
+
 output "bosh_rds_host_curr" {
-  value = "${module.base.bosh_rds_host_curr}"
+  value = module.base.bosh_rds_host_curr
 }
+
 output "bosh_rds_url_prev" {
-  value = "${module.base.bosh_rds_url_prev}"
+  value = module.base.bosh_rds_url_prev
 }
+
 output "bosh_rds_host_prev" {
-  value = "${module.base.bosh_rds_host_prev}"
+  value = module.base.bosh_rds_host_prev
 }
+
 output "bosh_rds_port" {
-  value = "${module.base.bosh_rds_port}"
+  value = module.base.bosh_rds_port
 }
+
 output "bosh_rds_username" {
-  value = "${module.base.bosh_rds_username}"
+  value = module.base.bosh_rds_username
 }
+
 output "bosh_rds_password" {
-  value = "${module.base.bosh_rds_password}"
+  value = module.base.bosh_rds_password
 }
 
 /*
@@ -123,21 +149,22 @@ output "bosh_rds_password" {
  */
 
 output "credhub_rds_host" {
-  value = "${module.base.credhub_rds_host}"
+  value = module.base.credhub_rds_host
 }
 
 output "credhub_rds_port" {
-  value = "${module.base.credhub_rds_port}"
+  value = module.base.credhub_rds_port
 }
 
 output "credhub_rds_url" {
-  value = "${module.base.credhub_rds_url}"
+  value = module.base.credhub_rds_url
 }
 
 output "credhub_rds_username" {
-  value = "${module.base.credhub_rds_username}"
+  value = module.base.credhub_rds_username
 }
 
 output "credhub_rds_password" {
-  value = "${module.base.credhub_rds_password}"
+  value = module.base.credhub_rds_password
 }
+

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -1,64 +1,65 @@
 module "base" {
   source                            = "../base"
-  stack_description                 = "${var.stack_description}"
-  vpc_cidr                          = "${var.vpc_cidr}"
-  az1                               = "${var.az1}"
-  az2                               = "${var.az2}"
-  aws_default_region                = "${var.aws_default_region}"
-  public_cidr_1                     = "${var.public_cidr_1}"
-  public_cidr_2                     = "${var.public_cidr_2}"
-  private_cidr_1                    = "${var.private_cidr_1}"
-  private_cidr_2                    = "${var.private_cidr_2}"
-  nat_gateway_instance_type         = "${var.nat_gateway_instance_type}"
-  rds_private_cidr_1                = "${var.rds_private_cidr_1}"
-  rds_private_cidr_2                = "${var.rds_private_cidr_2}"
-  rds_instance_type                 = "${var.rds_instance_type}"
-  rds_db_size                       = "${var.rds_db_size}"
-  rds_db_name                       = "${var.rds_db_name}"
-  rds_db_engine                     = "${var.rds_db_engine}"
-  rds_db_engine_version             = "${var.rds_db_engine_version}"
-  rds_allow_major_version_upgrade   = "${var.rds_allow_major_version_upgrade}"
-  rds_apply_immediately             = "${var.rds_apply_immediately}"
-  rds_username                      = "${var.rds_username}"
-  rds_password                      = "${var.rds_password}"
-  credhub_rds_password              = "${var.credhub_rds_password}"
-  restricted_ingress_web_cidrs      = "${var.restricted_ingress_web_cidrs}"
-  restricted_ingress_web_ipv6_cidrs = "${var.restricted_ingress_web_ipv6_cidrs}"
+  stack_description                 = var.stack_description
+  vpc_cidr                          = var.vpc_cidr
+  az1                               = var.az1
+  az2                               = var.az2
+  aws_default_region                = var.aws_default_region
+  public_cidr_1                     = var.public_cidr_1
+  public_cidr_2                     = var.public_cidr_2
+  private_cidr_1                    = var.private_cidr_1
+  private_cidr_2                    = var.private_cidr_2
+  nat_gateway_instance_type         = var.nat_gateway_instance_type
+  rds_private_cidr_1                = var.rds_private_cidr_1
+  rds_private_cidr_2                = var.rds_private_cidr_2
+  rds_instance_type                 = var.rds_instance_type
+  rds_db_size                       = var.rds_db_size
+  rds_db_name                       = var.rds_db_name
+  rds_db_engine                     = var.rds_db_engine
+  rds_db_engine_version             = var.rds_db_engine_version
+  rds_allow_major_version_upgrade   = var.rds_allow_major_version_upgrade
+  rds_apply_immediately             = var.rds_apply_immediately
+  rds_username                      = var.rds_username
+  rds_password                      = var.rds_password
+  credhub_rds_password              = var.credhub_rds_password
+  restricted_ingress_web_cidrs      = var.restricted_ingress_web_cidrs
+  restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
 
   rds_security_groups = [
-    "${module.base.bosh_security_group}",
-    "${var.target_bosh_security_group}",
+    module.base.bosh_security_group,
+    var.target_bosh_security_group,
   ]
 
   rds_security_groups_count         = 2
-  target_monitoring_security_groups = "${var.target_monitoring_security_groups}"
-  target_concourse_security_groups  = "${var.target_concourse_security_groups}"
+  target_monitoring_security_groups = var.target_monitoring_security_groups
+  target_concourse_security_groups  = var.target_concourse_security_groups
 }
 
 module "vpc_peering" {
   source = "../../vpc_peering"
 
-  peer_owner_id          = "${var.account_id}"
-  target_vpc_id          = "${var.target_vpc_id}"
-  target_vpc_cidr        = "${var.target_vpc_cidr}"
-  target_az1_route_table = "${var.target_az1_route_table}"
-  target_az2_route_table = "${var.target_az2_route_table}"
-  source_vpc_id          = "${module.base.vpc_id}"
-  source_vpc_cidr        = "${module.base.vpc_cidr}"
-  source_az1_route_table = "${module.base.private_route_table_az1}"
-  source_az2_route_table = "${module.base.private_route_table_az2}"
+  peer_owner_id          = var.account_id
+  target_vpc_id          = var.target_vpc_id
+  target_vpc_cidr        = var.target_vpc_cidr
+  target_az1_route_table = var.target_az1_route_table
+  target_az2_route_table = var.target_az2_route_table
+  source_vpc_id          = module.base.vpc_id
+  source_vpc_cidr        = module.base.vpc_cidr
+  source_az1_route_table = module.base.private_route_table_az1
+  source_az2_route_table = module.base.private_route_table_az2
 }
 
 module "vpc_security_source_to_target" {
   source = "../../vpc_peering_sg"
 
-  target_bosh_security_group = "${var.target_bosh_security_group}"
-  source_vpc_cidr            = "${module.base.vpc_cidr}"
+  target_bosh_security_group = var.target_bosh_security_group
+  source_vpc_cidr            = module.base.vpc_cidr
 }
 
 module "vpc_security_target_to_source" {
   source = "../../vpc_peering_sg"
 
-  target_bosh_security_group = "${module.base.bosh_security_group}"
-  source_vpc_cidr            = "${var.target_vpc_cidr}"
+  target_bosh_security_group = module.base.bosh_security_group
+  source_vpc_cidr            = var.target_vpc_cidr
 }
+

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -1,4 +1,5 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "vpc_cidr" {
   default = "10.0.0.0/16"
@@ -24,17 +25,21 @@ variable "public_cidr_2" {
   default = "10.0.101.0/24"
 }
 
-variable "private_cidr_1" {}
+variable "private_cidr_1" {
+}
 
-variable "private_cidr_2" {}
+variable "private_cidr_2" {
+}
 
 variable "nat_gateway_instance_type" {
   default = "c3.2xlarge"
 }
 
-variable "rds_private_cidr_1" {}
+variable "rds_private_cidr_1" {
+}
 
-variable "rds_private_cidr_2" {}
+variable "rds_private_cidr_2" {
+}
 
 variable "rds_instance_type" {
   default = "db.m4.large"
@@ -69,34 +74,49 @@ variable "rds_username" {
 }
 
 variable "restricted_ingress_web_cidrs" {
-  type    = "list"
+  type    = list(string)
   default = ["127.0.0.1/32", "192.168.0.1/24"]
 }
 
 variable "restricted_ingress_web_ipv6_cidrs" {
-  type    = "list"
+  type    = list(string)
   default = []
 }
 
-variable "aws_partition" {}
+variable "aws_partition" {
+}
 
-variable "rds_password" {}
-variable "credhub_rds_password" {}
+variable "rds_password" {
+}
 
-variable "account_id" {}
+variable "credhub_rds_password" {
+}
 
-variable "target_vpc_id" {}
-variable "target_vpc_cidr" {}
-variable "target_bosh_security_group" {}
-variable "target_az1_route_table" {}
-variable "target_az2_route_table" {}
+variable "account_id" {
+}
+
+variable "target_vpc_id" {
+}
+
+variable "target_vpc_cidr" {
+}
+
+variable "target_bosh_security_group" {
+}
+
+variable "target_az1_route_table" {
+}
+
+variable "target_az2_route_table" {
+}
 
 variable "target_monitoring_security_groups" {
-  type    = "list"
+  type    = list(string)
   default = []
 }
 
 variable "target_concourse_security_groups" {
-  type    = "list"
+  type    = list(string)
   default = []
 }
+

--- a/terraform/modules/stack/spoke/versions.tf
+++ b/terraform/modules/stack/spoke/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -13,40 +13,41 @@
 
 # Create peering connection for source_vpc_id -> target_vpc_id
 resource "aws_vpc_peering_connection" "peering" {
-    peer_owner_id = "${var.peer_owner_id}"
-    peer_vpc_id = "${var.target_vpc_id}"
-    auto_accept = true
-    vpc_id = "${var.source_vpc_id}"
+  peer_owner_id = var.peer_owner_id
+  peer_vpc_id   = var.target_vpc_id
+  auto_accept   = true
+  vpc_id        = var.source_vpc_id
 
-    tags = {
-        Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
-    }
+  tags = {
+    Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
+  }
 }
 
 # Add peering connection to target_az1_route_table with source_vpc_cidr
 resource "aws_route" "target_az1_to_source_cidr" {
-    route_table_id = "${var.target_az1_route_table}"
-    destination_cidr_block = "${var.source_vpc_cidr}"
-    vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+  route_table_id            = var.target_az1_route_table
+  destination_cidr_block    = var.source_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
 }
 
 # Add peering connection to target_az2_route_table with source_vpc_cidr
 resource "aws_route" "target_az2_to_source_cidr" {
-    route_table_id = "${var.target_az2_route_table}"
-    destination_cidr_block = "${var.source_vpc_cidr}"
-    vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+  route_table_id            = var.target_az2_route_table
+  destination_cidr_block    = var.source_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
 }
 
 # add peering connection to source_az1_route_table with target_vpc_cidr
 resource "aws_route" "source_az1_to_target_cidr" {
-    route_table_id = "${var.source_az1_route_table}"
-    destination_cidr_block = "${var.target_vpc_cidr}"
-    vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+  route_table_id            = var.source_az1_route_table
+  destination_cidr_block    = var.target_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
 }
 
 # add peering connection to source_az2_route_table with target_vpc_cidr
 resource "aws_route" "source_az2_to_target_cidr" {
-    route_table_id = "${var.source_az2_route_table}"
-    destination_cidr_block = "${var.target_vpc_cidr}"
-    vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+  route_table_id            = var.source_az2_route_table
+  destination_cidr_block    = var.target_vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
 }
+

--- a/terraform/modules/vpc_peering/outputs.tf
+++ b/terraform/modules/vpc_peering/outputs.tf
@@ -1,4 +1,4 @@
-
 output "peering_connection" {
-    value = "${aws_vpc_peering_connection.peering.id}"
+  value = aws_vpc_peering_connection.peering.id
 }
+

--- a/terraform/modules/vpc_peering/variables.tf
+++ b/terraform/modules/vpc_peering/variables.tf
@@ -1,17 +1,27 @@
-variable "peer_owner_id" {}
+variable "peer_owner_id" {
+}
 
-variable "source_az1_route_table" {}
+variable "source_az1_route_table" {
+}
 
-variable "source_az2_route_table" {}
+variable "source_az2_route_table" {
+}
 
-variable "target_az1_route_table" {}
+variable "target_az1_route_table" {
+}
 
-variable "target_az2_route_table" {}
+variable "target_az2_route_table" {
+}
 
-variable "target_vpc_id" {}
+variable "target_vpc_id" {
+}
 
-variable "target_vpc_cidr" {}
+variable "target_vpc_cidr" {
+}
 
-variable "source_vpc_id" {}
+variable "source_vpc_id" {
+}
 
-variable "source_vpc_cidr" {}
+variable "source_vpc_cidr" {
+}
+

--- a/terraform/modules/vpc_peering/versions.tf
+++ b/terraform/modules/vpc_peering/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/vpc_peering_sg/modify_bosh_sg.tf
+++ b/terraform/modules/vpc_peering_sg/modify_bosh_sg.tf
@@ -1,98 +1,99 @@
-
 resource "aws_security_group_rule" "bosh_ssh" {
-    type = "ingress"
-    from_port = 22
-    to_port = 22
-    protocol = "tcp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "dns_tcp" {
-    type = "ingress"
-    from_port = 53
-    to_port = 53
-    protocol = "tcp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "tcp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
+
 resource "aws_security_group_rule" "dns_udp" {
-    type = "ingress"
-    from_port = 53
-    to_port = 53
-    protocol = "udp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "ntp_udp" {
-    type = "ingress"
-    from_port = 123
-    to_port = 123
-    protocol = "udp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 123
+  to_port           = 123
+  protocol          = "udp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "bosh_nats" {
-    type = "ingress"
-    from_port = 4222
-    to_port = 4222
-    protocol = "tcp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 4222
+  to_port           = 4222
+  protocol          = "tcp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "bosh_agent" {
-    type = "ingress"
-    from_port = 6868
-    to_port = 6868
-    protocol = "tcp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 6868
+  to_port           = 6868
+  protocol          = "tcp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "uaa_http" {
-    type = "ingress"
-    from_port = 8080
-    to_port = 8080
-    protocol = "tcp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "tcp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "uaa_https" {
-    type = "ingress"
-    from_port = 8443
-    to_port = 8443
-    protocol = "tcp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 8443
+  to_port           = 8443
+  protocol          = "tcp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "credhub_https" {
-    type = "ingress"
-    from_port = 8844
-    to_port = 8844
-    protocol = "tcp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 8844
+  to_port           = 8844
+  protocol          = "tcp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "bosh_director" {
-    type = "ingress"
-    from_port = 25555
-    to_port = 25555
-    protocol = "tcp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 25555
+  to_port           = 25555
+  protocol          = "tcp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
 
 resource "aws_security_group_rule" "bosh_registry" {
-    type = "ingress"
-    from_port = 25777
-    to_port = 25777
-    protocol = "tcp"
-    cidr_blocks = ["${var.source_vpc_cidr}"]
-    security_group_id = "${var.target_bosh_security_group}"
+  type              = "ingress"
+  from_port         = 25777
+  to_port           = 25777
+  protocol          = "tcp"
+  cidr_blocks       = [var.source_vpc_cidr]
+  security_group_id = var.target_bosh_security_group
 }
+

--- a/terraform/modules/vpc_peering_sg/variables.tf
+++ b/terraform/modules/vpc_peering_sg/variables.tf
@@ -1,4 +1,6 @@
+variable "target_bosh_security_group" {
+}
 
-variable "target_bosh_security_group" {}
+variable "source_vpc_cidr" {
+}
 
-variable "source_vpc_cidr" {}

--- a/terraform/modules/vpc_peering_sg/versions.tf
+++ b/terraform/modules/vpc_peering_sg/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/stacks/bootstrap/bootstrap.tf
+++ b/terraform/stacks/bootstrap/bootstrap.tf
@@ -1,52 +1,54 @@
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
 
 variable "ingress_cidrs" {
-  type = "list"
+  type    = list(string)
   default = ["159.142.0.0/16"]
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 resource "aws_default_vpc" "bootstrap" {
-  tags {
+  tags = {
     Name = "DEFAULT"
   }
 }
 
 data "aws_route_table" "bootstrap" {
-  vpc_id = "${aws_default_vpc.bootstrap.id}"
+  vpc_id = aws_default_vpc.bootstrap.id
 }
 
 resource "aws_default_subnet" "default_az1" {
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = data.aws_availability_zones.available.names[0]
 }
 
 resource "aws_security_group" "bootstrap" {
   ingress {
-    from_port = 22
-    to_port = 22
-    protocol = "tcp"
-    cidr_blocks = ["${var.ingress_cidrs}"]
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
   }
 
   ingress {
-    from_port = 4443
-    to_port = 4443
-    protocol = "tcp"
-    cidr_blocks = ["${var.ingress_cidrs}"]
+    from_port   = 4443
+    to_port     = 4443
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
   }
 
   ingress {
-    from_port = 6868
-    to_port = 6868
-    protocol = "tcp"
-    cidr_blocks = ["${var.ingress_cidrs}"]
+    from_port   = 6868
+    to_port     = 6868
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
@@ -56,8 +58,8 @@ resource "aws_eip" "bootstrap" {
 }
 
 resource "aws_iam_role_policy" "iam_policy" {
-  name = "bootstrap"
-  role = "${aws_iam_role.iam_role.name}"
+  name   = "bootstrap"
+  role   = aws_iam_role.iam_role.name
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -70,10 +72,11 @@ resource "aws_iam_role_policy" "iam_policy" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role" "iam_role" {
-  name = "bootstrap"
+  name               = "bootstrap"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -88,33 +91,35 @@ resource "aws_iam_role" "iam_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_instance_profile" "iam_profile" {
   name = "bootstrap"
-  role = "${aws_iam_role.iam_role.name}"
+  role = aws_iam_role.iam_role.name
 }
 
 output "public_subnet_id" {
-  value = "${aws_default_subnet.default_az1.id}"
+  value = aws_default_subnet.default_az1.id
 }
 
 output "public_subnet_cidr" {
-  value = "${aws_default_subnet.default_az1.cidr_block}"
+  value = aws_default_subnet.default_az1.cidr_block
 }
 
 output "public_subnet_gateway" {
-  value = "${cidrhost("${aws_default_subnet.default_az1.cidr_block}", 1)}"
+  value = cidrhost(aws_default_subnet.default_az1.cidr_block, 1)
 }
 
 output "private_ip" {
-  value = "${cidrhost("${aws_default_subnet.default_az1.cidr_block}", 100)}"
+  value = cidrhost(aws_default_subnet.default_az1.cidr_block, 100)
 }
 
 output "public_ip" {
-  value = "${aws_eip.bootstrap.public_ip}"
+  value = aws_eip.bootstrap.public_ip
 }
 
 output "security_group_id" {
-  value = "${aws_security_group.bootstrap.id}"
+  value = aws_security_group.bootstrap.id
 }
+

--- a/terraform/stacks/bootstrap/peering.tf
+++ b/terraform/stacks/bootstrap/peering.tf
@@ -11,66 +11,67 @@ variable "tooling_stack_name" {
 }
 
 data "terraform_remote_state" "tooling_vpc" {
-  count = "${var.use_vpc_peering}"
+  count = var.use_vpc_peering
 
   backend = "s3"
-  config {
-    bucket = "${var.tooling_state_bucket}"
-    key = "${var.tooling_stack_name}/terraform.tfstate"
+  config = {
+    bucket = var.tooling_state_bucket
+    key    = "${var.tooling_stack_name}/terraform.tfstate"
   }
 }
 
 resource "aws_vpc_peering_connection" "peering" {
-  count = "${var.use_vpc_peering}"
+  count = var.use_vpc_peering
 
-  vpc_id = "${aws_default_vpc.bootstrap.id}"
-  peer_owner_id = "${data.aws_caller_identity.current.account_id}"
-  peer_vpc_id = "${data.terraform_remote_state.tooling_vpc.vpc_id}"
-  auto_accept = true
+  vpc_id        = aws_default_vpc.bootstrap.id
+  peer_owner_id = data.aws_caller_identity.current.account_id
+  peer_vpc_id   = data.terraform_remote_state.tooling_vpc[0].outputs.vpc_id
+  auto_accept   = true
 }
 
 resource "aws_route" "target_az1_to_source_cidr" {
-  count = "${var.use_vpc_peering}"
+  count = var.use_vpc_peering
 
-  route_table_id = "${data.terraform_remote_state.tooling_vpc.private_route_table_az1}"
-  destination_cidr_block = "${aws_default_vpc.bootstrap.cidr_block}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+  route_table_id            = data.terraform_remote_state.tooling_vpc[0].outputs.private_route_table_az1
+  destination_cidr_block    = aws_default_vpc.bootstrap.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering[0].id
 }
 
 resource "aws_route" "target_az2_to_source_cidr" {
-  count = "${var.use_vpc_peering}"
+  count = var.use_vpc_peering
 
-  route_table_id = "${data.terraform_remote_state.tooling_vpc.private_route_table_az2}"
-  destination_cidr_block = "${aws_default_vpc.bootstrap.cidr_block}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+  route_table_id            = data.terraform_remote_state.tooling_vpc[0].outputs.private_route_table_az2
+  destination_cidr_block    = aws_default_vpc.bootstrap.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering[0].id
 }
 
 resource "aws_route" "source_az1_to_target_cidr" {
-  count = "${var.use_vpc_peering}"
+  count = var.use_vpc_peering
 
-  route_table_id = "${data.aws_route_table.bootstrap.id}"
-  destination_cidr_block = "${data.terraform_remote_state.tooling_vpc.vpc_cidr}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+  route_table_id            = data.aws_route_table.bootstrap.id
+  destination_cidr_block    = data.terraform_remote_state.tooling_vpc[0].outputs.vpc_cidr
+  vpc_peering_connection_id = aws_vpc_peering_connection.peering[0].id
 }
 
 resource "aws_security_group_rule" "allow_all_bosh_default" {
-  count = "${var.use_vpc_peering}"
+  count = var.use_vpc_peering
 
-  type = "ingress"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  cidr_blocks = ["${aws_default_vpc.bootstrap.cidr_block}"]
-  security_group_id = "${data.terraform_remote_state.tooling_vpc.bosh_security_group}"
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = [aws_default_vpc.bootstrap.cidr_block]
+  security_group_id = data.terraform_remote_state.tooling_vpc[0].outputs.bosh_security_group
 }
 
 resource "aws_security_group_rule" "allow_rds_postgres" {
-  count = "${var.use_vpc_peering}"
+  count = var.use_vpc_peering
 
-  type = "ingress"
-  from_port = 5432
-  to_port = 5432
-  protocol = "tcp"
-  cidr_blocks = ["${aws_default_vpc.bootstrap.cidr_block}"]
-  security_group_id = "${data.terraform_remote_state.tooling_vpc.rds_postgres_security_group}"
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = [aws_default_vpc.bootstrap.cidr_block]
+  security_group_id = data.terraform_remote_state.tooling_vpc[0].outputs.rds_postgres_security_group
 }
+

--- a/terraform/stacks/bootstrap/versions.tf
+++ b/terraform/stacks/bootstrap/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -1,36 +1,52 @@
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}
+variable "aws_access_key" {
+}
+
+variable "aws_secret_key" {
+}
+
+variable "aws_region" {
+}
 
 terraform {
-  backend "s3" {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
   version    = "~> 2.40"
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  region     = "${var.aws_region}"
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
 }
 
 variable "cloudfront_zone_id" {
   default = "Z33AYJ8TM3BH4J"
 }
 
-variable "remote_state_bucket" {}
-variable "remote_state_region" {}
+variable "remote_state_bucket" {
+}
 
-variable "tooling_stack_name" {}
-variable "production_stack_name" {}
-variable "staging_stack_name" {}
-variable "development_stack_name" {}
+variable "remote_state_region" {
+}
+
+variable "tooling_stack_name" {
+}
+
+variable "production_stack_name" {
+}
+
+variable "staging_stack_name" {
+}
+
+variable "development_stack_name" {
+}
 
 data "terraform_remote_state" "tooling" {
   backend = "s3"
 
-  config {
-    bucket = "${var.remote_state_bucket}"
-    region = "${var.remote_state_region}"
+  config = {
+    bucket = var.remote_state_bucket
+    region = var.remote_state_region
     key    = "${var.tooling_stack_name}/terraform.tfstate"
   }
 }
@@ -38,9 +54,9 @@ data "terraform_remote_state" "tooling" {
 data "terraform_remote_state" "production" {
   backend = "s3"
 
-  config {
-    bucket = "${var.remote_state_bucket}"
-    region = "${var.remote_state_region}"
+  config = {
+    bucket = var.remote_state_bucket
+    region = var.remote_state_region
     key    = "${var.production_stack_name}/terraform.tfstate"
   }
 }
@@ -48,9 +64,9 @@ data "terraform_remote_state" "production" {
 data "terraform_remote_state" "staging" {
   backend = "s3"
 
-  config {
-    bucket = "${var.remote_state_bucket}"
-    region = "${var.remote_state_region}"
+  config = {
+    bucket = var.remote_state_bucket
+    region = var.remote_state_region
     key    = "${var.staging_stack_name}/terraform.tfstate"
   }
 }
@@ -58,9 +74,9 @@ data "terraform_remote_state" "staging" {
 data "terraform_remote_state" "development" {
   backend = "s3"
 
-  config {
-    bucket = "${var.remote_state_bucket}"
-    region = "${var.remote_state_region}"
+  config = {
+    bucket = var.remote_state_bucket
+    region = var.remote_state_region
     key    = "${var.development_stack_name}/terraform.tfstate"
   }
 }
@@ -68,13 +84,13 @@ data "terraform_remote_state" "development" {
 resource "aws_route53_zone" "cloud_gov_zone" {
   name = "cloud.gov."
 
-  tags {
+  tags = {
     Project = "dns"
   }
 }
 
 resource "aws_route53_record" "cloud_gov_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "cloud.gov."
   type    = "A"
 
@@ -86,7 +102,7 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_a" {
 }
 
 resource "aws_route53_record" "cloud_gov_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "cloud.gov."
   type    = "AAAA"
 
@@ -98,7 +114,7 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_aaaa" {
 }
 
 resource "aws_route53_record" "cloud_gov_google_gsuite_mx" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "cloud.gov."
   type    = "MX"
   ttl     = 100
@@ -113,7 +129,7 @@ resource "aws_route53_record" "cloud_gov_google_gsuite_mx" {
 }
 
 resource "aws_route53_record" "cloud_gov_cloud_gov_txt" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "cloud.gov."
   type    = "TXT"
   ttl     = 300
@@ -125,7 +141,7 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_txt" {
 }
 
 resource "aws_route53_record" "cloud_gov_zendesk_support_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "support.cloud.gov."
   type    = "CNAME"
   ttl     = 60
@@ -133,7 +149,7 @@ resource "aws_route53_record" "cloud_gov_zendesk_support_cname" {
 }
 
 resource "aws_route53_record" "cloud_gov_gsuite_dkim_txt" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "google._domainkey.cloud.gov"
   type    = "TXT"
   ttl     = 5
@@ -144,7 +160,7 @@ resource "aws_route53_record" "cloud_gov_gsuite_dkim_txt" {
 }
 
 resource "aws_route53_record" "cloud_gov_zendesk_verification_txt" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "zendeskverification.cloud.gov."
   type    = "TXT"
   ttl     = 300
@@ -155,7 +171,7 @@ resource "aws_route53_record" "cloud_gov_zendesk_verification_txt" {
 }
 
 resource "aws_route53_record" "cloud_gov_zendesk1_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "zendesk1.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -163,7 +179,7 @@ resource "aws_route53_record" "cloud_gov_zendesk1_cloud_gov_cname" {
 }
 
 resource "aws_route53_record" "cloud_gov_zendesk2_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "zendesk2.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -171,7 +187,7 @@ resource "aws_route53_record" "cloud_gov_zendesk2_cloud_gov_cname" {
 }
 
 resource "aws_route53_record" "cloud_gov_zendesk3_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "zendesk3.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -179,7 +195,7 @@ resource "aws_route53_record" "cloud_gov_zendesk3_cloud_gov_cname" {
 }
 
 resource "aws_route53_record" "cloud_gov_zendesk4_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "zendesk4.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -187,7 +203,7 @@ resource "aws_route53_record" "cloud_gov_zendesk4_cloud_gov_cname" {
 }
 
 resource "aws_route53_record" "cloud_gov_zendesk_domain_key1_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "zendesk1._domainkey.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -195,7 +211,7 @@ resource "aws_route53_record" "cloud_gov_zendesk_domain_key1_cname" {
 }
 
 resource "aws_route53_record" "cloud_gov_zendesk_domain_key2_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "zendesk2._domainkey.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -203,7 +219,7 @@ resource "aws_route53_record" "cloud_gov_zendesk_domain_key2_cname" {
 }
 
 resource "aws_route53_record" "cloud_gov_2a37e22b1f41ad3fe6af39f4fc38c1bc_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "2a37e22b1f41ad3fe6af39f4fc38c1bc.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -211,7 +227,7 @@ resource "aws_route53_record" "cloud_gov_2a37e22b1f41ad3fe6af39f4fc38c1bc_cloud_
 }
 
 resource "aws_route53_record" "cloud_gov_dc8dffe0fd99c8d067ce1bb5ef156f3e_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "dc8dffe0fd99c8d067ce1bb5ef156f3e.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -219,7 +235,7 @@ resource "aws_route53_record" "cloud_gov_dc8dffe0fd99c8d067ce1bb5ef156f3e_cloud_
 }
 
 resource "aws_route53_record" "cloud_gov_domainkey_cloud_gov_txt" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "mail._domainkey.cloud.gov."
   type    = "TXT"
   ttl     = 300
@@ -227,7 +243,7 @@ resource "aws_route53_record" "cloud_gov_domainkey_cloud_gov_txt" {
 }
 
 resource "aws_route53_record" "cloud_gov_docs_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "docs.cloud.gov."
   type    = "CNAME"
   ttl     = 60
@@ -235,7 +251,7 @@ resource "aws_route53_record" "cloud_gov_docs_cloud_gov_cname" {
 }
 
 resource "aws_route53_record" "cloud_gov_62c5ba6eb10ba1eec8fffd32f9a3cb7d_fr-stage_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "62c5ba6eb10ba1eec8fffd32f9a3cb7d.fr-stage.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -243,139 +259,139 @@ resource "aws_route53_record" "cloud_gov_62c5ba6eb10ba1eec8fffd32f9a3cb7d_fr-sta
 }
 
 resource "aws_route53_record" "cloud_gov_star_fr-stage_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.staging.cf_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.staging.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_star_fr-stage_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.fr-stage.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.staging.cf_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.staging.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_prometheus_fr-stage_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "prometheus.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_prometheus_fr-stage_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "prometheus.fr-stage.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_alertmanager_fr-stage_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "alertmanager.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_alertmanager_fr-stage_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "alertmanager.fr-stage.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_grafana_fr-stage_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "grafana.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_grafana_fr-stage_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "grafana.fr-stage.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_doomsday_fr-stage_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "doomsday.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_doomsday_fr-stage_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "doomsday.fr-stage.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ssh_fr-stage_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ssh.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.staging.diego_elb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.staging.outputs.diego_elb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_39e7c230acbbc55a537f450483f715f9_fr_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "39e7c230acbbc55a537f450483f715f9.fr.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -383,253 +399,253 @@ resource "aws_route53_record" "cloud_gov_39e7c230acbbc55a537f450483f715f9_fr_clo
 }
 
 resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.cf_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.fr.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.cf_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_star_app_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.app.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.cf_apps_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_star_app_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.app.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.cf_apps_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_admin_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "admin.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.admin_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.admin_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_admin_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "admin.fr.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.admin_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.admin_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_admin_fr-stage_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "admin.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.staging.admin_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.staging.outputs.admin_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_admin_fr-stage_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "admin.fr-stage.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.staging.admin_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.staging.outputs.admin_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ci-stage_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ci.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ci-stage_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ci.fr-stage.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ci_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ci.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ci_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ci.fr.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ci_dev2_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ci.dev2.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "A"
 
   alias {
     name                   = "dualstack.tooling-Concourse-us-gov-west-1a-1305041237.us-gov-west-1.elb.amazonaws.com."
-    zone_id                = "${var.cloudfront_zone_id}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_prometheus_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "prometheus.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_prometheus_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "prometheus.fr.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_alertmanager_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "alertmanager.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_alertmanager_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "alertmanager.fr.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_grafana_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "grafana.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_grafana_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "grafana.fr.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_doomsday_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "doomsday.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_doomsday_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "doomsday.fr.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
@@ -637,270 +653,270 @@ resource "aws_route53_record" "cloud_gov_doomsday_fr_cloud_gov_aaaa" {
 /* Platform logs */
 
 resource "aws_route53_record" "cloud_gov_logs_platform_dev_env_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_logs_platform_dev_env_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_logs_platform_stage_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "logs-platform.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.staging.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.staging.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_logs_platform_stage_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "logs-platform.fr-stage.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.staging.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.staging.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_logs_platform_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "logs-platform.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_logs_platform_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "logs-platform.fr.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_nessus_fr_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "nessus.fr.cloud.gov."
   type    = "CNAME"
   ttl     = 300
 
   records = [
-    "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}",
+    "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}",
   ]
 }
 
 resource "aws_route53_record" "cloud_gov_ssh_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ssh.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.diego_elb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.diego_elb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ops_uaa_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "opsuaa.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.opsuaa_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.opsuaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ops_uaa_dev2_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "opsuaa.dev2.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "A"
 
   alias {
     name                   = "dualstack.tooling-bosh-uaa-2083417090.us-gov-west-1.elb.amazonaws.com."
-    zone_id                = "${var.cloudfront_zone_id}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ops_login_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "opslogin.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.tooling.opsuaa_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.opsuaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ops_login_dev2_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "opslogin.dev2.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "A"
 
   alias {
     name                   = "dualstack.tooling-bosh-uaa-2083417090.us-gov-west-1.elb.amazonaws.com."
-    zone_id                = "${var.cloudfront_zone_id}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_idp_dev_us_gov_west_1_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "idp.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_idp_dev_us_gov_west_1_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "idp.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_idp_fr-stage_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "idp.fr-stage.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.staging.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.staging.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_idp_fr-stage_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "idp.fr-stage.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.staging.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.staging.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_idp_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "idp.fr.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_idp_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "idp.fr.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.main_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_star_dev_env_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.cf_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ssh_dev_env_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ssh.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.diego_elb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.diego_elb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_ssh_dev_env_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ssh.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.diego_elb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.diego_elb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_star_dev_env_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.cf_lb_dns_name}"
-    zone_id                = "${var.cloudfront_zone_id}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
 }
 
 resource "aws_route53_record" "cloud_gov_www_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "www.cloud.gov."
   type    = "CNAME"
   ttl     = 60
@@ -911,7 +927,7 @@ resource "aws_route53_record" "cloud_gov_www_cloud_gov_cname" {
 // in terraform (gasp), and connecting it with an NS record inside the module .
 
 resource "aws_route53_record" "cdn_broker_delegate" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "cdn-broker-test.cloud.gov."
   type    = "NS"
   ttl     = 300
@@ -925,7 +941,7 @@ resource "aws_route53_record" "cdn_broker_delegate" {
 }
 
 resource "aws_route53_record" "star_app_cloud_gov_dv" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "_baa568061ce9f20600f5faa54e0032b2.app.cloud.gov."
   type    = "NS"
   ttl     = 300
@@ -933,7 +949,7 @@ resource "aws_route53_record" "star_app_cloud_gov_dv" {
 }
 
 resource "aws_route53_record" "cloud_gov_b3b6346ca012f4c2600a876bec04df21_fr_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "b3b6346ca012f4c2600a876bec04df21.fr.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -941,7 +957,7 @@ resource "aws_route53_record" "cloud_gov_b3b6346ca012f4c2600a876bec04df21_fr_clo
 }
 
 resource "aws_route53_record" "cloud_gov_06c69b2987cb640e61fb65cc8213943d_fr-stage_cloud_gov_cname" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "06c69b2987cb640e61fb65cc8213943d.fr-stage.cloud.gov."
   type    = "CNAME"
   ttl     = 5
@@ -949,7 +965,7 @@ resource "aws_route53_record" "cloud_gov_06c69b2987cb640e61fb65cc8213943d_fr-sta
 }
 
 resource "aws_route53_record" "cloud_gov__dmarc_cloud_gov_txt" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "_dmarc.cloud.gov."
   type    = "TXT"
   ttl     = 300
@@ -960,7 +976,7 @@ resource "aws_route53_record" "cloud_gov__dmarc_cloud_gov_txt" {
 }
 
 resource "aws_route53_record" "dev2_delegate" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "dev2.cloud.gov."
   type    = "NS"
   ttl     = 300
@@ -974,5 +990,6 @@ resource "aws_route53_record" "dev2_delegate" {
 }
 
 output "cloud_gov_ns" {
-  value = "${aws_route53_zone.cloud_gov_zone.name_servers}"
+  value = aws_route53_zone.cloud_gov_zone.name_servers
 }
+

--- a/terraform/stacks/dns/versions.tf
+++ b/terraform/stacks/dns/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -1,125 +1,126 @@
 /* external domain broker user */
 output "external_domain_broker_username" {
-  value = "${module.external_domain_broker.username}"
+  value = module.external_domain_broker.username
 }
 
 output "external_domain_broker_access_key_id_prev" {
-  value = "${module.external_domain_broker.access_key_id_prev}"
+  value = module.external_domain_broker.access_key_id_prev
 }
 
 output "external_domain_broker_secret_access_key_prev" {
-  value = "${module.external_domain_broker.secret_access_key_prev}"
+  value = module.external_domain_broker.secret_access_key_prev
 }
 
 output "external_domain_broker_access_key_id_curr" {
-  value = "${module.external_domain_broker.access_key_id_curr}"
+  value = module.external_domain_broker.access_key_id_curr
 }
 
 output "external_domain_broker_secret_access_key_curr" {
-  value = "${module.external_domain_broker.secret_access_key_curr}"
+  value = module.external_domain_broker.secret_access_key_curr
 }
 
 /* external domain broker test user */
 output "external_domain_broker_tests_username" {
-  value = "${module.external_domain_broker_tests.username}"
+  value = module.external_domain_broker_tests.username
 }
 
 output "external_domain_broker_tests_access_key_id_prev" {
-  value = "${module.external_domain_broker_tests.access_key_id_prev}"
+  value = module.external_domain_broker_tests.access_key_id_prev
 }
 
 output "external_domain_broker_tests_secret_access_key_prev" {
-  value = "${module.external_domain_broker_tests.secret_access_key_prev}"
+  value = module.external_domain_broker_tests.secret_access_key_prev
 }
 
 output "external_domain_broker_tests_access_key_id_curr" {
-  value = "${module.external_domain_broker_tests.access_key_id_curr}"
+  value = module.external_domain_broker_tests.access_key_id_curr
 }
 
 output "external_domain_broker_tests_secret_access_key_curr" {
-  value = "${module.external_domain_broker_tests.secret_access_key_curr}"
+  value = module.external_domain_broker_tests.secret_access_key_curr
 }
 
 /* cdn broker user */
 output "cdn_broker_username" {
-  value = "${module.cdn_broker.username}"
+  value = module.cdn_broker.username
 }
 
 output "cdn_broker_access_key_id_prev" {
-  value = "${module.cdn_broker.access_key_id_prev}"
+  value = module.cdn_broker.access_key_id_prev
 }
 
 output "cdn_broker_secret_access_key_prev" {
-  value = "${module.cdn_broker.secret_access_key_prev}"
+  value = module.cdn_broker.secret_access_key_prev
 }
 
 output "cdn_broker_access_key_id_curr" {
-  value = "${module.cdn_broker.access_key_id_curr}"
+  value = module.cdn_broker.access_key_id_curr
 }
 
 output "cdn_broker_secret_access_key_curr" {
-  value = "${module.cdn_broker.secret_access_key_curr}"
+  value = module.cdn_broker.secret_access_key_curr
 }
 
 /* limit check user */
 output "limit_check_username" {
-  value = "${module.limit_check_user.username}"
+  value = module.limit_check_user.username
 }
 
 output "limit_check_access_key_id_prev" {
-  value = "${module.limit_check_user.access_key_id_prev}"
+  value = module.limit_check_user.access_key_id_prev
 }
 
 output "limit_check_secret_access_key_prev" {
-  value = "${module.limit_check_user.secret_access_key_prev}"
+  value = module.limit_check_user.secret_access_key_prev
 }
 
 output "limit_check_access_key_id_curr" {
-  value = "${module.limit_check_user.access_key_id_curr}"
+  value = module.limit_check_user.access_key_id_curr
 }
 
 output "limit_check_secret_access_key_curr" {
-  value = "${module.limit_check_user.secret_access_key_curr}"
+  value = module.limit_check_user.secret_access_key_curr
 }
 
 /* lets encrypt user */
 output "lets_encrypt_username" {
-  value = "${module.lets_encrypt_user.username}"
+  value = module.lets_encrypt_user.username
 }
 
 output "lets_encrypt_access_key_id_prev" {
-  value = "${module.lets_encrypt_user.access_key_id_prev}"
+  value = module.lets_encrypt_user.access_key_id_prev
 }
 
 output "lets_encrypt_secret_access_key_prev" {
-  value = "${module.lets_encrypt_user.secret_access_key_prev}"
+  value = module.lets_encrypt_user.secret_access_key_prev
 }
 
 output "lets_encrypt_access_key_id_curr" {
-  value = "${module.lets_encrypt_user.access_key_id_curr}"
+  value = module.lets_encrypt_user.access_key_id_curr
 }
 
 output "lets_encrypt_secret_access_key_curr" {
-  value = "${module.lets_encrypt_user.secret_access_key_curr}"
+  value = module.lets_encrypt_user.secret_access_key_curr
 }
 
 // Domain Broker v2
 output "domain_broker_v2" {
-  value = "${module.domain_broker_v2_user.username}"
+  value = module.domain_broker_v2_user.username
 }
 
 output "domain_broker_v2_access_key_id_prev" {
-  value = "${module.domain_broker_v2_user.access_key_id_prev}"
+  value = module.domain_broker_v2_user.access_key_id_prev
 }
 
 output "domain_broker_v2_secret_access_key_prev" {
-  value = "${module.domain_broker_v2_user.secret_access_key_prev}"
+  value = module.domain_broker_v2_user.secret_access_key_prev
 }
 
 output "domain_broker_v2_access_key_id_curr" {
-  value = "${module.domain_broker_v2_user.access_key_id_curr}"
+  value = module.domain_broker_v2_user.access_key_id_curr
 }
 
 output "domain_broker_v2_secret_access_key_curr" {
-  value = "${module.domain_broker_v2_user.secret_access_key_curr}"
+  value = module.domain_broker_v2_user.secret_access_key_curr
 }
+

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -1,37 +1,42 @@
 terraform {
-  backend "s3" {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
   version = "~> 2.40"
 }
 
-data "aws_partition" "current" {}
-data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {
+}
+
+data "aws_caller_identity" "current" {
+}
 
 module "external_domain_broker" {
   source = "../../modules/external_domain_broker"
 
-  account_id        = "${data.aws_caller_identity.current.account_id}"
-  stack_description = "${var.stack_description}"
-  aws_partition     = "${data.aws_partition.current.partition}"
+  account_id        = data.aws_caller_identity.current.account_id
+  stack_description = var.stack_description
+  aws_partition     = data.aws_partition.current.partition
 }
+
 module "external_domain_broker_tests" {
   source = "../../modules/external_domain_broker_tests"
 
-  aws_partition     = "${data.aws_partition.current.partition}"
-  stack_description = "${var.stack_description}"
+  aws_partition     = data.aws_partition.current.partition
+  stack_description = var.stack_description
 }
 
 module "cdn_broker" {
   source = "../../modules/cdn_broker"
 
-  account_id        = "${data.aws_caller_identity.current.account_id}"
-  aws_partition     = "${data.aws_partition.current.partition}"
-  username          = "${var.cdn_broker_username}"
-  bucket            = "${var.cdn_broker_bucket}"
-  cloudfront_prefix = "${var.cdn_broker_cloudfront_prefix}"
-  hosted_zone       = "${var.cdn_broker_hosted_zone}"
+  account_id        = data.aws_caller_identity.current.account_id
+  aws_partition     = data.aws_partition.current.partition
+  username          = var.cdn_broker_username
+  bucket            = var.cdn_broker_bucket
+  cloudfront_prefix = var.cdn_broker_cloudfront_prefix
+  hosted_zone       = var.cdn_broker_hosted_zone
 }
 
 module "limit_check_user" {
@@ -41,18 +46,19 @@ module "limit_check_user" {
 
 module "lets_encrypt_user" {
   source        = "../../modules/iam_user/lets_encrypt"
-  aws_partition = "${data.aws_partition.current.partition}"
-  hosted_zone   = "${var.lets_encrypt_hosted_zone}"
+  aws_partition = data.aws_partition.current.partition
+  hosted_zone   = var.lets_encrypt_hosted_zone
   username      = "lets-encrypt-${var.stack_description}"
 }
 
 module "domain_broker_v2_user" {
   source            = "../../modules/cdn_broker"
-  account_id        = "${data.aws_caller_identity.current.account_id}"
-  aws_partition     = "${data.aws_partition.current.partition}"
-  username          = "${var.domain_broker_v2_username}"
-  bucket            = "${var.domain_broker_v2_bucket}"
-  cloudfront_prefix = "${var.domain_broker_v2_cloudfront_prefix}"
-  hosted_zone       = "${var.cdn_broker_hosted_zone}"
+  account_id        = data.aws_caller_identity.current.account_id
+  aws_partition     = data.aws_partition.current.partition
+  username          = var.domain_broker_v2_username
+  bucket            = var.domain_broker_v2_bucket
+  cloudfront_prefix = var.domain_broker_v2_cloudfront_prefix
+  hosted_zone       = var.cdn_broker_hosted_zone
   username          = "domain-broker-v2"
 }
+

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -59,6 +59,5 @@ module "domain_broker_v2_user" {
   bucket            = var.domain_broker_v2_bucket
   cloudfront_prefix = var.domain_broker_v2_cloudfront_prefix
   hosted_zone       = var.cdn_broker_hosted_zone
-  username          = "domain-broker-v2"
 }
 

--- a/terraform/stacks/external/variables.tf
+++ b/terraform/stacks/external/variables.tf
@@ -1,18 +1,36 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
-variable "external_domain_broker_username" {}
-variable "external_domain_broker_cloudfront_prefix" {}
-variable "external_domain_broker_hosted_zone" {}
+variable "external_domain_broker_username" {
+}
 
-variable "cdn_broker_username" {}
-variable "cdn_broker_cloudfront_prefix" {}
-variable "cdn_broker_hosted_zone" {}
-variable "cdn_broker_bucket" {}
+variable "external_domain_broker_cloudfront_prefix" {
+}
 
-variable "lets_encrypt_hosted_zone" {}
+variable "external_domain_broker_hosted_zone" {
+}
 
-variable "domain_broker_v2_username" {}
+variable "cdn_broker_username" {
+}
 
-variable "domain_broker_v2_bucket" {}
+variable "cdn_broker_cloudfront_prefix" {
+}
 
-variable "domain_broker_v2_cloudfront_prefix" {}
+variable "cdn_broker_hosted_zone" {
+}
+
+variable "cdn_broker_bucket" {
+}
+
+variable "lets_encrypt_hosted_zone" {
+}
+
+variable "domain_broker_v2_username" {
+}
+
+variable "domain_broker_v2_bucket" {
+}
+
+variable "domain_broker_v2_cloudfront_prefix" {
+}
+

--- a/terraform/stacks/external/versions.tf
+++ b/terraform/stacks/external/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/stacks/main/buckets.tf
+++ b/terraform/stacks/main/buckets.tf
@@ -1,6 +1,7 @@
 module "bosh_blobstore_bucket" {
-  source = "../../modules/s3_bucket/encrypted_bucket"
-  bucket = "${var.blobstore_bucket_name}"
-  aws_partition = "${data.aws_partition.current.partition}"
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = var.blobstore_bucket_name
+  aws_partition = data.aws_partition.current.partition
   force_destroy = "true"
 }
+

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -97,7 +97,7 @@ resource "aws_lb" "domain_broker_v2" {
   ip_address_type = "dualstack"
   idle_timeout    = 3600
 
-  access_logs = {
+  access_logs {
     bucket = "${var.log_bucket_name}"
     prefix = "${var.stack_description}"
     enabled       = true

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -97,14 +97,6 @@ resource "aws_lb" "domain_broker_v2" {
 
   name    = "${var.stack_description}-domains-${count.index}"
   subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   security_groups = [module.stack.web_traffic_security_group]
   ip_address_type = "dualstack"
   idle_timeout    = 3600
@@ -225,14 +217,6 @@ resource "aws_db_instance" "domain_broker_v2" {
   password             = var.domain_broker_v2_rds_password
   engine               = "postgres"
   db_subnet_group_name = module.stack.rds_subnet_group
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   vpc_security_group_ids = [module.stack.rds_postgres_security_group]
 }
 

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -17,8 +17,11 @@
 // We attempted to delete these resources.  `terraform plan` looked good, but
 // `terraform apply` got real mad.  
 
-variable "domain_broker_v2_rds_username" {}
-variable "domain_broker_v2_rds_password" {}
+variable "domain_broker_v2_rds_username" {
+}
+
+variable "domain_broker_v2_rds_password" {
+}
 
 variable "domain_broker_v2_alb_count" {
   default = 0
@@ -32,13 +35,13 @@ resource "aws_iam_user" "domain_broker_v2" {
 
 // DO NOT DELETE (see above)
 resource "aws_iam_access_key" "domain_broker_v2_access_key" {
-  user = "${aws_iam_user.domain_broker_v2.name}"
+  user = aws_iam_user.domain_broker_v2.name
 }
 
 // DO NOT DELETE (see above)
 resource "aws_iam_user_policy" "domain_broker_v2_policy" {
   name = "domain_broker_v2_policy"
-  user = "${aws_iam_user.domain_broker_v2.name}"
+  user = aws_iam_user.domain_broker_v2.name
 
   policy = <<EOF
 {
@@ -85,64 +88,73 @@ resource "aws_iam_user_policy" "domain_broker_v2_policy" {
     ]
 }
 EOF
+
 }
 
 // DO NOT DELETE (see above)
 resource "aws_lb" "domain_broker_v2" {
-  count = "${var.domain_broker_v2_alb_count}"
+  count = var.domain_broker_v2_alb_count
 
-  name            = "${var.stack_description}-domains-${count.index}"
-  subnets         = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
-  security_groups = ["${module.stack.web_traffic_security_group}"]
+  name    = "${var.stack_description}-domains-${count.index}"
+  subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  security_groups = [module.stack.web_traffic_security_group]
   ip_address_type = "dualstack"
   idle_timeout    = 3600
 
   access_logs {
-    bucket = "${var.log_bucket_name}"
-    prefix = "${var.stack_description}"
-    enabled       = true
+    bucket  = var.log_bucket_name
+    prefix  = var.stack_description
+    enabled = true
   }
 }
 
 // DO NOT DELETE (see above)
 resource "aws_lb_listener" "domain_broker_v2_http" {
-  count = "${var.domain_broker_v2_alb_count}"
+  count = var.domain_broker_v2_alb_count
 
-  load_balancer_arn = "${aws_lb.domain_broker_v2.*.arn[count.index]}"
+  load_balancer_arn = aws_lb.domain_broker_v2[count.index].arn
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.domain_broker_v2_apps.*.arn[count.index]}"
+    target_group_arn = aws_lb_target_group.domain_broker_v2_apps[count.index].arn
     type             = "forward"
   }
 }
 
 // DO NOT DELETE (see above)
 resource "aws_lb_listener" "domain_broker_v2_https" {
-  count = "${var.domain_broker_v2_alb_count}"
+  count = var.domain_broker_v2_alb_count
 
-  load_balancer_arn = "${aws_lb.domain_broker_v2.*.arn[count.index]}"
+  load_balancer_arn = aws_lb.domain_broker_v2[count.index].arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = "${data.aws_iam_server_certificate.wildcard.arn}"
+  certificate_arn   = data.aws_iam_server_certificate.wildcard.arn
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.domain_broker_v2_apps.*.arn[count.index]}"
+    target_group_arn = aws_lb_target_group.domain_broker_v2_apps[count.index].arn
     type             = "forward"
   }
 }
 
 // DO NOT DELETE (see above)
 resource "aws_lb_listener_rule" "domain_broker_v2static_http" {
-  count = "${var.domain_broker_v2_alb_count}"
+  count = var.domain_broker_v2_alb_count
 
-  listener_arn = "${aws_lb_listener.domain_broker_v2_http.*.arn[count.index]}"
+  listener_arn = aws_lb_listener.domain_broker_v2_http[count.index].arn
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.domain_broker_v2_challenge.*.arn[count.index]}"
+    target_group_arn = aws_lb_target_group.domain_broker_v2_challenge[count.index].arn
   }
 
   condition {
@@ -154,13 +166,13 @@ resource "aws_lb_listener_rule" "domain_broker_v2static_http" {
 
 // DO NOT DELETE (see above)
 resource "aws_lb_listener_rule" "domain_broker_v2_static_https" {
-  count = "${var.domain_broker_v2_alb_count}"
+  count = var.domain_broker_v2_alb_count
 
-  listener_arn = "${aws_lb_listener.domain_broker_v2_https.*.arn[count.index]}"
+  listener_arn = aws_lb_listener.domain_broker_v2_https[count.index].arn
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.domain_broker_v2_challenge.*.arn[count.index]}"
+    target_group_arn = aws_lb_target_group.domain_broker_v2_challenge[count.index].arn
   }
 
   condition {
@@ -172,12 +184,12 @@ resource "aws_lb_listener_rule" "domain_broker_v2_static_https" {
 
 // DO NOT DELETE (see above)
 resource "aws_lb_target_group" "domain_broker_v2_apps" {
-  count = "${var.domain_broker_v2_alb_count}"
+  count = var.domain_broker_v2_alb_count
 
   name     = "${var.stack_description}-domains-apps-${count.index}"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${module.stack.vpc_id}"
+  vpc_id   = module.stack.vpc_id
 
   health_check {
     healthy_threshold   = 2
@@ -191,12 +203,12 @@ resource "aws_lb_target_group" "domain_broker_v2_apps" {
 
 // DO NOT DELETE (see above)
 resource "aws_lb_target_group" "domain_broker_v2_challenge" {
-  count = "${var.domain_broker_v2_alb_count}"
+  count = var.domain_broker_v2_alb_count
 
   name     = "${var.stack_description}-domains-acme-${count.index}"
   port     = 8081
   protocol = "HTTP"
-  vpc_id   = "${module.stack.vpc_id}"
+  vpc_id   = module.stack.vpc_id
 
   health_check {
     path = "/health"
@@ -205,56 +217,63 @@ resource "aws_lb_target_group" "domain_broker_v2_challenge" {
 
 // DO NOT DELETE (see above)
 resource "aws_db_instance" "domain_broker_v2" {
-  name                   = "domain_broker_v2"
-  storage_type           = "gp2"
-  allocated_storage      = 10
-  instance_class         = "db.t2.micro"
-  username               = "${var.domain_broker_v2_rds_username}"
-  password               = "${var.domain_broker_v2_rds_password}"
-  engine                 = "postgres"
-  db_subnet_group_name   = "${module.stack.rds_subnet_group}"
-  vpc_security_group_ids = ["${module.stack.rds_postgres_security_group}"]
+  name                 = "domain_broker_v2"
+  storage_type         = "gp2"
+  allocated_storage    = 10
+  instance_class       = "db.t2.micro"
+  username             = var.domain_broker_v2_rds_username
+  password             = var.domain_broker_v2_rds_password
+  engine               = "postgres"
+  db_subnet_group_name = module.stack.rds_subnet_group
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  vpc_security_group_ids = [module.stack.rds_postgres_security_group]
 }
 
 output "domain_broker_v2_rds_username" {
-  value = "${aws_db_instance.domain_broker_v2.username}"
+  value = aws_db_instance.domain_broker_v2.username
 }
 
 output "domain_broker_v2_rds_password" {
-  value = "${aws_db_instance.domain_broker_v2.password}"
+  value = aws_db_instance.domain_broker_v2.password
 }
 
 output "domain_broker_v2_rds_address" {
-  value = "${aws_db_instance.domain_broker_v2.address}"
+  value = aws_db_instance.domain_broker_v2.address
 }
 
 output "domain_broker_v2_rds_port" {
-  value = "${aws_db_instance.domain_broker_v2.port}"
+  value = aws_db_instance.domain_broker_v2.port
 }
 
 output "domain_broker_v2_alb_names" {
-  value = "${aws_lb.domain_broker_v2.*.name}"
+  value = aws_lb.domain_broker_v2.*.name
 }
 
 output "domain_broker_v2_target_group_apps_names" {
-  value = "${aws_lb_target_group.domain_broker_v2_apps.*.name}"
+  value = aws_lb_target_group.domain_broker_v2_apps.*.name
 }
 
 output "domain_broker_v2_target_group_challenge_names" {
-  value = "${aws_lb_target_group.domain_broker_v2_challenge.*.name}"
+  value = aws_lb_target_group.domain_broker_v2_challenge.*.name
 }
 
 output "domain_broker_v2_listener_arns" {
-  value = "${aws_lb_listener.domain_broker_v2_http.*.arn}"
+  value = aws_lb_listener.domain_broker_v2_http.*.arn
 }
 
 output "domain_broker_v2_access_key_id" {
-  value = "${aws_iam_access_key.domain_broker_v2_access_key.id}"
+  value = aws_iam_access_key.domain_broker_v2_access_key.id
 }
 
 output "domain_broker_v2_secret_access_key" {
-  value = "${aws_iam_access_key.domain_broker_v2_access_key.secret}"
+  value = aws_iam_access_key.domain_broker_v2_access_key.secret
 }
 
 /* end new broker alb config */
-

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -1,36 +1,52 @@
 variable "domains_broker_alb_count" {
   default = 0
 }
-variable "domains_broker_rds_username" {}
-variable "domains_broker_rds_password" {}
-variable "challenge_bucket" {}
+
+variable "domains_broker_rds_username" {
+}
+
+variable "domains_broker_rds_password" {
+}
+
+variable "challenge_bucket" {
+}
+
 variable "iam_cert_prefix" {
   default = "/domains/*"
 }
+
 variable "alb_prefix" {
   default = "domains-*"
 }
 
 /* Broker internal load balancer */
 resource "aws_lb" "domains_broker_internal" {
-  name            = "${var.stack_description}-domains-internal"
-  subnets         = ["${module.cf.services_subnet_az1}", "${module.cf.services_subnet_az2}"]
-  security_groups = ["${module.stack.bosh_security_group}"]
+  name    = "${var.stack_description}-domains-internal"
+  subnets = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  security_groups = [module.stack.bosh_security_group]
   internal        = true
   access_logs {
-    bucket = "${var.log_bucket_name}"
-    prefix = "${var.stack_description}"
+    bucket  = var.log_bucket_name
+    prefix  = var.stack_description
     enabled = true
   }
 }
 
 resource "aws_lb_listener" "domains_broker_internal" {
-  load_balancer_arn = "${aws_lb.domains_broker_internal.arn}"
+  load_balancer_arn = aws_lb.domains_broker_internal.arn
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.domains_broker_internal.arn}"
+    target_group_arn = aws_lb_target_group.domains_broker_internal.arn
     type             = "forward"
   }
 }
@@ -39,7 +55,7 @@ resource "aws_lb_target_group" "domains_broker_internal" {
   name     = "${var.stack_description}-domains-internal"
   port     = 3000
   protocol = "HTTP"
-  vpc_id   = "${module.stack.vpc_id}"
+  vpc_id   = module.stack.vpc_id
 
   health_check {
     path = "/healthcheck"
@@ -47,90 +63,110 @@ resource "aws_lb_target_group" "domains_broker_internal" {
 }
 
 output "domains_broker_internal_dns_name" {
-  value = "${aws_lb.domains_broker_internal.dns_name}"
+  value = aws_lb.domains_broker_internal.dns_name
 }
+
 output "domains_broker_internal_target_group" {
-  value = "${aws_lb_target_group.domains_broker_internal.name}"
+  value = aws_lb_target_group.domains_broker_internal.name
 }
 
 /* Broker database */
 resource "aws_db_instance" "domains_broker" {
-  name                   = "domains_broker"
-  storage_type           = "gp2"
-  allocated_storage      = 10
-  instance_class         = "db.t2.micro"
-  username               = "${var.domains_broker_rds_username}"
-  password               = "${var.domains_broker_rds_password}"
-  engine                 = "postgres"
-  db_subnet_group_name   = "${module.stack.rds_subnet_group}"
-  vpc_security_group_ids = ["${module.stack.rds_postgres_security_group}"]
+  name                 = "domains_broker"
+  storage_type         = "gp2"
+  allocated_storage    = 10
+  instance_class       = "db.t2.micro"
+  username             = var.domains_broker_rds_username
+  password             = var.domains_broker_rds_password
+  engine               = "postgres"
+  db_subnet_group_name = module.stack.rds_subnet_group
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  vpc_security_group_ids = [module.stack.rds_postgres_security_group]
 }
 
 output "domains_broker_rds_username" {
-  value = "${aws_db_instance.domains_broker.username}"
+  value = aws_db_instance.domains_broker.username
 }
+
 output "domains_broker_rds_password" {
-  value = "${aws_db_instance.domains_broker.password}"
+  value = aws_db_instance.domains_broker.password
 }
+
 output "domains_broker_rds_address" {
-  value = "${aws_db_instance.domains_broker.address}"
+  value = aws_db_instance.domains_broker.address
 }
+
 output "domains_broker_rds_port" {
-  value = "${aws_db_instance.domains_broker.port}"
+  value = aws_db_instance.domains_broker.port
 }
 
 /* old domains broker alb */
 resource "aws_lb" "domains_broker" {
-  count = "${var.domains_broker_alb_count}"
+  count = var.domains_broker_alb_count
 
-  name            = "${var.stack_description}-domains-${count.index}"
-  subnets         = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
-  security_groups = ["${module.stack.web_traffic_security_group}"]
+  name    = "${var.stack_description}-domains-${count.index}"
+  subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  security_groups = [module.stack.web_traffic_security_group]
   ip_address_type = "dualstack"
   idle_timeout    = 3600
   access_logs {
-    bucket = "${var.log_bucket_name}"
-    prefix = "${var.stack_description}"
+    bucket  = var.log_bucket_name
+    prefix  = var.stack_description
     enabled = true
   }
 }
 
 resource "aws_lb_listener" "domains_broker_http" {
-  count = "${var.domains_broker_alb_count}"
+  count = var.domains_broker_alb_count
 
-  load_balancer_arn = "${aws_lb.domains_broker.*.arn[count.index]}"
+  load_balancer_arn = aws_lb.domains_broker[count.index].arn
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.domains_broker_apps.*.arn[count.index]}"
+    target_group_arn = aws_lb_target_group.domains_broker_apps[count.index].arn
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener" "domains_broker_https" {
-  count = "${var.domains_broker_alb_count}"
+  count = var.domains_broker_alb_count
 
-  load_balancer_arn = "${aws_lb.domains_broker.*.arn[count.index]}"
+  load_balancer_arn = aws_lb.domains_broker[count.index].arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = "${data.aws_iam_server_certificate.wildcard.arn}"
+  certificate_arn   = data.aws_iam_server_certificate.wildcard.arn
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.domains_broker_apps.*.arn[count.index]}"
+    target_group_arn = aws_lb_target_group.domains_broker_apps[count.index].arn
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener_rule" "static_http" {
-  count = "${var.domains_broker_alb_count}"
+  count = var.domains_broker_alb_count
 
-  listener_arn = "${aws_lb_listener.domains_broker_http.*.arn[count.index]}"
+  listener_arn = aws_lb_listener.domains_broker_http[count.index].arn
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.domains_broker_challenge.*.arn[count.index]}"
+    target_group_arn = aws_lb_target_group.domains_broker_challenge[count.index].arn
   }
 
   condition {
@@ -141,13 +177,13 @@ resource "aws_lb_listener_rule" "static_http" {
 }
 
 resource "aws_lb_listener_rule" "static_https" {
-  count = "${var.domains_broker_alb_count}"
+  count = var.domains_broker_alb_count
 
-  listener_arn = "${aws_lb_listener.domains_broker_https.*.arn[count.index]}"
+  listener_arn = aws_lb_listener.domains_broker_https[count.index].arn
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.domains_broker_challenge.*.arn[count.index]}"
+    target_group_arn = aws_lb_target_group.domains_broker_challenge[count.index].arn
   }
 
   condition {
@@ -158,12 +194,12 @@ resource "aws_lb_listener_rule" "static_https" {
 }
 
 resource "aws_lb_target_group" "domains_broker_apps" {
-  count = "${var.domains_broker_alb_count}"
+  count = var.domains_broker_alb_count
 
   name     = "${var.stack_description}-domains-apps-${count.index}"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${module.stack.vpc_id}"
+  vpc_id   = module.stack.vpc_id
 
   health_check {
     healthy_threshold   = 2
@@ -176,12 +212,12 @@ resource "aws_lb_target_group" "domains_broker_apps" {
 }
 
 resource "aws_lb_target_group" "domains_broker_challenge" {
-  count = "${var.domains_broker_alb_count}"
+  count = var.domains_broker_alb_count
 
   name     = "${var.stack_description}-domains-acme-${count.index}"
   port     = 8081
   protocol = "HTTP"
-  vpc_id   = "${module.stack.vpc_id}"
+  vpc_id   = module.stack.vpc_id
 
   health_check {
     path = "/health"
@@ -189,16 +225,19 @@ resource "aws_lb_target_group" "domains_broker_challenge" {
 }
 
 output "domains_broker_alb_names" {
-  value = "${aws_lb.domains_broker.*.name}"
+  value = aws_lb.domains_broker.*.name
 }
+
 output "domains_broker_target_group_apps_names" {
-  value = "${aws_lb_target_group.domains_broker_apps.*.name}"
+  value = aws_lb_target_group.domains_broker_apps.*.name
 }
+
 output "domains_broker_target_group_challenge_names" {
-  value = "${aws_lb_target_group.domains_broker_challenge.*.name}"
+  value = aws_lb_target_group.domains_broker_challenge.*.name
 }
+
 output "domains_broker_listener_arns" {
-  value = "${aws_lb_listener.domains_broker_http.*.arn}"
+  value = aws_lb_listener.domains_broker_http.*.arn
 }
 
 /* n.b. this bucket is used for:
@@ -207,7 +246,7 @@ output "domains_broker_listener_arns" {
    - new domains + cdn broker
  */
 resource "aws_s3_bucket" "domains_bucket" {
-  bucket = "${var.challenge_bucket}"
+  bucket = var.challenge_bucket
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -224,18 +263,21 @@ resource "aws_s3_bucket" "domains_bucket" {
   ]
 }
 EOF
+
 }
+
 output "challenge_bucket" {
-  value = "${aws_s3_bucket.domains_bucket.id}"
+  value = aws_s3_bucket.domains_bucket.id
 }
+
 output "challenge_bucket_domain_name" {
-  value = "${aws_s3_bucket.domains_bucket.bucket_domain_name}"
+  value = aws_s3_bucket.domains_bucket.bucket_domain_name
 }
 
 /* IAM resources */
 resource "aws_iam_instance_profile" "domains_broker" {
   name = "${var.stack_description}-domain-broker"
-  role = "${aws_iam_role.domains_broker.name}"
+  role = aws_iam_role.domains_broker.name
 }
 
 resource "aws_iam_role" "domains_broker" {
@@ -255,6 +297,7 @@ resource "aws_iam_role" "domains_broker" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_policy" "domains_broker" {
@@ -295,16 +338,18 @@ resource "aws_iam_policy" "domains_broker" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_policy_attachment" "domains_broker" {
   name       = "${var.stack_description}-domains-broker"
-  policy_arn = "${aws_iam_policy.domains_broker.arn}"
+  policy_arn = aws_iam_policy.domains_broker.arn
   roles = [
-    "${aws_iam_role.domains_broker.name}"
+    aws_iam_role.domains_broker.name,
   ]
 }
 
 output "domains_broker_profile" {
-  value = "${aws_iam_instance_profile.domains_broker.name}"
+  value = aws_iam_instance_profile.domains_broker.name
 }
+

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -17,7 +17,7 @@ resource "aws_lb" "domains_broker_internal" {
   subnets         = ["${module.cf.services_subnet_az1}", "${module.cf.services_subnet_az2}"]
   security_groups = ["${module.stack.bosh_security_group}"]
   internal        = true
-  access_logs = {
+  access_logs {
     bucket = "${var.log_bucket_name}"
     prefix = "${var.stack_description}"
     enabled = true
@@ -88,7 +88,7 @@ resource "aws_lb" "domains_broker" {
   security_groups = ["${module.stack.web_traffic_security_group}"]
   ip_address_type = "dualstack"
   idle_timeout    = 3600
-  access_logs = {
+  access_logs {
     bucket = "${var.log_bucket_name}"
     prefix = "${var.stack_description}"
     enabled = true

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -23,14 +23,6 @@ variable "alb_prefix" {
 resource "aws_lb" "domains_broker_internal" {
   name    = "${var.stack_description}-domains-internal"
   subnets = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   security_groups = [module.stack.bosh_security_group]
   internal        = true
   access_logs {
@@ -80,14 +72,6 @@ resource "aws_db_instance" "domains_broker" {
   password             = var.domains_broker_rds_password
   engine               = "postgres"
   db_subnet_group_name = module.stack.rds_subnet_group
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   vpc_security_group_ids = [module.stack.rds_postgres_security_group]
 }
 
@@ -113,14 +97,6 @@ resource "aws_lb" "domains_broker" {
 
   name    = "${var.stack_description}-domains-${count.index}"
   subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   security_groups = [module.stack.web_traffic_security_group]
   ip_address_type = "dualstack"
   idle_timeout    = 3600

--- a/terraform/stacks/main/iam.tf
+++ b/terraform/stacks/main/iam.tf
@@ -198,14 +198,6 @@ resource "aws_iam_policy_attachment" "bosh_compilation" {
 resource "aws_iam_policy_attachment" "blobstore_upstream" {
   name       = "${var.stack_description}-blobstore-upstream"
   policy_arn = module.blobstore_upstream_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.bosh_role.role_name,
   ]
@@ -214,14 +206,6 @@ resource "aws_iam_policy_attachment" "blobstore_upstream" {
 resource "aws_iam_policy_attachment" "logsearch_ingestor" {
   name       = "logsearch_ingestor"
   policy_arn = module.logsearch_ingestor_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.logsearch_ingestor_role.role_name,
   ]
@@ -230,14 +214,6 @@ resource "aws_iam_policy_attachment" "logsearch_ingestor" {
 resource "aws_iam_policy_attachment" "kubernetes_master" {
   name       = "${var.stack_description}-kubernetes-master"
   policy_arn = module.kubernetes_master_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.kubernetes_master_role.role_name,
   ]
@@ -246,14 +222,6 @@ resource "aws_iam_policy_attachment" "kubernetes_master" {
 resource "aws_iam_policy_attachment" "kubernetes_minion" {
   name       = "${var.stack_description}-kubernetes-minion"
   policy_arn = module.kubernetes_minion_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.kubernetes_minion_role.role_name,
   ]
@@ -262,14 +230,6 @@ resource "aws_iam_policy_attachment" "kubernetes_minion" {
 resource "aws_iam_policy_attachment" "ectd_backup" {
   name       = "${var.stack_description}-etcd-backup"
   policy_arn = module.etcd_backup_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.etcd_backup_role.role_name,
   ]
@@ -278,14 +238,6 @@ resource "aws_iam_policy_attachment" "ectd_backup" {
 resource "aws_iam_policy_attachment" "cf_blobstore" {
   name       = "${var.stack_description}-cf_blobstore"
   policy_arn = module.cf_blobstore_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.cf_blobstore_role.role_name,
   ]
@@ -294,14 +246,6 @@ resource "aws_iam_policy_attachment" "cf_blobstore" {
 resource "aws_iam_policy_attachment" "s3_broker" {
   name       = "${var.stack_description}-s3-broker"
   policy_arn = module.s3_broker_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.platform_role.role_name,
   ]
@@ -310,14 +254,6 @@ resource "aws_iam_policy_attachment" "s3_broker" {
 resource "aws_iam_policy_attachment" "aws_broker" {
   name       = "${var.stack_description}-aws-broker"
   policy_arn = module.aws_broker_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.platform_role.role_name,
   ]
@@ -326,14 +262,6 @@ resource "aws_iam_policy_attachment" "aws_broker" {
 resource "aws_iam_policy_attachment" "elasticache_broker" {
   name       = "${var.stack_description}-elasticache-broker"
   policy_arn = module.elasticache_broker_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.elasticache_broker_role.role_name,
   ]

--- a/terraform/stacks/main/iam.tf
+++ b/terraform/stacks/main/iam.tf
@@ -182,14 +182,6 @@ resource "aws_iam_policy_attachment" "cloudwatch" {
 resource "aws_iam_policy_attachment" "bosh" {
   name       = "${var.stack_description}-bosh"
   policy_arn = module.bosh_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.bosh_role.role_name,
   ]
@@ -198,14 +190,6 @@ resource "aws_iam_policy_attachment" "bosh" {
 resource "aws_iam_policy_attachment" "bosh_compilation" {
   name       = "${var.stack_description}-bosh-compilation"
   policy_arn = module.bosh_compilation_policy.arn
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.bosh_compilation_role.role_name,
   ]

--- a/terraform/stacks/main/iam.tf
+++ b/terraform/stacks/main/iam.tf
@@ -1,289 +1,378 @@
 module "blobstore_policy" {
-  source = "../../modules/iam_role_policy/blobstore"
-  policy_name = "${var.stack_description}-blobstore"
-  aws_partition = "${data.aws_partition.current.partition}"
-  bucket_name = "${var.blobstore_bucket_name}"
+  source        = "../../modules/iam_role_policy/blobstore"
+  policy_name   = "${var.stack_description}-blobstore"
+  aws_partition = data.aws_partition.current.partition
+  bucket_name   = var.blobstore_bucket_name
 }
 
 // Allow development / staging / production bosh to read tooling bosh blobs
 module "blobstore_upstream_policy" {
-  source = "../../modules/iam_role_policy/blobstore"
-  policy_name = "${var.stack_description}-blobstore-upstream"
-  aws_partition = "${data.aws_partition.current.partition}"
-  bucket_name = "${var.upstream_blobstore_bucket_name}"
+  source        = "../../modules/iam_role_policy/blobstore"
+  policy_name   = "${var.stack_description}-blobstore-upstream"
+  aws_partition = data.aws_partition.current.partition
+  bucket_name   = var.upstream_blobstore_bucket_name
 }
 
 module "cloudwatch_policy" {
-  source = "../../modules/iam_role_policy/cloudwatch"
+  source      = "../../modules/iam_role_policy/cloudwatch"
   policy_name = "${var.stack_description}-cloudwatch-logs"
 }
 
 module "bosh_policy" {
-  source = "../../modules/iam_role_policy/bosh"
-  policy_name = "${var.stack_description}-bosh"
-  aws_partition = "${data.aws_partition.current.partition}"
-  account_id = "${data.aws_caller_identity.current.account_id}"
-  bucket_name = "${var.blobstore_bucket_name}"
+  source        = "../../modules/iam_role_policy/bosh"
+  policy_name   = "${var.stack_description}-bosh"
+  aws_partition = data.aws_partition.current.partition
+  account_id    = data.aws_caller_identity.current.account_id
+  bucket_name   = var.blobstore_bucket_name
 }
 
 module "bosh_compilation_policy" {
-  source = "../../modules/iam_role_policy/bosh_compilation"
-  policy_name = "${var.stack_description}-bosh-compilation"
-  aws_partition = "${data.aws_partition.current.partition}"
-  bucket_name = "${var.blobstore_bucket_name}"
+  source        = "../../modules/iam_role_policy/bosh_compilation"
+  policy_name   = "${var.stack_description}-bosh-compilation"
+  aws_partition = data.aws_partition.current.partition
+  bucket_name   = var.blobstore_bucket_name
 }
 
 module "logsearch_ingestor_policy" {
-  source = "../../modules/iam_role_policy/logsearch_ingestor"
-  policy_name = "${var.stack_description}-logsearch_ingestor"
-  aws_partition = "${data.aws_partition.current.partition}"
-  aws_default_region = "${var.aws_default_region}"
-  account_id = "${data.aws_caller_identity.current.account_id}"
+  source             = "../../modules/iam_role_policy/logsearch_ingestor"
+  policy_name        = "${var.stack_description}-logsearch_ingestor"
+  aws_partition      = data.aws_partition.current.partition
+  aws_default_region = var.aws_default_region
+  account_id         = data.aws_caller_identity.current.account_id
 }
 
 module "kubernetes_master_policy" {
-  source = "../../modules/iam_role_policy/kubernetes_master"
-  policy_name = "${var.stack_description}-kubernetes-master"
-  aws_partition = "${data.aws_partition.current.partition}"
+  source        = "../../modules/iam_role_policy/kubernetes_master"
+  policy_name   = "${var.stack_description}-kubernetes-master"
+  aws_partition = data.aws_partition.current.partition
 }
 
 module "kubernetes_minion_policy" {
-  source = "../../modules/iam_role_policy/kubernetes_minion"
-  policy_name = "${var.stack_description}-kubernetes-minion"
-  aws_partition = "${data.aws_partition.current.partition}"
+  source        = "../../modules/iam_role_policy/kubernetes_minion"
+  policy_name   = "${var.stack_description}-kubernetes-minion"
+  aws_partition = data.aws_partition.current.partition
 }
 
 module "etcd_backup_policy" {
-  source = "../../modules/iam_role_policy/etcd_backup"
-  policy_name = "${var.stack_description}-etcd-backup"
-  aws_partition = "${data.aws_partition.current.partition}"
-  bucket_name = "etcd-*"
+  source        = "../../modules/iam_role_policy/etcd_backup"
+  policy_name   = "${var.stack_description}-etcd-backup"
+  aws_partition = data.aws_partition.current.partition
+  bucket_name   = "etcd-*"
 }
 
 module "cf_blobstore_policy" {
-  source = "../../modules/iam_role_policy/cf_blobstore"
-  policy_name = "${var.stack_description}-cf-blobstore"
-  aws_partition = "${data.aws_partition.current.partition}"
-  buildpacks_bucket = "${module.cf.buildpacks_bucket_name}"
-  packages_bucket = "${module.cf.packages_bucket_name}"
-  resources_bucket = "${module.cf.resources_bucket_name}"
-  droplets_bucket = "${module.cf.droplets_bucket_name}"
+  source            = "../../modules/iam_role_policy/cf_blobstore"
+  policy_name       = "${var.stack_description}-cf-blobstore"
+  aws_partition     = data.aws_partition.current.partition
+  buildpacks_bucket = module.cf.buildpacks_bucket_name
+  packages_bucket   = module.cf.packages_bucket_name
+  resources_bucket  = module.cf.resources_bucket_name
+  droplets_bucket   = module.cf.droplets_bucket_name
 }
 
 module "s3_broker_policy" {
-  source = "../../modules/iam_role_policy/s3_broker"
-  policy_name = "${var.stack_description}-s3-broker"
-  account_id = "${data.aws_caller_identity.current.account_id}"
-  aws_partition = "${data.aws_partition.current.partition}"
-  bucket_prefix = "${var.bucket_prefix}"
-  iam_path = "/${var.stack_prefix}/s3/"
+  source        = "../../modules/iam_role_policy/s3_broker"
+  policy_name   = "${var.stack_description}-s3-broker"
+  account_id    = data.aws_caller_identity.current.account_id
+  aws_partition = data.aws_partition.current.partition
+  bucket_prefix = var.bucket_prefix
+  iam_path      = "/${var.stack_prefix}/s3/"
 }
 
 module "aws_broker_policy" {
-  source = "../../modules/iam_role_policy/aws_broker"
-  policy_name = "${var.stack_description}-aws-broker"
-  account_id = "${data.aws_caller_identity.current.account_id}"
-  aws_partition = "${data.aws_partition.current.partition}"
-  aws_default_region = "${var.aws_default_region}"
-  remote_state_bucket = "${var.remote_state_bucket}"
-  rds_subgroup = "${var.stack_description}"
+  source              = "../../modules/iam_role_policy/aws_broker"
+  policy_name         = "${var.stack_description}-aws-broker"
+  account_id          = data.aws_caller_identity.current.account_id
+  aws_partition       = data.aws_partition.current.partition
+  aws_default_region  = var.aws_default_region
+  remote_state_bucket = var.remote_state_bucket
+  rds_subgroup        = var.stack_description
 }
 
 module "elasticache_broker_policy" {
-  source = "../../modules/iam_role_policy/elasticache_broker"
+  source      = "../../modules/iam_role_policy/elasticache_broker"
   policy_name = "${var.stack_description}-elasticache-broker"
 }
 
 module "default_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-default"
 }
 
 module "bosh_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-bosh"
 }
 
 module "bosh_compilation_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-bosh-compilation"
 }
 
 module "logsearch_ingestor_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-logsearch-ingestor"
 }
 
 module "kubernetes_master_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-kubernetes-master"
 }
 
 module "kubernetes_minion_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-kubernetes-minion"
 }
 
 module "etcd_backup_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-etcd-backup"
 }
 
 module "cf_blobstore_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-cf-blobstore"
 }
 
 module "platform_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-platform"
 }
 
 module "elasticache_broker_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-elasticache-broker"
 }
 
 resource "aws_iam_policy_attachment" "blobstore" {
-  name = "${var.stack_description}-blobstore"
-  policy_arn = "${module.blobstore_policy.arn}"
+  name       = "${var.stack_description}-blobstore"
+  policy_arn = module.blobstore_policy.arn
   roles = [
-    "${module.default_role.role_name}",
-    "${module.bosh_role.role_name}",
-    "${module.logsearch_ingestor_role.role_name}",
-    "${module.kubernetes_master_role.role_name}",
-    "${module.kubernetes_minion_role.role_name}",
-    "${module.etcd_backup_role.role_name}",
-    "${module.cf_blobstore_role.role_name}",
-    "${module.elasticache_broker_role.role_name}",
-    "${module.platform_role.role_name}",
-    "${aws_iam_role.domains_broker.name}"
+    module.default_role.role_name,
+    module.bosh_role.role_name,
+    module.logsearch_ingestor_role.role_name,
+    module.kubernetes_master_role.role_name,
+    module.kubernetes_minion_role.role_name,
+    module.etcd_backup_role.role_name,
+    module.cf_blobstore_role.role_name,
+    module.elasticache_broker_role.role_name,
+    module.platform_role.role_name,
+    aws_iam_role.domains_broker.name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "cloudwatch" {
-  name = "${var.stack_description}-cloudwatch"
-  policy_arn = "${module.cloudwatch_policy.arn}"
+  name       = "${var.stack_description}-cloudwatch"
+  policy_arn = module.cloudwatch_policy.arn
   roles = [
-    "${module.default_role.role_name}",
-    "${module.bosh_role.role_name}",
-    "${module.bosh_compilation_role.role_name}",
-    "${module.logsearch_ingestor_role.role_name}",
-    "${module.kubernetes_master_role.role_name}",
-    "${module.kubernetes_minion_role.role_name}",
-    "${module.etcd_backup_role.role_name}",
-    "${module.cf_blobstore_role.role_name}",
-    "${module.elasticache_broker_role.role_name}",
-    "${module.platform_role.role_name}",
-    "${aws_iam_role.domains_broker.name}"
+    module.default_role.role_name,
+    module.bosh_role.role_name,
+    module.bosh_compilation_role.role_name,
+    module.logsearch_ingestor_role.role_name,
+    module.kubernetes_master_role.role_name,
+    module.kubernetes_minion_role.role_name,
+    module.etcd_backup_role.role_name,
+    module.cf_blobstore_role.role_name,
+    module.elasticache_broker_role.role_name,
+    module.platform_role.role_name,
+    aws_iam_role.domains_broker.name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "bosh" {
-  name = "${var.stack_description}-bosh"
-  policy_arn = "${module.bosh_policy.arn}"
+  name       = "${var.stack_description}-bosh"
+  policy_arn = module.bosh_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.bosh_role.role_name}"
+    module.bosh_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "bosh_compilation" {
-  name = "${var.stack_description}-bosh-compilation"
-  policy_arn = "${module.bosh_compilation_policy.arn}"
+  name       = "${var.stack_description}-bosh-compilation"
+  policy_arn = module.bosh_compilation_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.bosh_compilation_role.role_name}"
+    module.bosh_compilation_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "blobstore_upstream" {
-  name = "${var.stack_description}-blobstore-upstream"
-  policy_arn = "${module.blobstore_upstream_policy.arn}"
+  name       = "${var.stack_description}-blobstore-upstream"
+  policy_arn = module.blobstore_upstream_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.bosh_role.role_name}"
+    module.bosh_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "logsearch_ingestor" {
-  name = "logsearch_ingestor"
-  policy_arn = "${module.logsearch_ingestor_policy.arn}"
+  name       = "logsearch_ingestor"
+  policy_arn = module.logsearch_ingestor_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.logsearch_ingestor_role.role_name}"
+    module.logsearch_ingestor_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "kubernetes_master" {
-  name = "${var.stack_description}-kubernetes-master"
-  policy_arn = "${module.kubernetes_master_policy.arn}"
+  name       = "${var.stack_description}-kubernetes-master"
+  policy_arn = module.kubernetes_master_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.kubernetes_master_role.role_name}"
+    module.kubernetes_master_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "kubernetes_minion" {
-  name = "${var.stack_description}-kubernetes-minion"
-  policy_arn = "${module.kubernetes_minion_policy.arn}"
+  name       = "${var.stack_description}-kubernetes-minion"
+  policy_arn = module.kubernetes_minion_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.kubernetes_minion_role.role_name}"
+    module.kubernetes_minion_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "ectd_backup" {
-  name = "${var.stack_description}-etcd-backup"
-  policy_arn = "${module.etcd_backup_policy.arn}"
+  name       = "${var.stack_description}-etcd-backup"
+  policy_arn = module.etcd_backup_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.etcd_backup_role.role_name}"
+    module.etcd_backup_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "cf_blobstore" {
-  name = "${var.stack_description}-cf_blobstore"
-  policy_arn = "${module.cf_blobstore_policy.arn}"
+  name       = "${var.stack_description}-cf_blobstore"
+  policy_arn = module.cf_blobstore_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.cf_blobstore_role.role_name}"
+    module.cf_blobstore_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "s3_broker" {
-  name = "${var.stack_description}-s3-broker"
-  policy_arn = "${module.s3_broker_policy.arn}"
+  name       = "${var.stack_description}-s3-broker"
+  policy_arn = module.s3_broker_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.platform_role.role_name}"
+    module.platform_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "aws_broker" {
-  name = "${var.stack_description}-aws-broker"
-  policy_arn = "${module.aws_broker_policy.arn}"
+  name       = "${var.stack_description}-aws-broker"
+  policy_arn = module.aws_broker_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.platform_role.role_name}"
+    module.platform_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "elasticache_broker" {
-  name = "${var.stack_description}-elasticache-broker"
-  policy_arn = "${module.elasticache_broker_policy.arn}"
+  name       = "${var.stack_description}-elasticache-broker"
+  policy_arn = module.elasticache_broker_policy.arn
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.elasticache_broker_role.role_name}"
+    module.elasticache_broker_role.role_name,
   ]
 }
 
 module "kubernetes_node_role" {
-  source = "../../modules/iam_role/kubernetes_node"
-  role_name = "${var.stack_description}-kubernetes-node"
-  aws_partition = "${data.aws_partition.current.partition}"
-  account_id = "${data.aws_caller_identity.current.account_id}"
-  master_role = "${module.kubernetes_master_role.role_name}"
-  minion_role = "${module.kubernetes_minion_role.role_name}"
+  source           = "../../modules/iam_role/kubernetes_node"
+  role_name        = "${var.stack_description}-kubernetes-node"
+  aws_partition    = data.aws_partition.current.partition
+  account_id       = data.aws_caller_identity.current.account_id
+  master_role      = module.kubernetes_master_role.role_name
+  minion_role      = module.kubernetes_minion_role.role_name
   assume_role_path = "/bosh-passed/"
 }
 
 module "kubernetes_logger_role" {
-  source = "../../modules/iam_role/kubernetes_logger"
-  role_name = "${var.stack_description}-kubernetes-logger"
-  aws_default_region = "${var.aws_default_region}"
-  aws_partition = "${data.aws_partition.current.partition}"
-  account_id = "${data.aws_caller_identity.current.account_id}"
-  master_role = "${module.kubernetes_master_role.role_name}"
-  minion_role = "${module.kubernetes_minion_role.role_name}"
-  assume_role_path = "/bosh-passed/"
+  source             = "../../modules/iam_role/kubernetes_logger"
+  role_name          = "${var.stack_description}-kubernetes-logger"
+  aws_default_region = var.aws_default_region
+  aws_partition      = data.aws_partition.current.partition
+  account_id         = data.aws_caller_identity.current.account_id
+  master_role        = module.kubernetes_master_role.role_name
+  minion_role        = module.kubernetes_minion_role.role_name
+  assume_role_path   = "/bosh-passed/"
 }
+

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -1,118 +1,149 @@
 output "az1" {
-  value = "${data.aws_availability_zones.available.names[0]}"
+  value = data.aws_availability_zones.available.names[0]
 }
+
 output "az2" {
-  value = "${data.aws_availability_zones.available.names[1]}"
+  value = data.aws_availability_zones.available.names[1]
 }
+
 output "stack_description" {
-  value = "${var.stack_description}"
+  value = var.stack_description
 }
 
 /* VPC */
 output "vpc_region" {
-  value = "${var.aws_default_region}"
+  value = var.aws_default_region
 }
+
 output "vpc_id" {
-  value = "${module.stack.vpc_id}"
+  value = module.stack.vpc_id
 }
+
 output "vpc_cidr" {
-  value = "${module.stack.vpc_cidr}"
+  value = module.stack.vpc_cidr
 }
+
 output "vpc_cidr_dns" {
-  value = "${cidrhost("${module.stack.vpc_cidr}", 2)}"
+  value = cidrhost(module.stack.vpc_cidr, 2)
 }
 
 /* Private network */
 output "private_subnet_az1" {
-  value = "${module.stack.private_subnet_az1}"
+  value = module.stack.private_subnet_az1
 }
+
 output "private_subnet_az2" {
-  value = "${module.stack.private_subnet_az2}"
+  value = module.stack.private_subnet_az2
 }
+
 output "private_subnet_cidr_az1" {
-  value = "${module.stack.private_cidr_az1}"
+  value = module.stack.private_cidr_az1
 }
+
 output "private_subnet_cidr_az2" {
-  value = "${module.stack.private_cidr_az2}"
+  value = module.stack.private_cidr_az2
 }
+
 output "private_subnet_gateway_az1" {
-  value = "${cidrhost("${module.stack.private_cidr_az1}", 1)}"
+  value = cidrhost(module.stack.private_cidr_az1, 1)
 }
+
 output "private_subnet_gateway_az2" {
-  value = "${cidrhost("${module.stack.private_cidr_az2}", 1)}"
+  value = cidrhost(module.stack.private_cidr_az2, 1)
 }
+
 output "private_subnet_reserved_az1" {
-  value = "${cidrhost("${module.stack.private_cidr_az1}", 0)} - ${cidrhost("${module.stack.private_cidr_az1}", 3)}"
+  value = "${cidrhost(module.stack.private_cidr_az1, 0)} - ${cidrhost(module.stack.private_cidr_az1, 3)}"
 }
+
 output "private_subnet_reserved_az2" {
-  value = "${cidrhost("${module.stack.private_cidr_az2}", 0)} - ${cidrhost("${module.stack.private_cidr_az2}", 3)}"
+  value = "${cidrhost(module.stack.private_cidr_az2, 0)} - ${cidrhost(module.stack.private_cidr_az2, 3)}"
 }
+
 output "private_route_table_az1" {
-  value = "${module.stack.private_route_table_az1}"
+  value = module.stack.private_route_table_az1
 }
+
 output "private_route_table_az2" {
-  value = "${module.stack.private_route_table_az2}"
+  value = module.stack.private_route_table_az2
 }
 
 /* Public network */
 output "public_subnet_az1" {
-  value = "${module.stack.public_subnet_az1}"
+  value = module.stack.public_subnet_az1
 }
+
 output "public_subnet_az2" {
-  value = "${module.stack.public_subnet_az2}"
+  value = module.stack.public_subnet_az2
 }
+
 output "public_subnet_cidr_az1" {
-  value = "${module.stack.public_cidr_az1}"
+  value = module.stack.public_cidr_az1
 }
+
 output "public_subnet_cidr_az2" {
-  value = "${module.stack.public_cidr_az2}"
+  value = module.stack.public_cidr_az2
 }
+
 output "public_subnet_gateway_az1" {
-  value = "${cidrhost("${module.stack.public_cidr_az1}", 1)}"
+  value = cidrhost(module.stack.public_cidr_az1, 1)
 }
+
 output "public_subnet_gateway_az2" {
-  value = "${cidrhost("${module.stack.public_cidr_az2}", 1)}"
+  value = cidrhost(module.stack.public_cidr_az2, 1)
 }
+
 output "public_subnet_reserved_az1" {
-  value = "${cidrhost("${module.stack.public_cidr_az1}", 0)} - ${cidrhost("${module.stack.public_cidr_az1}", 3)}"
+  value = "${cidrhost(module.stack.public_cidr_az1, 0)} - ${cidrhost(module.stack.public_cidr_az1, 3)}"
 }
+
 output "public_subnet_reserved_az2" {
-  value = "${cidrhost("${module.stack.public_cidr_az2}", 0)} - ${cidrhost("${module.stack.public_cidr_az2}", 3)}"
+  value = "${cidrhost(module.stack.public_cidr_az2, 0)} - ${cidrhost(module.stack.public_cidr_az2, 3)}"
 }
+
 output "public_route_table" {
-  value = "${module.stack.public_route_table}"
+  value = module.stack.public_route_table
 }
+
 output "nat_egress_ip_az1" {
-  value = "${module.stack.nat_egress_ip_az1}"
+  value = module.stack.nat_egress_ip_az1
 }
+
 output "nat_egress_ip_az2" {
-  value = "${module.stack.nat_egress_ip_az2}"
+  value = module.stack.nat_egress_ip_az2
 }
 
 /* Services network */
 output "services_subnet_az1" {
-  value = "${module.cf.services_subnet_az1}"
+  value = module.cf.services_subnet_az1
 }
+
 output "services_subnet_az2" {
-  value = "${module.cf.services_subnet_az2}"
+  value = module.cf.services_subnet_az2
 }
+
 output "services_subnet_cidr_az1" {
-  value = "${module.cf.services_cidr_1}"
+  value = module.cf.services_cidr_1
 }
+
 output "services_subnet_cidr_az2" {
-  value = "${module.cf.services_cidr_2}"
+  value = module.cf.services_cidr_2
 }
+
 output "services_subnet_gateway_az1" {
-  value = "${cidrhost("${module.cf.services_cidr_1}", 1)}"
+  value = cidrhost(module.cf.services_cidr_1, 1)
 }
+
 output "services_subnet_gateway_az2" {
-  value = "${cidrhost("${module.cf.services_cidr_2}", 1)}"
+  value = cidrhost(module.cf.services_cidr_2, 1)
 }
+
 output "services_subnet_reserved_az1" {
-  value = "${cidrhost("${module.cf.services_cidr_1}", 0)} - ${cidrhost("${module.cf.services_cidr_1}", 3)}"
+  value = "${cidrhost(module.cf.services_cidr_1, 0)} - ${cidrhost(module.cf.services_cidr_1, 3)}"
 }
+
 output "services_subnet_reserved_az2" {
-  value = "${cidrhost("${module.cf.services_cidr_2}", 0)} - ${cidrhost("${module.cf.services_cidr_2}", 3)}"
+  value = "${cidrhost(module.cf.services_cidr_2, 0)} - ${cidrhost(module.cf.services_cidr_2, 3)}"
 }
 
 /* Per-deployment static IP ranges */
@@ -120,357 +151,432 @@ output "services_subnet_reserved_az2" {
 data "template_file" "logsearch_static_ips" {
   count = 31
   vars = {
-    address = "${cidrhost("${module.cf.services_cidr_1}", "${count.index + 20}")}"
+    address = cidrhost(module.cf.services_cidr_1, count.index + 20)
   }
   template = "$${address}"
 }
+
 output "logsearch_static_ips" {
-  value = ["${data.template_file.logsearch_static_ips.*.rendered}"]
+  value = [data.template_file.logsearch_static_ips.*.rendered]
 }
+
 data "template_file" "kubernetes_static_ips" {
   count = 50
   vars = {
-    address = "${cidrhost("${module.cf.services_cidr_1}", "${count.index + 200}")}"
+    address = cidrhost(module.cf.services_cidr_1, count.index + 200)
   }
   template = "$${address}"
 }
+
 output "kubernetes_static_ips" {
-  value = ["${data.template_file.kubernetes_static_ips.*.rendered}"]
+  value = [data.template_file.kubernetes_static_ips.*.rendered]
 }
+
 output "services_static_ips" {
-  value = "${concat(
+  value = concat(
     data.template_file.logsearch_static_ips.*.rendered,
-    data.template_file.kubernetes_static_ips.*.rendered
-  )}"
+    data.template_file.kubernetes_static_ips.*.rendered,
+  )
 }
 
 /* Main LB */
 output "main_lb_name" {
-  value = "${aws_lb.main.name}"
+  value = aws_lb.main.name
 }
+
 output "main_lb_dns_name" {
-  value = "${aws_lb.main.dns_name}"
+  value = aws_lb.main.dns_name
 }
 
 /* CloudFoundry LB */
 output "cf_lb_name" {
-  value = "${module.cf.lb_name}"
+  value = module.cf.lb_name
 }
+
 output "cf_lb_dns_name" {
-  value = "${module.cf.lb_dns_name}"
+  value = module.cf.lb_dns_name
 }
 
 output "cf_apps_lb_name" {
-  value = "${module.cf.apps_lb_name}"
+  value = module.cf.apps_lb_name
 }
+
 output "cf_apps_lb_dns_name" {
-  value = "${module.cf.apps_lb_dns_name}"
+  value = module.cf.apps_lb_dns_name
 }
 
 output "cf_router_target_groups" {
-  value = "${concat(
-    list("${module.cf.lb_target_group}"),
-    list("${module.cf.apps_lb_target_group}"),
+  value = concat(
+    [module.cf.lb_target_group],
+    [module.cf.apps_lb_target_group],
     aws_lb_target_group.domains_broker_apps.*.name,
     aws_lb_target_group.domains_broker_challenge.*.name,
     aws_lb_target_group.domain_broker_v2_apps.*.name,
-    aws_lb_target_group.domain_broker_v2_challenge.*.name
-  )}"
+    aws_lb_target_group.domain_broker_v2_challenge.*.name,
+  )
 }
 
 output "cf_target_group" {
-  value = "${module.cf.lb_target_group}"
+  value = module.cf.lb_target_group
 }
+
 output "cf_apps_target_group" {
-  value = "${module.cf.apps_lb_target_group}"
+  value = module.cf.apps_lb_target_group
 }
 
 /* Security Groups */
 output "bosh_security_group" {
-  value = "${module.stack.bosh_security_group}"
+  value = module.stack.bosh_security_group
 }
+
 output "local_vpc_traffic_security_group" {
-    value = "${module.stack.local_vpc_traffic_security_group}"
+  value = module.stack.local_vpc_traffic_security_group
 }
+
 output "web_traffic_security_group" {
-  value = "${module.stack.web_traffic_security_group}"
+  value = module.stack.web_traffic_security_group
 }
 
 /* RDS Network */
 output "rds_subnet_az1" {
-    value = "${module.stack.rds_subnet_az1}"
+  value = module.stack.rds_subnet_az1
 }
+
 output "rds_subnet_az2" {
-    value = "${module.stack.rds_subnet_az2}"
+  value = module.stack.rds_subnet_az2
 }
+
 output "rds_subnet_cidr_az1" {
-  value = "${module.stack.rds_private_cidr_1}"
+  value = module.stack.rds_private_cidr_1
 }
+
 output "rds_subnet_cidr_az2" {
-  value = "${module.stack.rds_private_cidr_2}"
+  value = module.stack.rds_private_cidr_2
 }
+
 output "rds_subnet_group" {
-    value = "${module.stack.rds_subnet_group}"
+  value = module.stack.rds_subnet_group
 }
+
 output "rds_mysql_security_group" {
-  value = "${module.stack.rds_mysql_security_group}"
+  value = module.stack.rds_mysql_security_group
 }
+
 output "rds_postgres_security_group" {
-  value = "${module.stack.rds_postgres_security_group}"
+  value = module.stack.rds_postgres_security_group
 }
+
 output "rds_mssql_security_group" {
-  value = "${module.stack.rds_mssql_security_group}"
+  value = module.stack.rds_mssql_security_group
 }
+
 output "rds_oracle_security_group" {
-  value = "${module.stack.rds_oracle_security_group}"
+  value = module.stack.rds_oracle_security_group
 }
 
 /* Elasticache Network */
 output "elasticache_subnet_az1" {
-  value = "${module.elasticache_broker_network.elasticache_subnet_az1}"
+  value = module.elasticache_broker_network.elasticache_subnet_az1
 }
+
 output "elasticache_subnet_az2" {
-  value = "${module.elasticache_broker_network.elasticache_subnet_az2}"
+  value = module.elasticache_broker_network.elasticache_subnet_az2
 }
+
 output "elasticache_subnet_cidr_az1" {
-  value = "${module.elasticache_broker_network.elasticache_private_cidr_1}"
+  value = module.elasticache_broker_network.elasticache_private_cidr_1
 }
+
 output "elasticache_subnet_cidr_az2" {
-  value = "${module.elasticache_broker_network.elasticache_private_cidr_2}"
+  value = module.elasticache_broker_network.elasticache_private_cidr_2
 }
+
 output "elasticache_subnet_group" {
-  value = "${module.elasticache_broker_network.elasticache_subnet_group}"
+  value = module.elasticache_broker_network.elasticache_subnet_group
 }
+
 output "elasticache_redis_security_group" {
-  value = "${module.elasticache_broker_network.elasticache_redis_security_group}"
+  value = module.elasticache_broker_network.elasticache_redis_security_group
 }
+
 output "elasticache_broker_elb_name" {
-  value = "${module.elasticache_broker_network.elasticache_elb_name}"
+  value = module.elasticache_broker_network.elasticache_elb_name
 }
+
 output "elasticache_broker_elb_dns_name" {
-  value = "${module.elasticache_broker_network.elasticache_elb_dns_name}"
+  value = module.elasticache_broker_network.elasticache_elb_dns_name
 }
 
 /* Elasticsearch Network */
 output "elasticsearch_subnet_az1" {
-  value = "${module.elasticsearch_broker.elasticsearch_subnet_az1}"
+  value = module.elasticsearch_broker.elasticsearch_subnet_az1
 }
+
 output "elasticsearch_subnet_az2" {
-  value = "${module.elasticsearch_broker.elasticsearch_subnet_az2}"
+  value = module.elasticsearch_broker.elasticsearch_subnet_az2
 }
+
 output "elasticsearch_subnet_cidr_az1" {
-  value = "${module.elasticsearch_broker.elasticsearch_private_cidr_1}"
+  value = module.elasticsearch_broker.elasticsearch_private_cidr_1
 }
+
 output "elasticsearch_subnet_cidr_az2" {
-  value = "${module.elasticsearch_broker.elasticsearch_private_cidr_2}"
+  value = module.elasticsearch_broker.elasticsearch_private_cidr_2
 }
+
 output "elasticsearch_security_group" {
-  value = "${module.elasticsearch_broker.elasticsearch_security_group}"
+  value = module.elasticsearch_broker.elasticsearch_security_group
 }
 
 /* RDS Bosh Instance */
 output "bosh_rds_url_curr" {
-  value = "${module.stack.bosh_rds_url_curr}"
+  value = module.stack.bosh_rds_url_curr
 }
+
 output "bosh_rds_host_curr" {
-  value = "${module.stack.bosh_rds_host_curr}"
+  value = module.stack.bosh_rds_host_curr
 }
+
 output "bosh_rds_url_prev" {
-  value = "${module.stack.bosh_rds_url_prev}"
+  value = module.stack.bosh_rds_url_prev
 }
+
 output "bosh_rds_host_prev" {
-  value = "${module.stack.bosh_rds_host_prev}"
+  value = module.stack.bosh_rds_host_prev
 }
+
 output "bosh_rds_port" {
-  value = "${module.stack.bosh_rds_port}"
+  value = module.stack.bosh_rds_port
 }
+
 output "bosh_rds_username" {
-  value = "${module.stack.bosh_rds_username}"
+  value = module.stack.bosh_rds_username
 }
+
 output "bosh_rds_password" {
-  value = "${module.stack.bosh_rds_password}"
+  value = module.stack.bosh_rds_password
 }
 
 /* CloudFoundry RDS */
 output "cf_rds_url" {
-  value = "${module.cf.cf_rds_url}"
+  value = module.cf.cf_rds_url
 }
+
 output "cf_rds_host" {
-  value = "${module.cf.cf_rds_host}"
+  value = module.cf.cf_rds_host
 }
+
 output "cf_rds_port" {
-  value = "${module.cf.cf_rds_port}"
+  value = module.cf.cf_rds_port
 }
+
 output "cf_rds_username" {
-  value = "${module.cf.cf_rds_username}"
+  value = module.cf.cf_rds_username
 }
+
 output "cf_rds_password" {
-  value = "${module.cf.cf_rds_password}"
+  value = module.cf.cf_rds_password
 }
+
 output "cf_rds_engine" {
-  value = "${module.cf.cf_rds_engine}"
+  value = module.cf.cf_rds_engine
 }
 
 /* CredHub RDS */
 output "credhub_rds_url" {
-  value = "${module.stack.credhub_rds_url}"
+  value = module.stack.credhub_rds_url
 }
+
 output "credhub_rds_host" {
-  value = "${module.stack.credhub_rds_host}"
+  value = module.stack.credhub_rds_host
 }
+
 output "credhub_rds_port" {
-  value = "${module.stack.credhub_rds_port}"
+  value = module.stack.credhub_rds_port
 }
+
 output "credhub_rds_username" {
-  value = "${module.stack.credhub_rds_username}"
+  value = module.stack.credhub_rds_username
 }
+
 output "credhub_rds_password" {
-  value = "${module.stack.credhub_rds_password}"
+  value = module.stack.credhub_rds_password
 }
 
 /* Diego ELB */
 output "diego_elb_name" {
-  value = "${module.diego.diego_elb_name}"
+  value = module.diego.diego_elb_name
 }
 
 output "diego_elb_dns_name" {
-  value = "${module.diego.diego_elb_dns_name}"
+  value = module.diego.diego_elb_dns_name
 }
 
 /* Kubernetes network */
 output "kubernetes_elb_name" {
-  value = "${module.kubernetes.kubernetes_elb_name}"
+  value = module.kubernetes.kubernetes_elb_name
 }
+
 output "kubernetes_elb_dns_name" {
-  value = "${module.kubernetes.kubernetes_elb_dns_name}"
+  value = module.kubernetes.kubernetes_elb_dns_name
 }
+
 output "kubernetes_elb_security_group" {
-  value = "${module.kubernetes.kubernetes_elb_security_group}"
+  value = module.kubernetes.kubernetes_elb_security_group
 }
+
 output "kubernetes_ec2_security_group" {
-  value = "${module.kubernetes.kubernetes_ec2_security_group}"
+  value = module.kubernetes.kubernetes_ec2_security_group
 }
 
 /* Logsearch network */
 output "logsearch_elb_name" {
-  value = "${module.logsearch.logsearch_elb_name}"
+  value = module.logsearch.logsearch_elb_name
 }
+
 output "logsearch_elb_dns_name" {
-  value = "${module.logsearch.logsearch_elb_dns_name}"
+  value = module.logsearch.logsearch_elb_dns_name
 }
 
 output "platform_syslog_elb_name" {
-  value = "${module.logsearch.platform_syslog_elb_name}"
+  value = module.logsearch.platform_syslog_elb_name
 }
+
 output "platform_syslog_elb_dns_name" {
-  value = "${module.logsearch.platform_syslog_elb_dns_name}"
+  value = module.logsearch.platform_syslog_elb_dns_name
 }
 
 output "platform_kibana_lb_target_group" {
-  value = "${module.logsearch.platform_kibana_lb_target_group}"
+  value = module.logsearch.platform_kibana_lb_target_group
 }
 
 /* Shibboleth Proxy ELB */
 output "shibboleth_lb_target_group" {
-  value = "${module.shibboleth.shibboleth_lb_target_group}"
+  value = module.shibboleth.shibboleth_lb_target_group
 }
 
 /* Admin UI ELB */
 output "admin_lb_name" {
-  value = "${module.admin.admin_lb_name}"
+  value = module.admin.admin_lb_name
 }
+
 output "admin_lb_dns_name" {
-  value = "${module.admin.admin_lb_dns_name}"
+  value = module.admin.admin_lb_dns_name
 }
+
 output "admin_lb_target_group" {
-  value = "${module.admin.admin_lb_target_group}"
+  value = module.admin.admin_lb_target_group
 }
 
 /* iam roles */
 output "default_profile" {
-  value = "${module.default_role.profile_name}"
+  value = module.default_role.profile_name
 }
+
 output "bosh_profile" {
-  value = "${module.bosh_role.profile_name}"
+  value = module.bosh_role.profile_name
 }
+
 output "bosh_compilation_profile" {
-  value = "${module.bosh_compilation_role.profile_name}"
+  value = module.bosh_compilation_role.profile_name
 }
+
 output "logsearch_ingestor_profile" {
-  value = "${module.logsearch_ingestor_role.profile_name}"
+  value = module.logsearch_ingestor_role.profile_name
 }
+
 output "kubernetes_master_profile" {
-  value = "${module.kubernetes_master_role.profile_name}"
+  value = module.kubernetes_master_role.profile_name
 }
+
 output "kubernetes_minion_profile" {
-  value = "${module.kubernetes_minion_role.profile_name}"
+  value = module.kubernetes_minion_role.profile_name
 }
+
 output "kubernetes_node_profile" {
-  value = "${module.kubernetes_node_role.profile_name}"
+  value = module.kubernetes_node_role.profile_name
 }
+
 output "kubernetes_logger_profile" {
-  value = "${module.kubernetes_logger_role.profile_name}"
+  value = module.kubernetes_logger_role.profile_name
 }
+
 output "etcd_backup_profile" {
-  value = "${module.etcd_backup_role.profile_name}"
+  value = module.etcd_backup_role.profile_name
 }
+
 output "cf_blobstore_profile" {
-  value = "${module.cf_blobstore_role.profile_name}"
+  value = module.cf_blobstore_role.profile_name
 }
+
 output "elasticache_broker_profile" {
-  value = "${module.elasticache_broker_role.profile_name}"
+  value = module.elasticache_broker_role.profile_name
 }
+
 output "platform_profile" {
-  value = "${module.platform_role.profile_name}"
+  value = module.platform_role.profile_name
 }
 
 output "upstream_bosh_compilation_profile" {
-  value = "${data.terraform_remote_state.target_vpc.bosh_compilation_profile}"
+  value = data.terraform_remote_state.target_vpc.outputs.bosh_compilation_profile
 }
 
-output "external_domain_broker_gov_username"{
-  value = "${module.external_domain_broker_govcloud.username}"
+output "external_domain_broker_gov_username" {
+  value = module.external_domain_broker_govcloud.username
 }
-output "external_domain_broker_gov_access_key_id_curr"{
-  value = "${module.external_domain_broker_govcloud.access_key_id_curr}"
+
+output "external_domain_broker_gov_access_key_id_curr" {
+  value = module.external_domain_broker_govcloud.access_key_id_curr
 }
-output "external_domain_broker_gov_secret_access_key_curr"{
-  value = "${module.external_domain_broker_govcloud.secret_access_key_curr}"
+
+output "external_domain_broker_gov_secret_access_key_curr" {
+  value = module.external_domain_broker_govcloud.secret_access_key_curr
 }
-output "external_domain_broker_gov_access_key_id_prev"{
-  value = "${module.external_domain_broker_govcloud.access_key_id_prev}"
+
+output "external_domain_broker_gov_access_key_id_prev" {
+  value = module.external_domain_broker_govcloud.access_key_id_prev
 }
-output "external_domain_broker_gov_secret_access_key_prev"{
-  value = "${module.external_domain_broker_govcloud.secret_access_key_prev}"
+
+output "external_domain_broker_gov_secret_access_key_prev" {
+  value = module.external_domain_broker_govcloud.secret_access_key_prev
 }
+
 output "bosh_static_ip" {
-  value = "${cidrhost("${module.stack.private_cidr_az1}", 7)}"
+  value = cidrhost(module.stack.private_cidr_az1, 7)
 }
+
 output "bosh_network_static_ips" {
   value = [
-    "${cidrhost("${module.stack.private_cidr_az1}", 7)}"
+    cidrhost(module.stack.private_cidr_az1, 7),
   ]
 }
 
 /* Buckets */
 output "logsearch_archive_bucket_name" {
-  value = "${module.cf.logsearch_archive_bucket_name}"
+  value = module.cf.logsearch_archive_bucket_name
 }
+
 output "etcd_backup_bucket_name" {
-  value = "${module.cf.etcd_backup_bucket_name}"
+  value = module.cf.etcd_backup_bucket_name
 }
+
 output "bosh_blobstore_bucket" {
-  value = "${module.bosh_blobstore_bucket.bucket_name}"
+  value = module.bosh_blobstore_bucket.bucket_name
 }
-output "elb_log_bucket"{
-  value = "${var.log_bucket_name}"
+
+output "elb_log_bucket" {
+  value = var.log_bucket_name
 }
+
 output "tooling_bosh_static_ip" {
-  value = "${data.terraform_remote_state.target_vpc.tooling_bosh_static_ip}"
+  value = data.terraform_remote_state.target_vpc.outputs.tooling_bosh_static_ip
 }
+
 output "master_bosh_static_ip" {
-  value = "${data.terraform_remote_state.target_vpc.master_bosh_static_ip}"
+  value = data.terraform_remote_state.target_vpc.outputs.master_bosh_static_ip
 }
+
 output "nessus_static_ip" {
-  value = "${data.terraform_remote_state.target_vpc.nessus_static_ip}"
+  value = data.terraform_remote_state.target_vpc.outputs.nessus_static_ip
 }
+

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -157,7 +157,7 @@ data "template_file" "logsearch_static_ips" {
 }
 
 output "logsearch_static_ips" {
-  value = [data.template_file.logsearch_static_ips.*.rendered]
+  value = data.template_file.logsearch_static_ips.*.rendered
 }
 
 data "template_file" "kubernetes_static_ips" {
@@ -169,7 +169,7 @@ data "template_file" "kubernetes_static_ips" {
 }
 
 output "kubernetes_static_ips" {
-  value = [data.template_file.kubernetes_static_ips.*.rendered]
+  value = data.template_file.kubernetes_static_ips.*.rendered
 }
 
 output "services_static_ips" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -1,5 +1,6 @@
 terraform {
-  backend "s3" {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
@@ -10,54 +11,68 @@ data "terraform_remote_state" "target_vpc" {
   backend = "s3"
 
   config = {
-    bucket = "${var.remote_state_bucket}"
+    bucket = var.remote_state_bucket
     key    = "${var.target_stack_name}/terraform.tfstate"
   }
 }
 
-data "aws_partition" "current" {}
-data "aws_availability_zones" "available" {}
-data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {
+}
 
-data "aws_region" "current" {}
+data "aws_availability_zones" "available" {
+}
+
+data "aws_caller_identity" "current" {
+}
+
+data "aws_region" "current" {
+}
 
 data "aws_iam_server_certificate" "wildcard" {
-  name_prefix = "${var.wildcard_certificate_name_prefix}"
+  name_prefix = var.wildcard_certificate_name_prefix
   latest      = true
 }
 
 data "aws_iam_server_certificate" "wildcard_apps" {
-  name_prefix = "${var.wildcard_apps_certificate_name_prefix}"
+  name_prefix = var.wildcard_apps_certificate_name_prefix
   latest      = true
 }
 
 resource "aws_lb" "main" {
   name    = "${var.stack_description}-main"
-  subnets = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
+  subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
 
-  security_groups = ["${var.force_restricted_network == "no" ?
-    module.stack.web_traffic_security_group :
-    module.stack.restricted_web_traffic_security_group}"]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  security_groups = [
+    var.force_restricted_network == "no" ? module.stack.web_traffic_security_group : module.stack.restricted_web_traffic_security_group,
+  ]
 
   ip_address_type = "dualstack"
   idle_timeout    = 3600
 
-  access_logs = {
-    bucket = "${var.log_bucket_name}"
-    prefix = "${var.stack_description}"
+  access_logs {
+    bucket  = var.log_bucket_name
+    prefix  = var.stack_description
     enabled = true
   }
 }
 
 resource "aws_lb_listener" "main" {
-  load_balancer_arn = "${aws_lb.main.arn}"
+  load_balancer_arn = aws_lb.main.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = "${data.aws_iam_server_certificate.wildcard.arn}"
+  certificate_arn   = data.aws_iam_server_certificate.wildcard.arn
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.dummy.arn}"
+    target_group_arn = aws_lb_target_group.dummy.arn
     type             = "forward"
   }
 }
@@ -65,170 +80,172 @@ resource "aws_lb_listener" "main" {
 resource "aws_lb_target_group" "dummy" {
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${module.stack.vpc_id}"
+  vpc_id   = module.stack.vpc_id
 }
 
 module "stack" {
   source = "../../modules/stack/spoke"
 
-  stack_description                 = "${var.stack_description}"
-  aws_partition                     = "${data.aws_partition.current.partition}"
-  vpc_cidr                          = "${var.vpc_cidr}"
-  aws_default_region                = "${var.aws_default_region}"
-  rds_db_size                       = "${var.rds_db_size}"
-  rds_apply_immediately             = "${var.rds_apply_immediately}"
-  rds_allow_major_version_upgrade   = "${var.rds_allow_major_version_upgrade}"
-  public_cidr_1                     = "${cidrsubnet(var.vpc_cidr, 8, 100)}"
-  public_cidr_2                     = "${cidrsubnet(var.vpc_cidr, 8, 101)}"
-  private_cidr_1                    = "${cidrsubnet(var.vpc_cidr, 8, 1)}"
-  private_cidr_2                    = "${cidrsubnet(var.vpc_cidr, 8, 2)}"
-  rds_private_cidr_1                = "${cidrsubnet(var.vpc_cidr, 8, 20)}"
-  rds_private_cidr_2                = "${cidrsubnet(var.vpc_cidr, 8, 21)}"
-  restricted_ingress_web_cidrs      = "${var.restricted_ingress_web_cidrs}"
-  restricted_ingress_web_ipv6_cidrs = "${var.restricted_ingress_web_ipv6_cidrs}"
-  rds_password                      = "${var.rds_password}"
-  credhub_rds_password              = "${var.credhub_rds_password}"
-  account_id                        = "${data.aws_caller_identity.current.account_id}"
+  stack_description                 = var.stack_description
+  aws_partition                     = data.aws_partition.current.partition
+  vpc_cidr                          = var.vpc_cidr
+  aws_default_region                = var.aws_default_region
+  rds_db_size                       = var.rds_db_size
+  rds_apply_immediately             = var.rds_apply_immediately
+  rds_allow_major_version_upgrade   = var.rds_allow_major_version_upgrade
+  public_cidr_1                     = cidrsubnet(var.vpc_cidr, 8, 100)
+  public_cidr_2                     = cidrsubnet(var.vpc_cidr, 8, 101)
+  private_cidr_1                    = cidrsubnet(var.vpc_cidr, 8, 1)
+  private_cidr_2                    = cidrsubnet(var.vpc_cidr, 8, 2)
+  rds_private_cidr_1                = cidrsubnet(var.vpc_cidr, 8, 20)
+  rds_private_cidr_2                = cidrsubnet(var.vpc_cidr, 8, 21)
+  restricted_ingress_web_cidrs      = var.restricted_ingress_web_cidrs
+  restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
+  rds_password                      = var.rds_password
+  credhub_rds_password              = var.credhub_rds_password
+  account_id                        = data.aws_caller_identity.current.account_id
 
-  target_vpc_id              = "${data.terraform_remote_state.target_vpc.vpc_id}"
-  target_vpc_cidr            = "${data.terraform_remote_state.target_vpc.vpc_cidr}"
-  target_bosh_security_group = "${data.terraform_remote_state.target_vpc.bosh_security_group}"
-  target_az1_route_table     = "${data.terraform_remote_state.target_vpc.private_route_table_az1}"
-  target_az2_route_table     = "${data.terraform_remote_state.target_vpc.private_route_table_az2}"
+  target_vpc_id              = data.terraform_remote_state.target_vpc.outputs.vpc_id
+  target_vpc_cidr            = data.terraform_remote_state.target_vpc.outputs.vpc_cidr
+  target_bosh_security_group = data.terraform_remote_state.target_vpc.outputs.bosh_security_group
+  target_az1_route_table     = data.terraform_remote_state.target_vpc.outputs.private_route_table_az1
+  target_az2_route_table     = data.terraform_remote_state.target_vpc.outputs.private_route_table_az2
 
   target_monitoring_security_groups = [
-    "${lookup(data.terraform_remote_state.target_vpc.monitoring_security_groups, var.stack_description)}",
+    data.terraform_remote_state.target_vpc.outputs.monitoring_security_groups[var.stack_description],
   ]
 
   target_concourse_security_groups = [
-    "${data.terraform_remote_state.target_vpc.production_concourse_security_group}",
-    "${data.terraform_remote_state.target_vpc.staging_concourse_security_group}",
+    data.terraform_remote_state.target_vpc.outputs.production_concourse_security_group,
+    data.terraform_remote_state.target_vpc.outputs.staging_concourse_security_group,
   ]
 }
 
 module "cf" {
   source = "../../modules/cloudfoundry"
 
-  stack_description = "${var.stack_description}"
-  aws_partition     = "${data.aws_partition.current.partition}"
-  elb_main_cert_id  = "${data.aws_iam_server_certificate.wildcard.arn}"
-  elb_apps_cert_id  = "${data.aws_iam_server_certificate.wildcard_apps.arn}"
-  elb_subnets       = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
+  stack_description = var.stack_description
+  aws_partition     = data.aws_partition.current.partition
+  elb_main_cert_id  = data.aws_iam_server_certificate.wildcard.arn
+  elb_apps_cert_id  = data.aws_iam_server_certificate.wildcard_apps.arn
+  elb_subnets       = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
 
-  elb_security_groups = ["${var.force_restricted_network == "no" ?
-      module.stack.web_traffic_security_group :
-      module.stack.restricted_web_traffic_security_group}"]
+  elb_security_groups = [
+    var.force_restricted_network == "no" ? module.stack.web_traffic_security_group : module.stack.restricted_web_traffic_security_group,
+  ]
 
-  rds_password        = "${var.cf_rds_password}"
-  rds_subnet_group    = "${module.stack.rds_subnet_group}"
-  rds_security_groups = ["${module.stack.rds_postgres_security_group}"]
-  stack_prefix        = "${var.stack_prefix}"
+  rds_password        = var.cf_rds_password
+  rds_subnet_group    = module.stack.rds_subnet_group
+  rds_security_groups = [module.stack.rds_postgres_security_group]
+  stack_prefix        = var.stack_prefix
 
-  vpc_id                  = "${module.stack.vpc_id}"
-  private_route_table_az1 = "${module.stack.private_route_table_az1}"
-  private_route_table_az2 = "${module.stack.private_route_table_az2}"
+  vpc_id                  = module.stack.vpc_id
+  private_route_table_az1 = module.stack.private_route_table_az1
+  private_route_table_az2 = module.stack.private_route_table_az2
 
-  services_cidr_1       = "${cidrsubnet(var.vpc_cidr, 8, 30)}"
-  services_cidr_2       = "${cidrsubnet(var.vpc_cidr, 8, 31)}"
-  kubernetes_cluster_id = "${var.kubernetes_cluster_id}"
-  bucket_prefix         = "${var.bucket_prefix}"
-  log_bucket_name       = "${var.log_bucket_name}"
+  services_cidr_1       = cidrsubnet(var.vpc_cidr, 8, 30)
+  services_cidr_2       = cidrsubnet(var.vpc_cidr, 8, 31)
+  kubernetes_cluster_id = var.kubernetes_cluster_id
+  bucket_prefix         = var.bucket_prefix
+  log_bucket_name       = var.log_bucket_name
 }
 
 module "diego" {
   source = "../../modules/diego"
 
-  stack_description = "${var.stack_description}"
-  elb_subnets       = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
+  stack_description = var.stack_description
+  elb_subnets       = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
 
-  vpc_id            = "${module.stack.vpc_id}"
+  vpc_id = module.stack.vpc_id
 
   # Workaround for https://github.com/hashicorp/terraform/issues/12453
-  ingress_cidrs = "${split(",",
-      var.force_restricted_network == "no" ?
-        "0.0.0.0/0" : join(",", var.restricted_ingress_web_cidrs))}"
+  ingress_cidrs = split(
+    ",",
+    var.force_restricted_network == "no" ? "0.0.0.0/0" : join(",", var.restricted_ingress_web_cidrs),
+  )
 
-  log_bucket_name = "${var.log_bucket_name}"
+  log_bucket_name = var.log_bucket_name
 }
 
 module "kubernetes" {
   source = "../../modules/kubernetes"
 
-  stack_description  = "${var.stack_description}"
-  aws_default_region = "${var.aws_default_region}"
+  stack_description  = var.stack_description
+  aws_default_region = var.aws_default_region
 
-  vpc_id                           = "${module.stack.vpc_id}"
-  vpc_cidr                         = "${var.vpc_cidr}"
-  tooling_vpc_cidr                 = "${data.terraform_remote_state.target_vpc.vpc_cidr}"
-  elb_subnets                      = ["${module.cf.services_subnet_az1}", "${module.cf.services_subnet_az2}"]
-  target_bosh_security_group       = "${module.stack.bosh_security_group}"
-  target_monitoring_security_group = "${lookup(data.terraform_remote_state.target_vpc.monitoring_security_groups, var.stack_description)}"
-  target_concourse_security_group  = "${data.terraform_remote_state.target_vpc.production_concourse_security_group}"
-  log_bucket_name                  = "${var.log_bucket_name}"
+  vpc_id                           = module.stack.vpc_id
+  vpc_cidr                         = var.vpc_cidr
+  tooling_vpc_cidr                 = data.terraform_remote_state.target_vpc.outputs.vpc_cidr
+  elb_subnets                      = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
+  target_bosh_security_group       = module.stack.bosh_security_group
+  target_monitoring_security_group = data.terraform_remote_state.target_vpc.outputs.monitoring_security_groups[var.stack_description]
+  target_concourse_security_group  = data.terraform_remote_state.target_vpc.outputs.production_concourse_security_group
+  log_bucket_name                  = var.log_bucket_name
 }
 
 module "logsearch" {
   source = "../../modules/logsearch"
 
-  stack_description   = "${var.stack_description}"
-  vpc_id              = "${module.stack.vpc_id}"
-  private_elb_subnets = ["${module.cf.services_subnet_az1}", "${module.cf.services_subnet_az2}"]
-  bosh_security_group = "${module.stack.bosh_security_group}"
-  listener_arn        = "${aws_lb_listener.main.arn}"
-  hosts               = ["${var.platform_kibana_hosts}"]
-  log_bucket_name     = "${var.log_bucket_name}"
+  stack_description   = var.stack_description
+  vpc_id              = module.stack.vpc_id
+  private_elb_subnets = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
+  bosh_security_group = module.stack.bosh_security_group
+  listener_arn        = aws_lb_listener.main.arn
+  hosts               = [var.platform_kibana_hosts]
+  log_bucket_name     = var.log_bucket_name
 }
 
 module "shibboleth" {
   source = "../../modules/shibboleth"
 
-  stack_description = "${var.stack_description}"
-  vpc_id            = "${module.stack.vpc_id}"
-  listener_arn      = "${aws_lb_listener.main.arn}"
-  hosts             = ["${var.shibboleth_hosts}"]
+  stack_description = var.stack_description
+  vpc_id            = module.stack.vpc_id
+  listener_arn      = aws_lb_listener.main.arn
+  hosts             = [var.shibboleth_hosts]
 }
 
 module "admin" {
   source = "../../modules/admin"
 
-  stack_description = "${var.stack_description}"
-  vpc_id            = "${module.stack.vpc_id}"
-  certificate_arn   = "${data.aws_iam_server_certificate.wildcard.arn}"
-  hosts             = ["${var.admin_hosts}"]
-  public_subnet_az1 = "${module.stack.public_subnet_az1}"
-  public_subnet_az2 = "${module.stack.public_subnet_az2}"
-  security_group    = "${module.stack.restricted_web_traffic_security_group}"
-  log_bucket_name = "${var.log_bucket_name}"
+  stack_description = var.stack_description
+  vpc_id            = module.stack.vpc_id
+  certificate_arn   = data.aws_iam_server_certificate.wildcard.arn
+  hosts             = [var.admin_hosts]
+  public_subnet_az1 = module.stack.public_subnet_az1
+  public_subnet_az2 = module.stack.public_subnet_az2
+  security_group    = module.stack.restricted_web_traffic_security_group
+  log_bucket_name   = var.log_bucket_name
 }
 
 module "elasticache_broker_network" {
   source                     = "../../modules/elasticache_broker_network"
-  stack_description          = "${var.stack_description}"
-  elasticache_private_cidr_1 = "${cidrsubnet(var.vpc_cidr, 8, 34)}"
-  elasticache_private_cidr_2 = "${cidrsubnet(var.vpc_cidr, 8, 35)}"
-  az1_route_table            = "${module.stack.private_route_table_az1}"
-  az2_route_table            = "${module.stack.private_route_table_az2}"
-  vpc_id                     = "${module.stack.vpc_id}"
-  security_groups            = ["${module.stack.bosh_security_group}"]
-  elb_subnets                = ["${module.cf.services_subnet_az1}", "${module.cf.services_subnet_az2}"]
-  elb_security_groups        = ["${module.stack.bosh_security_group}"]
-  log_bucket_name            = "${var.log_bucket_name}"
+  stack_description          = var.stack_description
+  elasticache_private_cidr_1 = cidrsubnet(var.vpc_cidr, 8, 34)
+  elasticache_private_cidr_2 = cidrsubnet(var.vpc_cidr, 8, 35)
+  az1_route_table            = module.stack.private_route_table_az1
+  az2_route_table            = module.stack.private_route_table_az2
+  vpc_id                     = module.stack.vpc_id
+  security_groups            = [module.stack.bosh_security_group]
+  elb_subnets                = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
+  elb_security_groups        = [module.stack.bosh_security_group]
+  log_bucket_name            = var.log_bucket_name
 }
 
 module "elasticsearch_broker" {
-  source                     = "../../modules/elasticsearch_broker"
-  stack_description          = "${var.stack_description}"
-  elasticsearch_private_cidr_1 = "${cidrsubnet(var.vpc_cidr, 8, 40)}"
-  elasticsearch_private_cidr_2 = "${cidrsubnet(var.vpc_cidr, 8, 42)}"
-  az1_route_table            = "${module.stack.private_route_table_az1}"
-  az2_route_table            = "${module.stack.private_route_table_az2}"
-  vpc_id                     = "${module.stack.vpc_id}"
-  security_groups            = ["${module.stack.bosh_security_group}"]
+  source                       = "../../modules/elasticsearch_broker"
+  stack_description            = var.stack_description
+  elasticsearch_private_cidr_1 = cidrsubnet(var.vpc_cidr, 8, 40)
+  elasticsearch_private_cidr_2 = cidrsubnet(var.vpc_cidr, 8, 42)
+  az1_route_table              = module.stack.private_route_table_az1
+  az2_route_table              = module.stack.private_route_table_az2
+  vpc_id                       = module.stack.vpc_id
+  security_groups              = [module.stack.bosh_security_group]
 }
 
 module "external_domain_broker_govcloud" {
   source = "../../modules/external_domain_broker_govcloud"
 
-  account_id        = "${data.aws_caller_identity.current.account_id}"
-  stack_description = "${var.stack_description}"
+  account_id        = data.aws_caller_identity.current.account_id
+  stack_description = var.stack_description
 }
+

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -41,15 +41,6 @@ data "aws_iam_server_certificate" "wildcard_apps" {
 resource "aws_lb" "main" {
   name    = "${var.stack_description}-main"
   subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
-
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   security_groups = [
     var.force_restricted_network == "no" ? module.stack.web_traffic_security_group : module.stack.restricted_web_traffic_security_group,
   ]

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -4,7 +4,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.40"
+  version = "~> 3.26"
 }
 
 data "terraform_remote_state" "target_vpc" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -191,7 +191,7 @@ module "logsearch" {
   private_elb_subnets = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
   bosh_security_group = module.stack.bosh_security_group
   listener_arn        = aws_lb_listener.main.arn
-  hosts               = [var.platform_kibana_hosts]
+  hosts               = var.platform_kibana_hosts
   log_bucket_name     = var.log_bucket_name
 }
 
@@ -201,7 +201,7 @@ module "shibboleth" {
   stack_description = var.stack_description
   vpc_id            = module.stack.vpc_id
   listener_arn      = aws_lb_listener.main.arn
-  hosts             = [var.shibboleth_hosts]
+  hosts             = var.shibboleth_hosts
 }
 
 module "admin" {
@@ -210,7 +210,7 @@ module "admin" {
   stack_description = var.stack_description
   vpc_id            = module.stack.vpc_id
   certificate_arn   = data.aws_iam_server_certificate.wildcard.arn
-  hosts             = [var.admin_hosts]
+  hosts             = var.admin_hosts
   public_subnet_az1 = module.stack.public_subnet_az1
   public_subnet_az2 = module.stack.public_subnet_az2
   security_group    = module.stack.restricted_web_traffic_security_group

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -80,10 +80,10 @@ variable "log_bucket_name" {
 }
 
 variable "rds_allow_major_version_upgrade" {
-  default = ""
+  default = "false"
 }
 
 variable "rds_apply_immediately" {
-  default = ""
+  default = "false"
 }
 

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -1,22 +1,28 @@
-variable "stack_description" {}
+variable "stack_description" {
+}
 
 variable "aws_default_region" {
   default = "us-gov-west-1"
 }
 
-variable "vpc_cidr" {}
+variable "vpc_cidr" {
+}
 
 variable "rds_db_size" {
   default = 20
 }
 
-variable "rds_password" {}
+variable "rds_password" {
+}
 
-variable "cf_rds_password" {}
+variable "cf_rds_password" {
+}
 
-variable "credhub_rds_password" {}
+variable "credhub_rds_password" {
+}
 
-variable "remote_state_bucket" {}
+variable "remote_state_bucket" {
+}
 
 variable "target_stack_name" {
   default = "tooling"
@@ -31,31 +37,39 @@ variable "wildcard_apps_certificate_name_prefix" {
 }
 
 variable "admin_hosts" {
-  type = "list"
+  type = list(string)
 }
 
 variable "shibboleth_hosts" {
-  type = "list"
+  type = list(string)
 }
 
 variable "platform_kibana_hosts" {
-  type = "list"
+  type = list(string)
 }
 
-variable "kubernetes_cluster_id" {}
+variable "kubernetes_cluster_id" {
+}
 
 variable "restricted_ingress_web_cidrs" {
-  type = "list"
+  type = list(string)
 }
 
 variable "restricted_ingress_web_ipv6_cidrs" {
-  type = "list"
+  type = list(string)
 }
 
-variable "stack_prefix" {}
-variable "bucket_prefix" {}
-variable "blobstore_bucket_name" {}
-variable "upstream_blobstore_bucket_name" {}
+variable "stack_prefix" {
+}
+
+variable "bucket_prefix" {
+}
+
+variable "blobstore_bucket_name" {
+}
+
+variable "upstream_blobstore_bucket_name" {
+}
 
 variable "force_restricted_network" {
   default = "yes"
@@ -72,3 +86,4 @@ variable "rds_allow_major_version_upgrade" {
 variable "rds_apply_immediately" {
   default = ""
 }
+

--- a/terraform/stacks/main/versions.tf
+++ b/terraform/stacks/main/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/stacks/test/test.tf
+++ b/terraform/stacks/test/test.tf
@@ -1,7 +1,8 @@
 resource "aws_security_group" "test_sg" {
   description = "Test terraform running under bootstrap"
 
-  tags =  {
+  tags = {
     Name = "Test terraform running under bootstrap"
   }
 }
+

--- a/terraform/stacks/test/versions.tf
+++ b/terraform/stacks/test/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/stacks/tooling/buckets.tf
+++ b/terraform/stacks/tooling/buckets.tf
@@ -1,14 +1,14 @@
 module "bosh_blobstore_bucket" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
-  bucket        = "${var.blobstore_bucket_name}"
-  aws_partition = "${data.aws_partition.current.partition}"
+  bucket        = var.blobstore_bucket_name
+  aws_partition = data.aws_partition.current.partition
   force_destroy = "true"
 }
 
 module "bosh_release_bucket" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
-  bucket        = "${var.bosh_release_bucket}"
-  aws_partition = "${data.aws_partition.current.partition}"
+  bucket        = var.bosh_release_bucket
+  aws_partition = data.aws_partition.current.partition
   versioning    = "true"
   force_destroy = "true"
 }
@@ -16,45 +16,46 @@ module "bosh_release_bucket" {
 module "billing_bucket_staging" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
   bucket        = "${var.bucket_prefix}cg-billing-staging"
-  aws_partition = "${data.aws_partition.current.partition}"
+  aws_partition = data.aws_partition.current.partition
 }
 
 module "billing_bucket_production" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
   bucket        = "${var.bucket_prefix}cg-billing-production"
-  aws_partition = "${data.aws_partition.current.partition}"
+  aws_partition = data.aws_partition.current.partition
 }
 
 module "buildpack_notify_state_staging" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
   bucket        = "${var.bucket_prefix}buildpack-notify-state-staging"
-  aws_partition = "${data.aws_partition.current.partition}"
+  aws_partition = data.aws_partition.current.partition
   versioning    = "true"
 }
 
 module "buildpack_notify_state_production" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
   bucket        = "${var.bucket_prefix}buildpack-notify-state-production"
-  aws_partition = "${data.aws_partition.current.partition}"
+  aws_partition = data.aws_partition.current.partition
   versioning    = "true"
 }
 
 module "cg_binaries_bucket" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
   bucket        = "${var.bucket_prefix}cg-binaries"
-  aws_partition = "${data.aws_partition.current.partition}"
+  aws_partition = data.aws_partition.current.partition
 }
 
 module "log_bucket" {
   source          = "../../modules/log_bucket"
-  aws_partition   = "${data.aws_partition.current.partition}"
-  log_bucket_name = "${var.log_bucket_name}"
-  aws_region      = "${data.aws_region.current.name}"
+  aws_partition   = data.aws_partition.current.partition
+  log_bucket_name = var.log_bucket_name
+  aws_region      = data.aws_region.current.name
 }
 
 module "build_artifacts_bucket" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
   bucket        = "cg-build-artifacts"
-  aws_partition = "${data.aws_partition.current.partition}"
+  aws_partition = data.aws_partition.current.partition
   versioning    = "true"
 }
+

--- a/terraform/stacks/tooling/elb_uaa.tf
+++ b/terraform/stacks/tooling/elb_uaa.tf
@@ -1,14 +1,6 @@
 resource "aws_lb" "opsuaa" {
   name    = "${var.stack_description}-opsuaa"
   subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   security_groups = [module.stack.restricted_web_traffic_security_group]
   ip_address_type = "dualstack"
   idle_timeout    = 3600

--- a/terraform/stacks/tooling/elb_uaa.tf
+++ b/terraform/stacks/tooling/elb_uaa.tf
@@ -1,13 +1,21 @@
 resource "aws_lb" "opsuaa" {
-  name = "${var.stack_description}-opsuaa"
-  subnets = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
-  security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
+  name    = "${var.stack_description}-opsuaa"
+  subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  security_groups = [module.stack.restricted_web_traffic_security_group]
   ip_address_type = "dualstack"
-  idle_timeout = 3600
-  access_logs = {
-      bucket        = "${var.log_bucket_name}"
-      prefix        = "${var.stack_description}"
-      enabled       = true
+  idle_timeout    = 3600
+  access_logs {
+    bucket  = var.log_bucket_name
+    prefix  = var.stack_description
+    enabled = true
   }
 }
 
@@ -15,32 +23,33 @@ resource "aws_lb_target_group" "opsuaa_target" {
   name     = "${var.stack_description}-opsuaa"
   port     = 8081
   protocol = "HTTP"
-  vpc_id   = "${module.stack.vpc_id}"
+  vpc_id   = module.stack.vpc_id
 
   health_check {
-    healthy_threshold = 2
-    interval = 61
-    timeout = 60
+    healthy_threshold   = 2
+    interval            = 61
+    timeout             = 60
     unhealthy_threshold = 3
-    path = "/healthz"
-    matcher = 200
+    path                = "/healthz"
+    matcher             = 200
   }
 
   stickiness {
-    type = "lb_cookie"
+    type    = "lb_cookie"
     enabled = true
   }
 }
 
 resource "aws_lb_listener" "opsuaa_listener" {
-  load_balancer_arn = "${aws_lb.opsuaa.arn}"
+  load_balancer_arn = aws_lb.opsuaa.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${data.aws_iam_server_certificate.wildcard_production.arn}"
+  certificate_arn   = data.aws_iam_server_certificate.wildcard_production.arn
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.opsuaa_target.arn}"
+    target_group_arn = aws_lb_target_group.opsuaa_target.arn
     type             = "forward"
   }
 }
+

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -167,14 +167,6 @@ resource "aws_iam_policy_attachment" "bosh_compilation" {
   name       = "${var.stack_description}-bosh-compilation"
   policy_arn = module.bosh_compilation_policy.arn
 
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.bosh_compilation_role.role_name,
   ]
@@ -184,14 +176,6 @@ resource "aws_iam_policy_attachment" "concourse_worker" {
   name       = "concourse_worker"
   policy_arn = module.concourse_worker_policy.arn
 
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.concourse_worker_role.role_name,
   ]
@@ -201,14 +185,6 @@ resource "aws_iam_policy_attachment" "concourse_iaas_worker" {
   name       = "concourse_iaas_worker"
   policy_arn = module.concourse_iaas_worker_policy.arn
 
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
     module.concourse_iaas_worker_role.role_name,
   ]

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -2,14 +2,14 @@ module "billing_user" {
   source         = "../../modules/iam_user/billing_user"
   username       = "cg-billing"
   billing_bucket = "cg-billing-*"
-  aws_partition  = "${data.aws_partition.current.partition}"
+  aws_partition  = data.aws_partition.current.partition
 }
 
 module "s3_logstash" {
   source        = "../../modules/iam_user/s3_logstash"
   username      = "s3-logstash"
-  log_bucket    = "${var.log_bucket_name}"
-  aws_partition = "${data.aws_partition.current.partition}"
+  log_bucket    = var.log_bucket_name
+  aws_partition = data.aws_partition.current.partition
 }
 
 module "rds_storage_alert" {
@@ -20,8 +20,8 @@ module "rds_storage_alert" {
 module "iam_cert_provision_user" {
   source        = "../../modules/iam_user/iam_cert_provision"
   username      = "cg-iam-cert-provision"
-  aws_partition = "${data.aws_partition.current.partition}"
-  account_id    = "${data.aws_caller_identity.current.account_id}"
+  aws_partition = data.aws_partition.current.partition
+  account_id    = data.aws_caller_identity.current.account_id
 }
 
 # This user has access to all cloudtrail events in the account, as there
@@ -40,40 +40,40 @@ module "federalist_auditor_user" {
 module "blobstore_policy" {
   source        = "../../modules/iam_role_policy/blobstore"
   policy_name   = "blobstore"
-  aws_partition = "${data.aws_partition.current.partition}"
-  bucket_name   = "${var.blobstore_bucket_name}"
+  aws_partition = data.aws_partition.current.partition
+  bucket_name   = var.blobstore_bucket_name
 }
 
 module "bosh_policy" {
   source        = "../../modules/iam_role_policy/bosh"
   policy_name   = "${var.stack_description}-bosh"
-  aws_partition = "${data.aws_partition.current.partition}"
-  account_id    = "${data.aws_caller_identity.current.account_id}"
-  bucket_name   = "${var.blobstore_bucket_name}"
+  aws_partition = data.aws_partition.current.partition
+  account_id    = data.aws_caller_identity.current.account_id
+  bucket_name   = var.blobstore_bucket_name
 }
 
 module "bosh_compilation_policy" {
   source        = "../../modules/iam_role_policy/bosh_compilation"
   policy_name   = "${var.stack_description}-bosh-compilation"
-  aws_partition = "${data.aws_partition.current.partition}"
-  bucket_name   = "${var.blobstore_bucket_name}"
+  aws_partition = data.aws_partition.current.partition
+  bucket_name   = var.blobstore_bucket_name
 }
 
 module "concourse_worker_policy" {
   source                  = "../../modules/iam_role_policy/concourse_worker"
   policy_name             = "concourse-worker"
-  aws_partition           = "${data.aws_partition.current.partition}"
-  varz_bucket             = "${var.varz_bucket}"
-  varz_staging_bucket     = "${var.varz_bucket_stage}"
-  bosh_release_bucket     = "${var.bosh_release_bucket}"
-  terraform_state_bucket  = "${var.terraform_state_bucket}"
-  build_artifacts_bucket  = "${var.build_artifacts_bucket}"
-  semver_bucket           = "${var.semver_bucket}"
-  buildpack_notify_bucket = "${var.buildpack_notify_bucket}"
-  billing_bucket          = "${var.billing_bucket}"
-  cg_binaries_bucket      = "${var.cg_binaries_bucket}"
-  log_bucket              = "${var.log_bucket_name}"
-  concourse_varz_bucket   = "${var.concourse_varz_bucket}"
+  aws_partition           = data.aws_partition.current.partition
+  varz_bucket             = var.varz_bucket
+  varz_staging_bucket     = var.varz_bucket_stage
+  bosh_release_bucket     = var.bosh_release_bucket
+  terraform_state_bucket  = var.terraform_state_bucket
+  build_artifacts_bucket  = var.build_artifacts_bucket
+  semver_bucket           = var.semver_bucket
+  buildpack_notify_bucket = var.buildpack_notify_bucket
+  billing_bucket          = var.billing_bucket
+  cg_binaries_bucket      = var.cg_binaries_bucket
+  log_bucket              = var.log_bucket_name
+  concourse_varz_bucket   = var.concourse_varz_bucket
 }
 
 module "concourse_iaas_worker_policy" {
@@ -89,14 +89,13 @@ module "cloudwatch_policy" {
 module "self_managed_credentials" {
   source        = "../../modules/iam_role_policy/self_managed_credentials"
   policy_name   = "self-managed-credentials"
-  aws_partition = "${data.aws_partition.current.partition}"
+  aws_partition = data.aws_partition.current.partition
 }
 
 module "compliance_role" {
   source        = "../../modules/iam_role_policy/compliance_role"
   policy_name   = "compliance-role"
-  aws_partition = "${data.aws_partition.current.partition}"
-
+  aws_partition = data.aws_partition.current.partition
 }
 
 module "default_role" {
@@ -131,62 +130,87 @@ module "concourse_iaas_worker_role" {
 
 resource "aws_iam_policy_attachment" "blobstore" {
   name       = "${var.stack_description}-blobstore"
-  policy_arn = "${module.blobstore_policy.arn}"
+  policy_arn = module.blobstore_policy.arn
 
   roles = [
-    "${module.default_role.role_name}",
-    "${module.bosh_role.role_name}",
-    "${module.concourse_worker_role.role_name}",
-    "${module.concourse_iaas_worker_role.role_name}",
+    module.default_role.role_name,
+    module.bosh_role.role_name,
+    module.concourse_worker_role.role_name,
+    module.concourse_iaas_worker_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "cloudwatch" {
   name       = "${var.stack_description}-cloudwatch"
-  policy_arn = "${module.cloudwatch_policy.arn}"
+  policy_arn = module.cloudwatch_policy.arn
 
   roles = [
-    "${module.default_role.role_name}",
-    "${module.bosh_role.role_name}",
-    "${module.bosh_compilation_role.role_name}",
-    "${module.concourse_worker_role.role_name}",
-    "${module.concourse_iaas_worker_role.role_name}",
+    module.default_role.role_name,
+    module.bosh_role.role_name,
+    module.bosh_compilation_role.role_name,
+    module.concourse_worker_role.role_name,
+    module.concourse_iaas_worker_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "bosh" {
   name       = "${var.stack_description}-bosh"
-  policy_arn = "${module.bosh_policy.arn}"
+  policy_arn = module.bosh_policy.arn
 
   roles = [
-    "${module.master_bosh_role.role_name}",
-    "${module.bosh_role.role_name}",
+    module.master_bosh_role.role_name,
+    module.bosh_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "bosh_compilation" {
   name       = "${var.stack_description}-bosh-compilation"
-  policy_arn = "${module.bosh_compilation_policy.arn}"
+  policy_arn = module.bosh_compilation_policy.arn
 
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.bosh_compilation_role.role_name}",
+    module.bosh_compilation_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "concourse_worker" {
   name       = "concourse_worker"
-  policy_arn = "${module.concourse_worker_policy.arn}"
+  policy_arn = module.concourse_worker_policy.arn
 
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.concourse_worker_role.role_name}",
+    module.concourse_worker_role.role_name,
   ]
 }
 
 resource "aws_iam_policy_attachment" "concourse_iaas_worker" {
   name       = "concourse_iaas_worker"
-  policy_arn = "${module.concourse_iaas_worker_policy.arn}"
+  policy_arn = module.concourse_iaas_worker_policy.arn
 
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   roles = [
-    "${module.concourse_iaas_worker_role.role_name}",
+    module.concourse_iaas_worker_role.role_name,
   ]
 }
+

--- a/terraform/stacks/tooling/nessus_elb.tf
+++ b/terraform/stacks/tooling/nessus_elb.tf
@@ -2,29 +2,30 @@ resource "aws_lb_target_group" "nessus_target" {
   name     = "${var.stack_description}-nessus"
   port     = 8834
   protocol = "HTTPS"
-  vpc_id   = "${module.stack.vpc_id}"
+  vpc_id   = module.stack.vpc_id
 
   health_check {
-    protocol = "HTTPS"
-    healthy_threshold = 2
-    interval = 61
-    timeout = 60
+    protocol            = "HTTPS"
+    healthy_threshold   = 2
+    interval            = 61
+    timeout             = 60
     unhealthy_threshold = 3
-    matcher = 200
+    matcher             = 200
   }
 }
 
 resource "aws_lb_listener_rule" "nessus_listener_rule" {
-  listener_arn = "${aws_lb_listener.main.arn}"
+  listener_arn = aws_lb_listener.main.arn
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.nessus_target.arn}"
+    target_group_arn = aws_lb_target_group.nessus_target.arn
   }
 
   condition {
     host_header {
-      values = ["${var.nessus_hosts}"]
+      values = var.nessus_hosts
     }
   }
 }
+

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -1,37 +1,39 @@
-variable "opsuaa_rds_password" {}
+variable "opsuaa_rds_password" {
+}
 
 module "opsuaa_db" {
   source = "../../modules/rds"
 
-  stack_description = "${var.stack_description}"
-  rds_instance_type = "db.t2.medium"
-  rds_db_name = "opsuaa"
-  rds_username = "opsuaa"
-  rds_password = "${var.opsuaa_rds_password}"
-  rds_subnet_group = "${module.stack.rds_subnet_group}"
-  rds_security_groups = ["${module.stack.rds_postgres_security_group}"]
+  stack_description   = var.stack_description
+  rds_instance_type   = "db.t2.medium"
+  rds_db_name         = "opsuaa"
+  rds_username        = "opsuaa"
+  rds_password        = var.opsuaa_rds_password
+  rds_subnet_group    = module.stack.rds_subnet_group
+  rds_security_groups = [module.stack.rds_postgres_security_group]
 }
 
 output "opsuaa_rds_url" {
-  value = "${module.opsuaa_db.rds_url}"
+  value = module.opsuaa_db.rds_url
 }
 
 output "opsuaa_rds_host" {
-  value = "${module.opsuaa_db.rds_host}"
+  value = module.opsuaa_db.rds_host
 }
 
 output "opsuaa_rds_port" {
-  value = "${module.opsuaa_db.rds_port}"
+  value = module.opsuaa_db.rds_port
 }
 
 output "opsuaa_rds_username" {
-  value = "${module.opsuaa_db.rds_username}"
+  value = module.opsuaa_db.rds_username
 }
 
 output "opsuaa_rds_password" {
-  value = "${module.opsuaa_db.rds_password}"
+  value = module.opsuaa_db.rds_password
 }
 
 output "opsuaa_rds_engine" {
-  value = "${module.opsuaa_db.rds_engine}"
+  value = module.opsuaa_db.rds_engine
 }
+

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -1,541 +1,638 @@
 # Declare values used in multiple outputs
 locals {
-  private_subnet_az1_reserved = "${cidrhost("${module.stack.private_cidr_az1}", 0)} - ${cidrhost("${module.stack.private_cidr_az1}", 3)}"
-  private_subnet_az2_reserved = "${cidrhost("${module.stack.private_cidr_az2}", 0)} - ${cidrhost("${module.stack.private_cidr_az2}", 3)}"
-  master_bosh_static_ip = "${cidrhost("${module.stack.private_cidr_az1}", 6)}"
-  bosh_static_ip = "${cidrhost("${module.stack.private_cidr_az1}", 7)}"
+  private_subnet_az1_reserved = "${cidrhost(module.stack.private_cidr_az1, 0)} - ${cidrhost(module.stack.private_cidr_az1, 3)}"
+  private_subnet_az2_reserved = "${cidrhost(module.stack.private_cidr_az2, 0)} - ${cidrhost(module.stack.private_cidr_az2, 3)}"
+  master_bosh_static_ip       = cidrhost(module.stack.private_cidr_az1, 6)
+  bosh_static_ip              = cidrhost(module.stack.private_cidr_az1, 7)
   bosh_uaa_static_ips = [
-    "${cidrhost("${module.stack.private_cidr_az1}", 4)}",
-    "${cidrhost("${module.stack.private_cidr_az1}", 5)}"
+    cidrhost(module.stack.private_cidr_az1, 4),
+    cidrhost(module.stack.private_cidr_az1, 5),
   ]
   staging_dns_private_ips = [
-    "${cidrhost("${module.stack.private_cidr_az1}", 8)}",
-    "${cidrhost("${module.stack.private_cidr_az1}", 9)}"
+    cidrhost(module.stack.private_cidr_az1, 8),
+    cidrhost(module.stack.private_cidr_az1, 9),
   ]
   production_dns_private_ips = [
-    "${cidrhost("${module.stack.private_cidr_az1}", 10)}",
-    "${cidrhost("${module.stack.private_cidr_az1}", 11)}"
+    cidrhost(module.stack.private_cidr_az1, 10),
+    cidrhost(module.stack.private_cidr_az1, 11),
   ]
-  production_smtp_private_ip = "${cidrhost("${module.stack.private_cidr_az1}", 12)}"
+  production_smtp_private_ip = cidrhost(module.stack.private_cidr_az1, 12)
 }
 
 output "az1" {
-  value = "${data.aws_availability_zones.available.names[0]}"
+  value = data.aws_availability_zones.available.names[0]
 }
+
 output "az2" {
-  value = "${data.aws_availability_zones.available.names[1]}"
+  value = data.aws_availability_zones.available.names[1]
 }
+
 output "stack_description" {
-  value = "${var.stack_description}"
+  value = var.stack_description
 }
 
 /* VPC */
 output "vpc_region" {
-  value = "${var.aws_default_region}"
+  value = var.aws_default_region
 }
+
 output "vpc_id" {
-  value = "${module.stack.vpc_id}"
+  value = module.stack.vpc_id
 }
+
 output "vpc_cidr" {
-  value = "${module.stack.vpc_cidr}"
+  value = module.stack.vpc_cidr
 }
+
 output "vpc_cidr_dns" {
-  value = "${cidrhost("${module.stack.vpc_cidr}", 2)}"
+  value = cidrhost(module.stack.vpc_cidr, 2)
 }
 
 /* Private network */
 output "private_subnet_az1" {
-  value = "${module.stack.private_subnet_az1}"
+  value = module.stack.private_subnet_az1
 }
+
 output "private_subnet_az2" {
-  value = "${module.stack.private_subnet_az2}"
+  value = module.stack.private_subnet_az2
 }
 
 output "private_route_table_az1" {
-  value = "${module.stack.private_route_table_az1}"
+  value = module.stack.private_route_table_az1
 }
+
 output "private_route_table_az2" {
-  value = "${module.stack.private_route_table_az2}"
+  value = module.stack.private_route_table_az2
 }
 
 output "private_subnet_az1_cidr" {
-  value = "${module.stack.private_cidr_az1}"
+  value = module.stack.private_cidr_az1
 }
+
 output "private_subnet_az2_cidr" {
-  value = "${module.stack.private_cidr_az2}"
+  value = module.stack.private_cidr_az2
 }
 
 output "master_bosh_reserved" {
-  value = "${concat(
-    list("${local.private_subnet_az1_reserved}"),
-    list("${local.master_bosh_static_ip}"),
+  value = concat(
+    [local.private_subnet_az1_reserved],
+    [local.master_bosh_static_ip],
     local.bosh_uaa_static_ips,
     local.staging_dns_private_ips,
     local.production_dns_private_ips,
-    list("${local.production_smtp_private_ip}")
-  )}"
+    [local.production_smtp_private_ip],
+  )
 }
 
 output "private_subnet_az1_reserved" {
-  value = "${local.private_subnet_az1_reserved}"
+  value = local.private_subnet_az1_reserved
 }
 
 output "private_subnet_az2_reserved" {
-  value = "${local.private_subnet_az2_reserved}"
+  value = local.private_subnet_az2_reserved
 }
 
 output "private_subnet_az1_gateway" {
-  value = "${cidrhost("${module.stack.private_cidr_az1}", 1)}"
+  value = cidrhost(module.stack.private_cidr_az1, 1)
 }
 
 output "private_subnet_az2_gateway" {
-  value = "${cidrhost("${module.stack.private_cidr_az2}", 1)}"
+  value = cidrhost(module.stack.private_cidr_az2, 1)
 }
 
 output "production_monitoring_subnet_reserved" {
-  value = "${cidrhost("${module.monitoring_production.monitoring_cidr}", 0)} - ${cidrhost("${module.monitoring_production.monitoring_cidr}", 3)}"
+  value = "${cidrhost(module.monitoring_production.monitoring_cidr, 0)} - ${cidrhost(module.monitoring_production.monitoring_cidr, 3)}"
 }
+
 output "staging_monitoring_subnet_reserved" {
-  value = "${cidrhost("${module.monitoring_staging.monitoring_cidr}", 0)} - ${cidrhost("${module.monitoring_staging.monitoring_cidr}", 3)}"
+  value = "${cidrhost(module.monitoring_staging.monitoring_cidr, 0)} - ${cidrhost(module.monitoring_staging.monitoring_cidr, 3)}"
 }
 
 output "production_monitoring_subnet_cidr" {
-  value = "${module.monitoring_production.monitoring_cidr}"
+  value = module.monitoring_production.monitoring_cidr
 }
+
 output "staging_monitoring_subnet_cidr" {
-  value = "${module.monitoring_staging.monitoring_cidr}"
+  value = module.monitoring_staging.monitoring_cidr
 }
 
 output "production_monitoring_subnet_gateway" {
-  value = "${cidrhost("${module.monitoring_production.monitoring_cidr}", 1)}"
+  value = cidrhost(module.monitoring_production.monitoring_cidr, 1)
 }
+
 output "staging_monitoring_subnet_gateway" {
-  value = "${cidrhost("${module.monitoring_staging.monitoring_cidr}", 1)}"
+  value = cidrhost(module.monitoring_staging.monitoring_cidr, 1)
 }
 
 output "master_bosh_static_ip" {
-  value = "${local.master_bosh_static_ip}"
+  value = local.master_bosh_static_ip
 }
+
 output "tooling_bosh_static_ip" {
-  value = "${local.bosh_static_ip}"
+  value = local.bosh_static_ip
 }
+
 output "bosh_static_ip" {
-  value = "${local.bosh_static_ip}"
+  value = local.bosh_static_ip
 }
+
 output "bosh_uaa_static_ips" {
-  value = ["${local.bosh_uaa_static_ips}"]
+  value = [local.bosh_uaa_static_ips]
 }
+
 output "bosh_network_static_ips" {
-  value = "${concat(
-    list("${local.bosh_static_ip}"),
-    local.bosh_uaa_static_ips
-  )}"
+  value = concat([local.bosh_static_ip], local.bosh_uaa_static_ips)
 }
 
 /* Public network */
 output "public_subnet_az1" {
-  value = "${module.stack.public_subnet_az1}"
+  value = module.stack.public_subnet_az1
 }
+
 output "public_subnet_az2" {
-  value = "${module.stack.public_subnet_az2}"
+  value = module.stack.public_subnet_az2
 }
+
 output "public_subnet_az1_cidr" {
-  value = "${module.stack.public_cidr_az1}"
+  value = module.stack.public_cidr_az1
 }
+
 output "public_subnet_az2_cidr" {
-  value = "${module.stack.public_cidr_az2}"
+  value = module.stack.public_cidr_az2
 }
 
 output "public_route_table" {
-  value = "${module.stack.public_route_table}"
+  value = module.stack.public_route_table
 }
+
 output "nat_egress_ip_az1" {
-  value = "${module.stack.nat_egress_ip_az1}"
+  value = module.stack.nat_egress_ip_az1
 }
+
 output "nat_egress_ip_az2" {
-  value = "${module.stack.nat_egress_ip_az2}"
+  value = module.stack.nat_egress_ip_az2
 }
 
 /* Security Groups */
 output "bosh_security_group" {
-  value = "${module.stack.bosh_security_group}"
+  value = module.stack.bosh_security_group
 }
+
 output "local_vpc_traffic_security_group" {
-    value = "${module.stack.local_vpc_traffic_security_group}"
+  value = module.stack.local_vpc_traffic_security_group
 }
+
 output "web_traffic_security_group" {
-  value = "${module.stack.web_traffic_security_group}"
+  value = module.stack.web_traffic_security_group
 }
+
 output "nessus_security_group" {
-  value = "${aws_security_group.nessus_traffic.id}"
+  value = aws_security_group.nessus_traffic.id
 }
+
 output "bosh_uaa_security_group" {
-  value = "${aws_security_group.bosh_uaa_traffic.id}"
+  value = aws_security_group.bosh_uaa_traffic.id
 }
 
 /* RDS Network */
 output "rds_subnet_az1" {
-  value = "${module.stack.rds_subnet_az1}"
+  value = module.stack.rds_subnet_az1
 }
+
 output "rds_subnet_az2" {
-  value = "${module.stack.rds_subnet_az2}"
+  value = module.stack.rds_subnet_az2
 }
+
 output "rds_subnet_group" {
-  value = "${module.stack.rds_subnet_group}"
+  value = module.stack.rds_subnet_group
 }
+
 output "rds_mysql_security_group" {
-  value = "${module.stack.rds_mysql_security_group}"
+  value = module.stack.rds_mysql_security_group
 }
+
 output "rds_postgres_security_group" {
-  value = "${module.stack.rds_postgres_security_group}"
+  value = module.stack.rds_postgres_security_group
 }
+
 output "rds_mssql_security_group" {
-  value = "${module.stack.rds_mssql_security_group}"
+  value = module.stack.rds_mssql_security_group
 }
+
 output "rds_oracle_security_group" {
-  value = "${module.stack.rds_oracle_security_group}"
+  value = module.stack.rds_oracle_security_group
 }
 
 /* RDS Bosh Instance */
 output "bosh_rds_url_curr" {
-  value = "${module.stack.bosh_rds_url_curr}"
+  value = module.stack.bosh_rds_url_curr
 }
+
 output "bosh_rds_host_curr" {
-  value = "${module.stack.bosh_rds_host_curr}"
+  value = module.stack.bosh_rds_host_curr
 }
+
 output "bosh_rds_url_prev" {
-  value = "${module.stack.bosh_rds_url_prev}"
+  value = module.stack.bosh_rds_url_prev
 }
+
 output "bosh_rds_host_prev" {
-  value = "${module.stack.bosh_rds_host_prev}"
+  value = module.stack.bosh_rds_host_prev
 }
+
 output "bosh_rds_port" {
-  value = "${module.stack.bosh_rds_port}"
+  value = module.stack.bosh_rds_port
 }
+
 output "bosh_rds_username" {
-  value = "${module.stack.bosh_rds_username}"
+  value = module.stack.bosh_rds_username
 }
+
 output "bosh_rds_password" {
-  value = "${module.stack.bosh_rds_password}"
+  value = module.stack.bosh_rds_password
 }
 
 /* CredHub RDS */
 output "credhub_rds_url" {
-  value = "${module.stack.credhub_rds_url}"
+  value = module.stack.credhub_rds_url
 }
+
 output "credhub_rds_host" {
-  value = "${module.stack.credhub_rds_host}"
+  value = module.stack.credhub_rds_host
 }
+
 output "credhub_rds_port" {
-  value = "${module.stack.credhub_rds_port}"
+  value = module.stack.credhub_rds_port
 }
+
 output "credhub_rds_username" {
-  value = "${module.stack.credhub_rds_username}"
+  value = module.stack.credhub_rds_username
 }
+
 output "credhub_rds_password" {
-  value = "${module.stack.credhub_rds_password}"
+  value = module.stack.credhub_rds_password
 }
 
 /* Main LB */
 output "main_lb_name" {
-  value = "${aws_lb.main.name}"
+  value = aws_lb.main.name
 }
+
 output "main_lb_dns_name" {
-  value = "${aws_lb.main.dns_name}"
+  value = aws_lb.main.dns_name
 }
 
 /* Production Concourse */
 output "production_concourse_subnet" {
-  value = "${module.concourse_production.concourse_subnet}"
+  value = module.concourse_production.concourse_subnet
 }
+
 output "production_concourse_subnet_reserved" {
-  value = "${cidrhost("${module.concourse_production.concourse_subnet_cidr}", 0)} - ${cidrhost("${module.concourse_production.concourse_subnet_cidr}", 3)}"
+  value = "${cidrhost(module.concourse_production.concourse_subnet_cidr, 0)} - ${cidrhost(module.concourse_production.concourse_subnet_cidr, 3)}"
 }
+
 output "production_concourse_subnet_cidr" {
-  value = "${module.concourse_production.concourse_subnet_cidr}"
+  value = module.concourse_production.concourse_subnet_cidr
 }
+
 output "production_concourse_subnet_gateway" {
-  value = "${cidrhost("${module.concourse_production.concourse_subnet_cidr}", 1)}"
+  value = cidrhost(module.concourse_production.concourse_subnet_cidr, 1)
 }
+
 output "production_concourse_security_group" {
-  value = "${module.concourse_production.concourse_security_group}"
+  value = module.concourse_production.concourse_security_group
 }
+
 output "production_concourse_rds_identifier" {
-  value = "${module.concourse_production.concourse_rds_identifier}"
+  value = module.concourse_production.concourse_rds_identifier
 }
+
 output "production_concourse_rds_name" {
-  value = "${module.concourse_production.concourse_rds_name}"
+  value = module.concourse_production.concourse_rds_name
 }
+
 output "production_concourse_rds_host" {
-  value = "${module.concourse_production.concourse_rds_host}"
+  value = module.concourse_production.concourse_rds_host
 }
+
 output "production_concourse_rds_port" {
-  value = "${module.concourse_production.concourse_rds_port}"
+  value = module.concourse_production.concourse_rds_port
 }
+
 output "production_concourse_rds_url" {
-  value = "${module.concourse_production.concourse_rds_url}"
+  value = module.concourse_production.concourse_rds_url
 }
+
 output "production_concourse_rds_username" {
-  value = "${module.concourse_production.concourse_rds_username}"
+  value = module.concourse_production.concourse_rds_username
 }
+
 output "production_concourse_rds_password" {
-  value = "${module.concourse_production.concourse_rds_password}"
+  value = module.concourse_production.concourse_rds_password
 }
+
 output "production_concourse_lb_target_group" {
-  value = "${module.concourse_production.concourse_lb_target_group}"
+  value = module.concourse_production.concourse_lb_target_group
 }
 
 /* Staging Concourse */
 output "staging_concourse_subnet" {
-  value = "${module.concourse_staging.concourse_subnet}"
+  value = module.concourse_staging.concourse_subnet
 }
+
 output "staging_concourse_subnet_reserved" {
-  value = "${cidrhost("${module.concourse_staging.concourse_subnet_cidr}", 0)} - ${cidrhost("${module.concourse_staging.concourse_subnet_cidr}", 3)}"
+  value = "${cidrhost(module.concourse_staging.concourse_subnet_cidr, 0)} - ${cidrhost(module.concourse_staging.concourse_subnet_cidr, 3)}"
 }
+
 output "staging_concourse_subnet_cidr" {
-  value = "${module.concourse_staging.concourse_subnet_cidr}"
+  value = module.concourse_staging.concourse_subnet_cidr
 }
+
 output "staging_concourse_subnet_gateway" {
-  value = "${cidrhost("${module.concourse_staging.concourse_subnet_cidr}", 1)}"
+  value = cidrhost(module.concourse_staging.concourse_subnet_cidr, 1)
 }
+
 output "staging_concourse_security_group" {
-  value = "${module.concourse_staging.concourse_security_group}"
+  value = module.concourse_staging.concourse_security_group
 }
+
 output "staging_concourse_rds_identifier" {
-  value = "${module.concourse_staging.concourse_rds_identifier}"
+  value = module.concourse_staging.concourse_rds_identifier
 }
+
 output "staging_concourse_rds_name" {
-  value = "${module.concourse_staging.concourse_rds_name}"
+  value = module.concourse_staging.concourse_rds_name
 }
+
 output "staging_concourse_rds_host" {
-  value = "${module.concourse_staging.concourse_rds_host}"
+  value = module.concourse_staging.concourse_rds_host
 }
+
 output "staging_concourse_rds_port" {
-  value = "${module.concourse_staging.concourse_rds_port}"
+  value = module.concourse_staging.concourse_rds_port
 }
+
 output "staging_concourse_rds_url" {
-  value = "${module.concourse_staging.concourse_rds_url}"
+  value = module.concourse_staging.concourse_rds_url
 }
+
 output "staging_concourse_rds_username" {
-  value = "${module.concourse_staging.concourse_rds_username}"
+  value = module.concourse_staging.concourse_rds_username
 }
+
 output "staging_concourse_rds_password" {
-  value = "${module.concourse_staging.concourse_rds_password}"
+  value = module.concourse_staging.concourse_rds_password
 }
+
 output "staging_concourse_lb_target_group" {
-  value = "${module.concourse_staging.concourse_lb_target_group}"
+  value = module.concourse_staging.concourse_lb_target_group
 }
 
 /* Production Monitoring */
 output "production_monitoring_az" {
-  value = "${module.monitoring_production.monitoring_az}"
+  value = module.monitoring_production.monitoring_az
 }
+
 output "production_monitoring_subnet" {
-  value = "${module.monitoring_production.monitoring_subnet}"
+  value = module.monitoring_production.monitoring_subnet
 }
+
 output "production_monitoring_security_group" {
-  value = "${module.monitoring_production.monitoring_security_group}"
+  value = module.monitoring_production.monitoring_security_group
 }
+
 output "production_monitoring_lb_target_group" {
-  value = "${module.monitoring_production.lb_target_group}"
+  value = module.monitoring_production.lb_target_group
 }
 
 output "production_doomsday_lb_target_group" {
-  value = "${module.monitoring_production.doomsday_lb_target_group}"
+  value = module.monitoring_production.doomsday_lb_target_group
 }
 
 output "monitoring_security_groups" {
   value = {
-    staging = "${module.monitoring_staging.monitoring_security_group}"
-    development = "${module.monitoring_staging.monitoring_security_group}"
-    production = "${module.monitoring_production.monitoring_security_group}"
+    staging     = module.monitoring_staging.monitoring_security_group
+    development = module.monitoring_staging.monitoring_security_group
+    production  = module.monitoring_production.monitoring_security_group
   }
 }
 
 /* Staging Monitoring */
 output "staging_monitoring_az" {
-  value = "${module.monitoring_staging.monitoring_az}"
+  value = module.monitoring_staging.monitoring_az
 }
+
 output "staging_monitoring_subnet" {
-  value = "${module.monitoring_staging.monitoring_subnet}"
+  value = module.monitoring_staging.monitoring_subnet
 }
+
 output "staging_monitoring_security_group" {
-  value = "${module.monitoring_staging.monitoring_security_group}"
+  value = module.monitoring_staging.monitoring_security_group
 }
+
 output "staging_monitoring_lb_target_group" {
-  value = "${module.monitoring_staging.lb_target_group}"
+  value = module.monitoring_staging.lb_target_group
 }
 
 output "staging_doomsday_lb_target_group" {
-  value = "${module.monitoring_staging.doomsday_lb_target_group}"
+  value = module.monitoring_staging.doomsday_lb_target_group
 }
 
 /* billing user */
 output "billing_username" {
-  value = "${module.billing_user.username}"
+  value = module.billing_user.username
 }
+
 output "billing_access_key_id_prev" {
-  value = "${module.billing_user.access_key_id_prev}"
+  value = module.billing_user.access_key_id_prev
 }
+
 output "billing_secret_access_key_prev" {
-  value = "${module.billing_user.secret_access_key_prev}"
+  value = module.billing_user.secret_access_key_prev
 }
+
 output "billing_access_key_id_curr" {
-  value = "${module.billing_user.access_key_id_curr}"
+  value = module.billing_user.access_key_id_curr
 }
+
 output "billing_secret_access_key_curr" {
-  value = "${module.billing_user.secret_access_key_curr}"
+  value = module.billing_user.secret_access_key_curr
 }
 
 /* federalist auditor user */
 output "federalist_auditor_username" {
-  value = "${module.federalist_auditor_user.username}"
+  value = module.federalist_auditor_user.username
 }
+
 output "federalist_auditor_access_key_id_prev" {
-  value = "${module.federalist_auditor_user.access_key_id_prev}"
+  value = module.federalist_auditor_user.access_key_id_prev
 }
+
 output "federalist_auditor_secret_access_key_prev" {
-  value = "${module.federalist_auditor_user.secret_access_key_prev}"
+  value = module.federalist_auditor_user.secret_access_key_prev
 }
+
 output "federalist_auditor_access_key_id_curr" {
-  value = "${module.federalist_auditor_user.access_key_id_curr}"
+  value = module.federalist_auditor_user.access_key_id_curr
 }
+
 output "federalist_auditor_secret_access_key_curr" {
-  value = "${module.federalist_auditor_user.secret_access_key_curr}"
+  value = module.federalist_auditor_user.secret_access_key_curr
 }
 
 /* s3 logstash user */
 output "s3_logstash_username" {
-  value = "${module.s3_logstash.username}"
+  value = module.s3_logstash.username
 }
+
 output "s3_logstash_access_key_id_prev" {
-  value = "${module.s3_logstash.access_key_id_prev}"
+  value = module.s3_logstash.access_key_id_prev
 }
+
 output "s3_logstash_secret_access_key_prev" {
-  value = "${module.s3_logstash.secret_access_key_prev}"
+  value = module.s3_logstash.secret_access_key_prev
 }
+
 output "s3_logstash_access_key_id_curr" {
-  value = "${module.s3_logstash.access_key_id_curr}"
+  value = module.s3_logstash.access_key_id_curr
 }
+
 output "s3_logstash_secret_access_key_curr" {
-  value = "${module.s3_logstash.secret_access_key_curr}"
+  value = module.s3_logstash.secret_access_key_curr
 }
 
 /* rds storage user */
 output "rds_storage_alert_username" {
-  value = "${module.rds_storage_alert.username}"
+  value = module.rds_storage_alert.username
 }
+
 output "rds_storage_alert_access_key_id" {
-  value = "${module.rds_storage_alert.access_key_id}"
+  value = module.rds_storage_alert.access_key_id
 }
+
 output "rds_storage_alert_secret_access_key" {
-  value = "${module.rds_storage_alert.secret_access_key}"
+  value = module.rds_storage_alert.secret_access_key
 }
 
 /* iam cert provision user */
 output "iam_cert_provision_username" {
-  value = "${module.iam_cert_provision_user.username}"
+  value = module.iam_cert_provision_user.username
 }
+
 output "iam_cert_provision_access_key_id_prev" {
-  value = "${module.iam_cert_provision_user.access_key_id_prev}"
+  value = module.iam_cert_provision_user.access_key_id_prev
 }
+
 output "iam_cert_provision_secret_access_key_prev" {
-  value = "${module.iam_cert_provision_user.secret_access_key_prev}"
+  value = module.iam_cert_provision_user.secret_access_key_prev
 }
+
 output "iam_cert_provision_access_key_id_curr" {
-  value = "${module.iam_cert_provision_user.access_key_id_curr}"
+  value = module.iam_cert_provision_user.access_key_id_curr
 }
+
 output "iam_cert_provision_secret_access_key_curr" {
-  value = "${module.iam_cert_provision_user.secret_access_key_curr}"
+  value = module.iam_cert_provision_user.secret_access_key_curr
 }
 
 /* iam roles */
 output "default_profile" {
-  value = "${module.default_role.profile_name}"
+  value = module.default_role.profile_name
 }
+
 output "master_bosh_profile" {
-  value = "${module.master_bosh_role.profile_name}"
+  value = module.master_bosh_role.profile_name
 }
+
 output "bosh_profile" {
-  value = "${module.bosh_role.profile_name}"
+  value = module.bosh_role.profile_name
 }
+
 output "bosh_compilation_profile" {
-  value = "${module.bosh_compilation_role.profile_name}"
+  value = module.bosh_compilation_role.profile_name
 }
+
 output "concourse_worker_profile" {
-  value = "${module.concourse_worker_role.profile_name}"
+  value = module.concourse_worker_role.profile_name
 }
+
 output "concourse_iaas_worker_profile" {
-  value = "${module.concourse_iaas_worker_role.profile_name}"
+  value = module.concourse_iaas_worker_role.profile_name
 }
 
 /* nessus elb */
 output "nessus_target_group" {
-  value = "${aws_lb_target_group.nessus_target.name}"
+  value = aws_lb_target_group.nessus_target.name
 }
 
 output "nessus_static_ip" {
-  value = "${cidrhost("${module.stack.private_cidr_az1}", 71)}"
+  value = cidrhost(module.stack.private_cidr_az1, 71)
 }
 
 /* BOSH UAA elb */
 output "opsuaa_lb_dns_name" {
-  value = "${aws_lb.opsuaa.dns_name}"
+  value = aws_lb.opsuaa.dns_name
 }
+
 output "opsuaa_lb_name" {
-  value = "${aws_lb.opsuaa.name}"
+  value = aws_lb.opsuaa.name
 }
+
 output "opsuaa_target_group" {
-  value = "${aws_lb_target_group.opsuaa_target.name}"
+  value = aws_lb_target_group.opsuaa_target.name
 }
 
 /* DNS static IPs */
 output "staging_dns_public_ips" {
-  value = ["${aws_eip.staging_dns_eip.*.public_ip}"]
+  value = [aws_eip.staging_dns_eip.*.public_ip]
 }
 
 output "dns_axfr_security_group" {
-  value = "${module.dns.axfr_security_group}"
+  value = module.dns.axfr_security_group
 }
+
 output "dns_public_security_group" {
-  value = "${module.dns.public_security_group}"
+  value = module.dns.public_security_group
 }
 
 output "staging_dns_private_ips" {
-  value = ["${local.staging_dns_private_ips}"]
+  value = [local.staging_dns_private_ips]
 }
 
 output "production_dns_public_ips" {
-  value = ["${aws_eip.production_dns_eip.*.public_ip}"]
+  value = [aws_eip.production_dns_eip.*.public_ip]
 }
 
 output "production_dns_private_ips" {
-  value = ["${local.production_dns_private_ips}"]
+  value = [local.production_dns_private_ips]
 }
 
 output "dns_private_ips" {
-  value = "${concat(
+  value = concat(
     local.production_dns_private_ips,
-    local.staging_dns_private_ips
-  )}"
+    local.staging_dns_private_ips,
+  )
 }
 
 /* Bucket names */
 output "bosh_blobstore_bucket" {
-  value = "${module.bosh_blobstore_bucket.bucket_name}"
+  value = module.bosh_blobstore_bucket.bucket_name
 }
+
 output "buildpack_notify_state_staging_bucket_name" {
-  value = "${module.buildpack_notify_state_staging.bucket_name}"
+  value = module.buildpack_notify_state_staging.bucket_name
 }
+
 output "buildpack_notify_state_production_bucket_name" {
-  value = "${module.buildpack_notify_state_production.bucket_name}"
+  value = module.buildpack_notify_state_production.bucket_name
 }
 
 /* smtp security group */
 output "smtp_security_group" {
-  value = "${module.smtp.smtp_security_group}"
+  value = module.smtp.smtp_security_group
 }
 
 output "production_smtp_private_ip" {
-  value = "${local.production_smtp_private_ip}"
+  value = local.production_smtp_private_ip
 }
+

--- a/terraform/stacks/tooling/read_only_access_restrictions.tf
+++ b/terraform/stacks/tooling/read_only_access_restrictions.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "read_only_access_restrictions" {
-  name = "ReadOnlyAccessRestrictions"
+  name        = "ReadOnlyAccessRestrictions"
   description = "Use in combination with Amazon managed ReadOnlyAccess policy."
 
   policy = <<EOF
@@ -26,4 +26,6 @@ resource "aws_iam_policy" "read_only_access_restrictions" {
   ]
 }
 EOF
+
 }
+

--- a/terraform/stacks/tooling/s3-logs.tf
+++ b/terraform/stacks/tooling/s3-logs.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "cg-s3-cloudtrail-bucket" {
-  bucket        = "${var.cloudtrail_bucket}"
+  bucket        = var.cloudtrail_bucket
   force_destroy = true
 
   policy = <<POLICY
@@ -32,13 +32,14 @@ resource "aws_s3_bucket" "cg-s3-cloudtrail-bucket" {
     ]
 }
 POLICY
+
 }
 
-resource "aws_cloudtrail" "cg-s3-cloudtrail-trail"{
-  name                          = "s3-audit-logs"
-  s3_bucket_name                = "${aws_s3_bucket.cg-s3-cloudtrail-bucket.id}"
+resource "aws_cloudtrail" "cg-s3-cloudtrail-trail" {
+  name           = "s3-audit-logs"
+  s3_bucket_name = aws_s3_bucket.cg-s3-cloudtrail-bucket.id
   event_selector {
-    read_write_type = "All"
+    read_write_type           = "All"
     include_management_events = true
 
     data_resource {
@@ -47,3 +48,4 @@ resource "aws_cloudtrail" "cg-s3-cloudtrail-trail"{
     }
   }
 }
+

--- a/terraform/stacks/tooling/sg_elb_uaa.tf
+++ b/terraform/stacks/tooling/sg_elb_uaa.tf
@@ -1,22 +1,23 @@
 resource "aws_security_group" "bosh_uaa_traffic" {
   description = "Allow access to incoming BOSH UAA traffic for operations"
-  vpc_id = "${module.stack.vpc_id}"
+  vpc_id      = module.stack.vpc_id
 
   ingress {
-    from_port = 8081
-    to_port = 8081
-    protocol = "tcp"
+    from_port   = 8081
+    to_port     = 8081
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
+  tags = {
     Name = "${var.stack_description} - Incoming BOSH UAA Traffic for operations"
   }
 }
+

--- a/terraform/stacks/tooling/sg_nessus.tf
+++ b/terraform/stacks/tooling/sg_nessus.tf
@@ -8,24 +8,24 @@
 
 resource "aws_security_group" "nessus_traffic" {
   description = "Allow access to incoming nessus traffic"
-  vpc_id = "${module.stack.vpc_id}"
+  vpc_id      = module.stack.vpc_id
 
   ingress {
-    from_port = 8834
-    to_port = 8834
-    protocol = "tcp"
+    from_port   = 8834
+    to_port     = 8834
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags =  {
+  tags = {
     Name = "${var.stack_description} - Incoming Nessus Traffic"
   }
-
 }
+

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -1,48 +1,64 @@
 terraform {
-  backend "s3" {}
+  backend "s3" {
+  }
 }
 
 provider "aws" {
   version = "~> 2.40"
 }
 
-data "aws_partition" "current" {}
-data "aws_caller_identity" "current" {}
-data "aws_availability_zones" "available" {}
-data "aws_region" "current" {}
+data "aws_partition" "current" {
+}
+
+data "aws_caller_identity" "current" {
+}
+
+data "aws_availability_zones" "available" {
+}
+
+data "aws_region" "current" {
+}
 
 data "aws_iam_server_certificate" "wildcard_production" {
-  name_prefix = "${var.wildcard_production_certificate_name_prefix}"
-  latest = true
+  name_prefix = var.wildcard_production_certificate_name_prefix
+  latest      = true
 }
 
 data "aws_iam_server_certificate" "wildcard_staging" {
-  name_prefix = "${var.wildcard_staging_certificate_name_prefix}"
-  latest = true
+  name_prefix = var.wildcard_staging_certificate_name_prefix
+  latest      = true
 }
 
 resource "aws_lb" "main" {
-  name = "${var.stack_description}-main"
-  subnets = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
-  security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
+  name    = "${var.stack_description}-main"
+  subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibility in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  security_groups = [module.stack.restricted_web_traffic_security_group]
   ip_address_type = "dualstack"
-  idle_timeout = 3600
-  access_logs = {
-      bucket        = "${var.log_bucket_name}"
-      prefix        = "${var.stack_description}"
-      enabled       = true
+  idle_timeout    = 3600
+  access_logs {
+    bucket  = var.log_bucket_name
+    prefix  = var.stack_description
+    enabled = true
   }
 }
 
 resource "aws_lb_listener" "main" {
-  load_balancer_arn = "${aws_lb.main.arn}"
+  load_balancer_arn = aws_lb.main.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${data.aws_iam_server_certificate.wildcard_production.arn}"
+  certificate_arn   = data.aws_iam_server_certificate.wildcard_production.arn
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.dummy.arn}"
+    target_group_arn = aws_lb_target_group.dummy.arn
     type             = "forward"
   }
 }
@@ -50,103 +66,103 @@ resource "aws_lb_listener" "main" {
 resource "aws_lb_target_group" "dummy" {
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${module.stack.vpc_id}"
+  vpc_id   = module.stack.vpc_id
 }
 
 resource "aws_lb_listener_certificate" "main-staging" {
-  listener_arn    = "${aws_lb_listener.main.arn}"
-  certificate_arn = "${data.aws_iam_server_certificate.wildcard_staging.arn}"
+  listener_arn    = aws_lb_listener.main.arn
+  certificate_arn = data.aws_iam_server_certificate.wildcard_staging.arn
 }
 
 module "stack" {
   source = "../../modules/stack/base"
 
-  stack_description = "${var.stack_description}"
-  vpc_cidr = "${var.vpc_cidr}"
-  az1 = "${data.aws_availability_zones.available.names[0]}"
-  az2 = "${data.aws_availability_zones.available.names[1]}"
-  aws_default_region = "${var.aws_default_region}"
-  public_cidr_1 = "${cidrsubnet(var.vpc_cidr, 8, 100)}"
-  public_cidr_2 = "${cidrsubnet(var.vpc_cidr, 8, 101)}"
-  private_cidr_1 = "${cidrsubnet(var.vpc_cidr, 8, 1)}"
-  private_cidr_2 = "${cidrsubnet(var.vpc_cidr, 8, 2)}"
-  restricted_ingress_web_cidrs = "${var.restricted_ingress_web_cidrs}"
-  restricted_ingress_web_ipv6_cidrs = "${var.restricted_ingress_web_ipv6_cidrs}"
-  rds_private_cidr_1 = "${cidrsubnet(var.vpc_cidr, 8, 20)}"
-  rds_private_cidr_2 = "${cidrsubnet(var.vpc_cidr, 8, 21)}"
-  rds_password = "${var.rds_password}"
-  credhub_rds_password = "${var.credhub_rds_password}"
-  rds_multi_az = "${var.rds_multi_az}"
-  rds_security_groups = ["${module.stack.bosh_security_group}"]
-  rds_security_groups_count = "1"
+  stack_description                 = var.stack_description
+  vpc_cidr                          = var.vpc_cidr
+  az1                               = data.aws_availability_zones.available.names[0]
+  az2                               = data.aws_availability_zones.available.names[1]
+  aws_default_region                = var.aws_default_region
+  public_cidr_1                     = cidrsubnet(var.vpc_cidr, 8, 100)
+  public_cidr_2                     = cidrsubnet(var.vpc_cidr, 8, 101)
+  private_cidr_1                    = cidrsubnet(var.vpc_cidr, 8, 1)
+  private_cidr_2                    = cidrsubnet(var.vpc_cidr, 8, 2)
+  restricted_ingress_web_cidrs      = var.restricted_ingress_web_cidrs
+  restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
+  rds_private_cidr_1                = cidrsubnet(var.vpc_cidr, 8, 20)
+  rds_private_cidr_2                = cidrsubnet(var.vpc_cidr, 8, 21)
+  rds_password                      = var.rds_password
+  credhub_rds_password              = var.credhub_rds_password
+  rds_multi_az                      = var.rds_multi_az
+  rds_security_groups               = [module.stack.bosh_security_group]
+  rds_security_groups_count         = "1"
 }
 
 module "concourse_production" {
-  source = "../../modules/concourse"
-  stack_description = "${var.stack_description}"
-  vpc_id = "${module.stack.vpc_id}"
-  concourse_cidr = "${cidrsubnet(var.vpc_cidr, 8, 30)}"
-  concourse_az = "${data.aws_availability_zones.available.names[0]}"
-  route_table_id = "${module.stack.private_route_table_az1}"
-  rds_password = "${var.concourse_prod_rds_password}"
-  rds_subnet_group = "${module.stack.rds_subnet_group}"
-  rds_security_groups = ["${module.stack.rds_postgres_security_group}"]
-  rds_parameter_group_name = "tooling-concourse-production"
-  rds_instance_type = "db.m4.xlarge"
-  rds_multi_az = "${var.rds_multi_az}"
+  source                        = "../../modules/concourse"
+  stack_description             = var.stack_description
+  vpc_id                        = module.stack.vpc_id
+  concourse_cidr                = cidrsubnet(var.vpc_cidr, 8, 30)
+  concourse_az                  = data.aws_availability_zones.available.names[0]
+  route_table_id                = module.stack.private_route_table_az1
+  rds_password                  = var.concourse_prod_rds_password
+  rds_subnet_group              = module.stack.rds_subnet_group
+  rds_security_groups           = [module.stack.rds_postgres_security_group]
+  rds_parameter_group_name      = "tooling-concourse-production"
+  rds_instance_type             = "db.m4.xlarge"
+  rds_multi_az                  = var.rds_multi_az
   rds_final_snapshot_identifier = "final-snapshot-atc-tooling-production"
-  listener_arn = "${aws_lb_listener.main.arn}"
-  hosts = ["${var.concourse_production_hosts}"]
+  listener_arn                  = aws_lb_listener.main.arn
+  hosts                         = [var.concourse_production_hosts]
 }
 
 module "concourse_staging" {
-  source = "../../modules/concourse"
-  stack_description = "${var.stack_description}"
-  vpc_id = "${module.stack.vpc_id}"
-  concourse_cidr = "${cidrsubnet(var.vpc_cidr, 8, 31)}"
-  concourse_az = "${data.aws_availability_zones.available.names[1]}"
-  route_table_id = "${module.stack.private_route_table_az2}"
-  rds_password = "${var.concourse_staging_rds_password}"
-  rds_subnet_group = "${module.stack.rds_subnet_group}"
-  rds_security_groups = ["${module.stack.rds_postgres_security_group}"]
-  rds_parameter_group_name = "tooling-concourse-staging"
-  rds_instance_type = "db.m4.large"
-  rds_multi_az = "${var.rds_multi_az}"
+  source                        = "../../modules/concourse"
+  stack_description             = var.stack_description
+  vpc_id                        = module.stack.vpc_id
+  concourse_cidr                = cidrsubnet(var.vpc_cidr, 8, 31)
+  concourse_az                  = data.aws_availability_zones.available.names[1]
+  route_table_id                = module.stack.private_route_table_az2
+  rds_password                  = var.concourse_staging_rds_password
+  rds_subnet_group              = module.stack.rds_subnet_group
+  rds_security_groups           = [module.stack.rds_postgres_security_group]
+  rds_parameter_group_name      = "tooling-concourse-staging"
+  rds_instance_type             = "db.m4.large"
+  rds_multi_az                  = var.rds_multi_az
   rds_final_snapshot_identifier = "final-snapshot-atc-tooling-staging"
-  listener_arn = "${aws_lb_listener.main.arn}"
-  hosts = ["${var.concourse_staging_hosts}"]
+  listener_arn                  = aws_lb_listener.main.arn
+  hosts                         = [var.concourse_staging_hosts]
 }
 
 module "monitoring_production" {
-  source = "../../modules/monitoring"
-  stack_description = "production"
-  vpc_id = "${module.stack.vpc_id}"
-  monitoring_cidr = "${cidrsubnet(var.vpc_cidr, 8, 32)}"
-  monitoring_az = "${data.aws_availability_zones.available.names[0]}"
-  route_table_id = "${module.stack.private_route_table_az1}"
-  listener_arn = "${aws_lb_listener.main.arn}"
-  hosts = ["${var.monitoring_production_hosts}"]
-  oidc_client = "${var.oidc_client}"
-  oidc_client_secret = "${var.oidc_client_secret}"
+  source             = "../../modules/monitoring"
+  stack_description  = "production"
+  vpc_id             = module.stack.vpc_id
+  monitoring_cidr    = cidrsubnet(var.vpc_cidr, 8, 32)
+  monitoring_az      = data.aws_availability_zones.available.names[0]
+  route_table_id     = module.stack.private_route_table_az1
+  listener_arn       = aws_lb_listener.main.arn
+  hosts              = [var.monitoring_production_hosts]
+  oidc_client        = var.oidc_client
+  oidc_client_secret = var.oidc_client_secret
 }
 
 module "monitoring_staging" {
-  source = "../../modules/monitoring"
-  stack_description = "staging"
-  vpc_id = "${module.stack.vpc_id}"
-  monitoring_cidr = "${cidrsubnet(var.vpc_cidr, 8, 33)}"
-  monitoring_az = "${data.aws_availability_zones.available.names[1]}"
-  route_table_id = "${module.stack.private_route_table_az2}"
-  listener_arn = "${aws_lb_listener.main.arn}"
-  hosts = ["${var.monitoring_staging_hosts}"]
-  oidc_client = "${var.oidc_client}"
-  oidc_client_secret = "${var.oidc_client_secret}"
+  source             = "../../modules/monitoring"
+  stack_description  = "staging"
+  vpc_id             = module.stack.vpc_id
+  monitoring_cidr    = cidrsubnet(var.vpc_cidr, 8, 33)
+  monitoring_az      = data.aws_availability_zones.available.names[1]
+  route_table_id     = module.stack.private_route_table_az2
+  listener_arn       = aws_lb_listener.main.arn
+  hosts              = [var.monitoring_staging_hosts]
+  oidc_client        = var.oidc_client
+  oidc_client_secret = var.oidc_client_secret
 }
 
 resource "aws_eip" "production_dns_eip" {
   vpc = true
 
-  count = "${var.dns_eip_count_production}"
+  count = var.dns_eip_count_production
 
   lifecycle {
     prevent_destroy = true
@@ -156,7 +172,7 @@ resource "aws_eip" "production_dns_eip" {
 resource "aws_eip" "staging_dns_eip" {
   vpc = true
 
-  count = "${var.dns_eip_count_staging}"
+  count = var.dns_eip_count_staging
 
   lifecycle {
     prevent_destroy = true
@@ -164,14 +180,15 @@ resource "aws_eip" "staging_dns_eip" {
 }
 
 module "dns" {
-  source = "../../modules/dns"
-  stack_description = "${var.stack_description}"
-  vpc_id = "${module.stack.vpc_id}"
+  source            = "../../modules/dns"
+  stack_description = var.stack_description
+  vpc_id            = module.stack.vpc_id
 }
 
 module "smtp" {
-  source = "../../modules/smtp"
-  stack_description = "${var.stack_description}"
-  vpc_id = "${module.stack.vpc_id}"
-  ingress_cidr_blocks = ["${var.smtp_ingress_cidr_blocks}"]
+  source              = "../../modules/smtp"
+  stack_description   = var.stack_description
+  vpc_id              = module.stack.vpc_id
+  ingress_cidr_blocks = [var.smtp_ingress_cidr_blocks]
 }
+

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -32,14 +32,6 @@ data "aws_iam_server_certificate" "wildcard_staging" {
 resource "aws_lb" "main" {
   name    = "${var.stack_description}-main"
   subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibility in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   security_groups = [module.stack.restricted_web_traffic_security_group]
   ip_address_type = "dualstack"
   idle_timeout    = 3600

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -104,7 +104,7 @@ module "concourse_production" {
   rds_multi_az                  = var.rds_multi_az
   rds_final_snapshot_identifier = "final-snapshot-atc-tooling-production"
   listener_arn                  = aws_lb_listener.main.arn
-  hosts                         = [var.concourse_production_hosts]
+  hosts                         = var.concourse_production_hosts
 }
 
 module "concourse_staging" {
@@ -122,7 +122,7 @@ module "concourse_staging" {
   rds_multi_az                  = var.rds_multi_az
   rds_final_snapshot_identifier = "final-snapshot-atc-tooling-staging"
   listener_arn                  = aws_lb_listener.main.arn
-  hosts                         = [var.concourse_staging_hosts]
+  hosts                         = var.concourse_staging_hosts
 }
 
 module "monitoring_production" {
@@ -133,7 +133,7 @@ module "monitoring_production" {
   monitoring_az      = data.aws_availability_zones.available.names[0]
   route_table_id     = module.stack.private_route_table_az1
   listener_arn       = aws_lb_listener.main.arn
-  hosts              = [var.monitoring_production_hosts]
+  hosts              = var.monitoring_production_hosts
   oidc_client        = var.oidc_client
   oidc_client_secret = var.oidc_client_secret
 }
@@ -146,7 +146,7 @@ module "monitoring_staging" {
   monitoring_az      = data.aws_availability_zones.available.names[1]
   route_table_id     = module.stack.private_route_table_az2
   listener_arn       = aws_lb_listener.main.arn
-  hosts              = [var.monitoring_staging_hosts]
+  hosts              = var.monitoring_staging_hosts
   oidc_client        = var.oidc_client
   oidc_client_secret = var.oidc_client_secret
 }
@@ -181,6 +181,6 @@ module "smtp" {
   source              = "../../modules/smtp"
   stack_description   = var.stack_description
   vpc_id              = module.stack.vpc_id
-  ingress_cidr_blocks = [var.smtp_ingress_cidr_blocks]
+  ingress_cidr_blocks = var.smtp_ingress_cidr_blocks
 }
 

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -6,21 +6,30 @@ variable "aws_default_region" {
   default = "us-gov-west-1"
 }
 
-variable "vpc_cidr" {}
+variable "vpc_cidr" {
+}
 
-variable "rds_password" {}
-variable "credhub_rds_password" {}
+variable "rds_password" {
+}
+
+variable "credhub_rds_password" {
+}
 
 variable "rds_multi_az" {
   default = "true"
 }
 
-variable "remote_state_bucket" {}
+variable "remote_state_bucket" {
+}
 
-variable "concourse_prod_rds_password" {}
-variable "concourse_staging_rds_password" {}
+variable "concourse_prod_rds_password" {
+}
 
-variable "concourse_varz_bucket" {}
+variable "concourse_staging_rds_password" {
+}
+
+variable "concourse_varz_bucket" {
+}
 
 variable "wildcard_production_certificate_name_prefix" {
   default = ""
@@ -31,34 +40,35 @@ variable "wildcard_staging_certificate_name_prefix" {
 }
 
 variable "concourse_production_hosts" {
-  type = "list"
+  type = list(string)
 }
 
 variable "concourse_staging_hosts" {
-  type = "list"
+  type = list(string)
 }
 
 variable "monitoring_production_hosts" {
-  type = "list"
+  type = list(string)
 }
 
 variable "monitoring_staging_hosts" {
-  type = "list"
+  type = list(string)
 }
 
 variable "nessus_hosts" {
-  type = "list"
+  type = list(string)
 }
 
 variable "restricted_ingress_web_cidrs" {
-  type = "list"
+  type = list(string)
 }
 
 variable "restricted_ingress_web_ipv6_cidrs" {
-  type = "list"
+  type = list(string)
 }
 
-variable "blobstore_bucket_name" {}
+variable "blobstore_bucket_name" {
+}
 
 variable "bucket_prefix" {
   default = ""
@@ -109,7 +119,7 @@ variable "cg_binaries_bucket" {
 }
 
 variable "smtp_ingress_cidr_blocks" {
-  type = "list"
+  type = list(string)
 }
 
 variable "cloudtrail_bucket" {
@@ -120,8 +130,12 @@ variable "log_bucket_name" {
   default = "cg-elb-logs"
 }
 
-variable "oidc_client" {}
+variable "oidc_client" {
+}
 
-variable "oidc_client_secret" {}
+variable "oidc_client_secret" {
+}
 
-variable "payer_account_id" {}
+variable "payer_account_id" {
+}
+

--- a/terraform/stacks/tooling/versions.tf
+++ b/terraform/stacks/tooling/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/validate.sh
+++ b/validate.sh
@@ -9,9 +9,12 @@ path="$(dirname $0)"
 dirs=$(find "${path}/terraform/stacks" -mindepth 1 -maxdepth 1 -type d)
 status=0
 
+TERRAFORM="${TERRAFORM_BIN:-terraform}"
+
 for dir in $dirs; do
   echo "Validating terraform directory $dir"
-  terraform validate -check-variables=false ${dir} || status=1
+  AWS_DEFAULT_REGION=us-gov-west-1 ${TERRAFORM} init -backend=false ${dir}
+  AWS_DEFAULT_REGION=us-gov-west-1 ${TERRAFORM} validate -check-variables=false ${dir} || status=1
 done
 
 exit ${status}

--- a/validate.sh
+++ b/validate.sh
@@ -14,7 +14,7 @@ TERRAFORM="${TERRAFORM_BIN:-terraform}"
 for dir in $dirs; do
   echo "Validating terraform directory $dir"
   AWS_DEFAULT_REGION=us-gov-west-1 ${TERRAFORM} init -backend=false ${dir}
-  AWS_DEFAULT_REGION=us-gov-west-1 ${TERRAFORM} validate -check-variables=false ${dir} || status=1
+  AWS_DEFAULT_REGION=us-gov-west-1 ${TERRAFORM} validate ${dir} || status=1
 done
 
 exit ${status}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Pretty much a lot of format changes done by the upgrade tool.
- The main change is how lists are being done and used.
- Terraform version is 0.12.30
- AWS Provider version is 3.26
- Dev was upgraded and plan/apply before and after will do no infrastructure changes.

## security considerations
None 