### PR TITLE
Update PostgreSQL version defaults

### DIFF
--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -25,7 +25,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "9.6.19"
+  default = "12.4"
 }
 
 variable "rds_username" {
@@ -50,7 +50,7 @@ variable "rds_parameter_group_name" {
 }
 
 variable "rds_parameter_group_family" {
-  default = "postgres9.6"
+  default = "postgres12"
 }
 
 variable "rds_multi_az" {

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -69,6 +69,6 @@ module "credhub_rds" {
   rds_force_ssl                   = var.credhub_rds_force_ssl
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
-  rds_parameter_group_family      = var.rds_parameter_group_family
+  rds_parameter_group_family      = var.credhub_rds_parameter_group_family
 }
 

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -66,11 +66,11 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "9.6.19"
+  default = "12.4"
 }
 
 variable "rds_parameter_group_family" {
-  default = "postgres9.6"
+  default = "postgres12"
 }
 
 variable "rds_username" {
@@ -145,6 +145,10 @@ variable "credhub_rds_password" {
 
 variable "credhub_rds_db_engine_version" {
   default = "9.6.19"
+}
+
+variable "credhub_rds_parameter_group_family" {
+  default = "postgres9.6"
 }
 
 variable "rds_parameter_group_name" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update the default PostgreSQL version to 12.4, except for CredHub, which hasn't been upgraded yet.

## security considerations
This should increase our security posture due to SSL/TLS changes in newer PostgreSQL versions (cloud-gov/product#1398).