### PR TITLE
add standalone credhub

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -257,6 +257,8 @@ jobs:
       TF_VAR_credhub_rds_password: ((tooling_credhub_rds_password))
       TF_VAR_concourse_prod_rds_password: ((concourse_prod_rds_password))
       TF_VAR_concourse_staging_rds_password: ((concourse_staging_rds_password))
+      TF_VAR_credhub_prod_rds_password: ((credhub_prod_rds_password))
+      TF_VAR_credhub_staging_rds_password: ((credhub_staging_rds_password))
       TF_VAR_opsuaa_rds_password: ((opsuaa_rds_password))
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_cloudtrail_bucket: ((aws_s3_cloudtrail_bucket))
@@ -267,6 +269,8 @@ jobs:
       TF_VAR_blobstore_bucket_name: bosh-tooling-blobstore
       TF_VAR_concourse_production_hosts: '["ci.fr.cloud.gov"]'
       TF_VAR_concourse_staging_hosts: '["ci.fr-stage.cloud.gov"]'
+      TF_VAR_credhub_production_hosts: '["credhub.fr.cloud.gov"]'
+      TF_VAR_credhub_staging_hosts: '["credhub.fr-stage.cloud.gov"]'
       TF_VAR_monitoring_production_hosts: '["prometheus.fr.cloud.gov", "alertmanager.fr.cloud.gov", "grafana.fr.cloud.gov"]'
       TF_VAR_monitoring_staging_hosts: '["prometheus.fr-stage.cloud.gov", "alertmanager.fr-stage.cloud.gov", "grafana.fr-stage.cloud.gov"]'
       TF_VAR_nessus_hosts: '["nessus.fr.cloud.gov"]'

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -57,3 +57,8 @@ variable "concourse_security_groups" {
   default = []
 }
 
+variable "credhub_security_groups" {
+  type    = list(string)
+  default = []
+}
+

--- a/terraform/modules/credhub/alb.tf
+++ b/terraform/modules/credhub/alb.tf
@@ -1,0 +1,37 @@
+resource "aws_lb_target_group" "credhub_target" {
+  name     = "${var.stack_description}-credhub-${var.credhub_az}"
+  port     = 8844
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 10
+    timeout             = 5
+    interval            = 30
+    matcher             = 200
+  }
+
+  stickiness {
+    type    = "lb_cookie"
+    enabled = true
+  }
+}
+
+resource "aws_lb_listener_rule" "credhub_listener_rule" {
+  count = length(var.hosts)
+
+  listener_arn = var.listener_arn
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.credhub_target.arn
+  }
+
+  condition {
+    host_header {
+      values = [element(var.hosts, count.index)]
+    }
+  }
+}
+

--- a/terraform/modules/credhub/network.tf
+++ b/terraform/modules/credhub/network.tf
@@ -1,0 +1,15 @@
+resource "aws_subnet" "credhub" {
+  vpc_id            = var.vpc_id
+  cidr_block        = var.credhub_cidr
+  availability_zone = var.credhub_az
+
+  tags = {
+    Name = "${var.stack_description} (Credhub - ${var.credhub_cidr})"
+  }
+}
+
+resource "aws_route_table_association" "credhub_rta" {
+  subnet_id      = aws_subnet.credhub.id
+  route_table_id = var.route_table_id
+}
+

--- a/terraform/modules/credhub/outputs.tf
+++ b/terraform/modules/credhub/outputs.tf
@@ -1,0 +1,45 @@
+output "credhub_subnet" {
+  value = aws_subnet.credhub.id
+}
+
+output "credhub_subnet_cidr" {
+  value = aws_subnet.credhub.cidr_block
+}
+
+output "credhub_security_group" {
+  value = aws_security_group.credhub.id
+}
+
+/* RDS credhub Instance */
+output "credhub_rds_identifier" {
+  value = module.rds_96.rds_identifier
+}
+
+output "credhub_rds_name" {
+  value = module.rds_96.rds_name
+}
+
+output "credhub_rds_host" {
+  value = module.rds_96.rds_host
+}
+
+output "credhub_rds_port" {
+  value = module.rds_96.rds_port
+}
+
+output "credhub_rds_url" {
+  value = module.rds_96.rds_url
+}
+
+output "credhub_rds_username" {
+  value = module.rds_96.rds_username
+}
+
+output "credhub_rds_password" {
+  value = module.rds_96.rds_password
+}
+
+output "credhub_lb_target_group" {
+  value = aws_lb_target_group.credhub_target.name
+}
+

