### PR TITLE
Upgrade opsuaa PostgreSQL database to 12.4

### DIFF
--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -11,10 +11,10 @@ module "opsuaa_db" {
   rds_password                    = var.opsuaa_rds_password
   rds_subnet_group                = module.stack.rds_subnet_group
   rds_security_groups             = [module.stack.rds_postgres_security_group]
-  rds_db_engine_version           = "9.6.19" #var.rds_db_engine_version
-  rds_parameter_group_family      = "postgres9.6" #var.rds_parameter_group_family
-  rds_allow_major_version_upgrade = "false" #var.rds_allow_major_version_upgrade
-  rds_apply_immediately           = "false" #var.rds_apply_immediately
+  rds_db_engine_version           = var.rds_db_engine_version
+  rds_parameter_group_family      = var.rds_parameter_group_family
+  rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  rds_apply_immediately           = var.rds_apply_immediately
 }
 
 output "opsuaa_rds_url" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- This is the last remaining PostgreSQL upgrade for https://github.com/cloud-gov/product/issues/1398!
- Upgrade `opsuaa` database from 9.6.19 to 12.4

## security considerations
Improves security posture per https://github.com/cloud-gov/product/issues/1398
