### PR TITLE
Add access to old CDN domain service

### DIFF
--- a/terraform/modules/external_domain_broker/policy.json
+++ b/terraform/modules/external_domain_broker/policy.json
@@ -10,7 +10,8 @@
         "iam:UpdateServerCertificate"
       ],
       "Resource": [
-        "arn:aws:iam::${account_id}:server-certificate/cloudfront/external-domains-${stack}/*"
+        "arn:aws:iam::${account_id}:server-certificate/cloudfront/external-domains-${stack}/*",
+        "arn:aws:iam::${account_id}:server-certificate/cloudfront/cg-${stack}/*"
       ]
     },
     {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Allow the external-domains-migrator to run actions on the old CDN resources 

## security considerations
none
