### PR TITLE
Add permission to aws-broker rds role policy

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -5,6 +5,7 @@
       "Effect": "Allow",
       "Action": [
         "rds:DescribeDBInstances",
+        "rds:DescribeDBEngineVersions",
         "rds:CreateDBInstance",
         "rds:DeleteDBInstance",
         "rds:ModifyDBInstance",


### PR DESCRIPTION
This changeset adds a single permission, rds:DescribeDBEngineVersions, to the role policy for the aws-broker.  This will allow us to retrieve information necessary for generating new custom parameter groups that we would not be able to otherwise.

This is in support of https://github.com/cloud-gov/aws-broker/pull/148, which requires this change.

## Changes proposed in this pull request:
- Add Allow rule for `rds:DescribeDBEngineVersions`

## security considerations:
- This grants another read operation permission to the `aws-broker`, which already has other permissions to read information about the RDS environment and instances within our AWS account