--- a/terraform/modules/credhub/rds.tf
+++ b/terraform/modules/credhub/rds.tf
@@ -1,0 +1,19 @@
+module "rds_96" {
+  source = "../rds"
+
+  stack_description             = var.stack_description
+  rds_db_name                   = var.rds_db_name
+  rds_instance_type             = var.rds_instance_type
+  rds_db_size                   = var.rds_db_size
+  rds_db_storage_type           = var.rds_db_storage_type
+  rds_db_iops                   = var.rds_db_iops
+  rds_db_engine_version         = var.rds_engine_version
+  rds_username                  = var.rds_username
+  rds_password                  = var.rds_password
+  rds_subnet_group              = var.rds_subnet_group
+  rds_security_groups           = var.rds_security_groups
+  rds_parameter_group_name      = var.rds_parameter_group_name
+  rds_multi_az                  = var.rds_multi_az
+  rds_final_snapshot_identifier = var.rds_final_snapshot_identifier
+}
+

--- a/terraform/modules/credhub/sg_concourse.tf
+++ b/terraform/modules/credhub/sg_concourse.tf
@@ -1,0 +1,42 @@
+/*
+ * Variables required:
+ *  stack_description
+ *  vpc_id
+ */
+
+resource "aws_security_group" "credhub" {
+  description = "Allow access to incoming credhub traffic"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${var.stack_description} - Incoming Credhub Traffic"
+  }
+}
+
+resource "aws_security_group_rule" "self_reference" {
+  type              = "ingress"
+  self              = true
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  security_group_id = aws_security_group.credhub.id
+}
+
+resource "aws_security_group_rule" "credhub" {
+  type              = "ingress"
+  from_port         = 8844
+  to_port           = 8844
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.credhub.id
+}
+
+resource "aws_security_group_rule" "outbound" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.credhub.id
+}
+

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -1,0 +1,72 @@
+variable "stack_description" {
+}
+
+variable "credhub_cidr" {
+  default = "10.0.30.0/24"
+}
+
+variable "credhub_az" {
+  default = "us-gov-west-1a"
+}
+
+variable "rds_db_name" {
+  default = "credhub"
+}
+
+variable "rds_parameter_group_name" {
+  default = ""
+}
+
+variable "rds_db_size" {
+  default = 200
+}
+
+variable "rds_db_iops" {
+  default = 0
+}
+
+variable "rds_db_storage_type" {
+  default = "gp2"
+}
+
+variable "rds_instance_type" {
+  default = "db.m4.xlarge"
+}
+
+variable "rds_engine_version" {
+  default = "9.6.19"
+}
+
+variable "rds_username" {
+  default = "atc"
+}
+
+variable "rds_password" {
+}
+
+variable "rds_subnet_group" {
+}
+
+variable "rds_security_groups" {
+  type = list(string)
+}
+
+variable "rds_multi_az" {
+}
+
+variable "rds_final_snapshot_identifier" {
+}
+
+variable "route_table_id" {
+}
+
+variable "vpc_id" {
+}
+
+variable "listener_arn" {
+}
+
+variable "hosts" {
+  type = list(string)
+}
+

--- a/terraform/modules/credhub/versions.tf
+++ b/terraform/modules/credhub/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -15,6 +15,7 @@ module "vpc" {
   nat_gateway_instance_type         = var.nat_gateway_instance_type
   monitoring_security_groups        = var.target_monitoring_security_groups
   concourse_security_groups         = var.target_concourse_security_groups
+  credhub_security_groups           = var.target_credhub_security_groups
 }
 
 module "rds_network" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -104,6 +104,11 @@ variable "target_concourse_security_groups" {
   default = []
 }
 
+variable "target_credhub_security_groups" {
+  type    = list(string)
+  default = []
+}
+
 variable "rds_multi_az" {
   default = "true"
 }

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -33,6 +33,7 @@ module "base" {
   rds_security_groups_count         = 2
   target_monitoring_security_groups = var.target_monitoring_security_groups
   target_concourse_security_groups  = var.target_concourse_security_groups
+  target_credhub_security_groups    = var.target_credhub_security_groups
 }
 
 module "vpc_peering" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -120,3 +120,7 @@ variable "target_concourse_security_groups" {
   default = []
 }
 
+variable "target_credhub_security_groups" {
+  type    = list(string)
+  default = []
+}

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -542,6 +542,54 @@ resource "aws_route53_record" "cloud_gov_ci_fr_cloud_gov_aaaa" {
   }
 }
 
+resource "aws_route53_record" "cloud_gov_credhub-stage_fr_cloud_gov_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "credhub.fr-stage.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_credhub-stage_fr_cloud_gov_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "credhub.fr-stage.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_credhub_fr_cloud_gov_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "credhub.fr.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_credhub_fr_cloud_gov_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "credhub.fr.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.tooling.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "cloud_gov_ci_dev2_cloud_gov_a" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "ci.dev2.us-gov-west-1.aws-us-gov.cloud.gov."

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -110,6 +110,11 @@ module "stack" {
     data.terraform_remote_state.target_vpc.outputs.production_concourse_security_group,
     data.terraform_remote_state.target_vpc.outputs.staging_concourse_security_group,
   ]
