### PR TITLE
Upgrade credhub database in dev/staging/production to postgres 12.4

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -254,6 +254,9 @@ jobs:
       AWS_DEFAULT_REGION: ((aws_default_region))
       TF_VAR_aws_default_region: ((aws_default_region))
       TF_VAR_rds_password: ((tooling_rds_password))
+      # Enable for database upgrades:
+      #TF_VAR_rds_apply_immediately: "true"
+      #TF_VAR_rds_allow_major_version_upgrade: "true"
       TF_VAR_credhub_rds_password: ((tooling_credhub_rds_password))
       TF_VAR_concourse_prod_rds_password: ((concourse_prod_rds_password))
       TF_VAR_concourse_staging_rds_password: ((concourse_staging_rds_password))
@@ -370,7 +373,9 @@ jobs:
       # IDs from `data` resources.
       TF_VAR_rds_password: ((development_rds_password))
       TF_VAR_rds_db_size: ((development_rds_db_size))
-      TF_VAR_rds_apply_immediately: "true"
+      # Enable for database upgrades:
+      #TF_VAR_rds_apply_immediately: "true"
+      #TF_VAR_rds_allow_major_version_upgrade: "true"
       TF_VAR_rds_multi_az: "false"
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_vpc_cidr: ((development_vpc_cidr))
@@ -486,6 +491,9 @@ jobs:
       # IDs from `data` resources.
       TF_VAR_rds_password: ((staging_rds_password))
       TF_VAR_rds_db_size: ((staging_rds_db_size))
+      # Enable for database upgrades:
+      #TF_VAR_rds_apply_immediately: "true"
+      #TF_VAR_rds_allow_major_version_upgrade: "true"
       TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_vpc_cidr: ((staging_vpc_cidr))
@@ -600,6 +608,9 @@ jobs:
       # IDs from `data` resources.
       TF_VAR_rds_password: ((production_rds_password))
       TF_VAR_rds_db_size: ((production_rds_db_size))
+      # Enable for database upgrades:
+      #TF_VAR_rds_apply_immediately: "true"
+      #TF_VAR_rds_allow_major_version_upgrade: "true"
       TF_VAR_credhub_rds_password: ((production_credhub_rds_password))
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_vpc_cidr: ((production_vpc_cidr))

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -18,7 +18,7 @@ variable "rds_parameter_group_name" {
 }
 
 variable "rds_parameter_group_family" {
-  default = "postgres9.6"
+  default = "postgres12"
 }
 
 variable "rds_db_size" {
@@ -38,7 +38,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_engine_version" {
-  default = "9.6.19"
+  default = "12.4"
 }
 
 variable "rds_username" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -144,11 +144,11 @@ variable "credhub_rds_password" {
 }
 
 variable "credhub_rds_db_engine_version" {
-  default = "9.6.19"
+  default = "12.4"
 }
 
 variable "credhub_rds_parameter_group_family" {
-  default = "postgres9.6"
+  default = "postgres12"
 }
 
 variable "rds_parameter_group_name" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Upgrade main credhub PostgreSQL database from 9.6.19 to 12.4
- Implements https://github.com/cloud-gov/product/issues/1398

## security considerations
Improves security posture by implementing https://github.com/cloud-gov/product/issues/1398