### PR TITLE
Fix rds:DescribeDBEngineVersions permissions

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -5,7 +5,6 @@
       "Effect": "Allow",
       "Action": [
         "rds:DescribeDBInstances",
-        "rds:DescribeDBEngineVersions",
         "rds:CreateDBInstance",
         "rds:DeleteDBInstance",
         "rds:ModifyDBInstance",
@@ -33,6 +32,15 @@
       ],
       "Resource": [
         "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:pg:*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "rds:DescribeDBEngineVersions"
+      ],
+      "Resouce": [
+        "*"
       ]
     },
     {


### PR DESCRIPTION
This particular permission requires all resources.

## Changes proposed in this pull request:

- Adjust the permissions to create a new resource block to account for the `rds:DescribeDBEngineVersions` restrictions

## security considerations:
- This requires a resource of `*`, but this is also a read only call not tied to a specific instance