+
+  target_credhub_security_groups = [
+    data.terraform_remote_state.target_vpc.outputs.production_credhub_security_group,
+    data.terraform_remote_state.target_vpc.outputs.staging_credhub_security_group,
+  ]
 }
 
 module "cf" {

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -388,6 +388,112 @@ output "staging_concourse_lb_target_group" {
   value = module.concourse_staging.concourse_lb_target_group
 }
 
+/* Production credhub */
+output "production_credhub_subnet" {
+  value = module.credhub_production.credhub_subnet
+}
+
+output "production_credhub_subnet_reserved" {
+  value = "${cidrhost(module.credhub_production.credhub_subnet_cidr, 0)} - ${cidrhost(module.credhub_production.credhub_subnet_cidr, 3)}"
+}
+
+output "production_credhub_subnet_cidr" {
+  value = module.credhub_production.credhub_subnet_cidr
+}
+
+output "production_credhub_subnet_gateway" {
+  value = cidrhost(module.credhub_production.credhub_subnet_cidr, 1)
+}
+
+output "production_credhub_security_group" {
+  value = module.credhub_production.credhub_security_group
+}
+
+output "production_credhub_rds_identifier" {
+  value = module.credhub_production.credhub_rds_identifier
+}
+
+output "production_credhub_rds_name" {
+  value = module.credhub_production.credhub_rds_name
+}
+
+output "production_credhub_rds_host" {
+  value = module.credhub_production.credhub_rds_host
+}
+
+output "production_credhub_rds_port" {
+  value = module.credhub_production.credhub_rds_port
+}
+
+output "production_credhub_rds_url" {
+  value = module.credhub_production.credhub_rds_url
+}
+
+output "production_credhub_rds_username" {
+  value = module.credhub_production.credhub_rds_username
+}
+
+output "production_credhub_rds_password" {
+  value = module.credhub_production.credhub_rds_password
+}
+
+output "production_credhub_lb_target_group" {
+  value = module.credhub_production.credhub_lb_target_group
+}
+
+/* Staging credhub */
+output "staging_credhub_subnet" {
+  value = module.credhub_staging.credhub_subnet
+}
+
+output "staging_credhub_subnet_reserved" {
+  value = "${cidrhost(module.credhub_staging.credhub_subnet_cidr, 0)} - ${cidrhost(module.credhub_staging.credhub_subnet_cidr, 3)}"
+}
+
+output "staging_credhub_subnet_cidr" {
+  value = module.credhub_staging.credhub_subnet_cidr
+}
+
+output "staging_credhub_subnet_gateway" {
+  value = cidrhost(module.credhub_staging.credhub_subnet_cidr, 1)
+}
+
+output "staging_credhub_security_group" {
+  value = module.credhub_staging.credhub_security_group
+}
+
+output "staging_credhub_rds_identifier" {
+  value = module.credhub_staging.credhub_rds_identifier
+}
+
+output "staging_credhub_rds_name" {
+  value = module.credhub_staging.credhub_rds_name
+}
+
+output "staging_credhub_rds_host" {
+  value = module.credhub_staging.credhub_rds_host
+}
+
+output "staging_credhub_rds_port" {
+  value = module.credhub_staging.credhub_rds_port
+}
+
+output "staging_credhub_rds_url" {
+  value = module.credhub_staging.credhub_rds_url
+}
+
+output "staging_credhub_rds_username" {
+  value = module.credhub_staging.credhub_rds_username
+}
+
+output "staging_credhub_rds_password" {
+  value = module.credhub_staging.credhub_rds_password
+}
+
+output "staging_credhub_lb_target_group" {
+  value = module.credhub_staging.credhub_lb_target_group
+}
+
 /* Production Monitoring */
 output "production_monitoring_az" {
   value = module.monitoring_production.monitoring_az

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -31,6 +31,12 @@ variable "concourse_staging_rds_password" {
 variable "concourse_varz_bucket" {
 }
 
+variable "credhub_prod_rds_password" {
+}
+
+variable "credhub_staging_rds_password" {
+}
+
 variable "wildcard_production_certificate_name_prefix" {
   default = ""
 }
@@ -44,6 +50,14 @@ variable "concourse_production_hosts" {
 }
 
 variable "concourse_staging_hosts" {
+  type = list(string)
+}
+
+variable "credhub_production_hosts" {
+  type = list(string)
+}
+
+variable "credhub_staging_hosts" {
   type = list(string)
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

Support the deployment of a standalone in credhub instance in staging and production. Credhub needs:

- DNS entries
- ALB routing rules on tooling-main
- A Postgres DB

_I followed the pattern of concourse as the end deployment should look similar with the same requirements. However, I noticed there are multiple places with duplication. I followed the pattern as I am not 100% sure exactly which parts are required._

## security considerations

The credhub deployment will be similar to concourse. The VPN is required to access it as the tooling-main alb is used. 
