### PR TITLE
Removed terratest because terraform bin is now 0.14.11

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -44,7 +44,6 @@ jobs:
       inputs:
       - name: pull-request
       params:
-        TERRAFORM_BIN: terratest-14.11
       run:
         path: pull-request/validate.sh
     on_success:
@@ -73,7 +72,6 @@ jobs:
     file: pipeline-tasks/terraform-apply.yml
     input_mapping: {terraform-templates: cg-provision-repo}
     params: &external-staging-params
-      TERRAFORM_BIN: terratest-14.11
       TERRAFORM_ACTION: plan
       STACK_NAME: external-staging
       TEMPLATE_SUBDIR: terraform/stacks/external
@@ -142,7 +140,6 @@ jobs:
     file: pipeline-tasks/terraform-apply.yml
     input_mapping: {terraform-templates: cg-provision-repo}
     params: &external-production-params
-      TERRAFORM_BIN: terratest-14.11
       TERRAFORM_ACTION: plan
       STACK_NAME: external-production
       TEMPLATE_SUBDIR: terraform/stacks/external
@@ -202,7 +199,6 @@ jobs:
     file: pipeline-tasks/terraform-apply.yml
     input_mapping: {terraform-templates: cg-provision-repo}
     params: &dns-params
-      TERRAFORM_BIN: terratest-14.11
       TERRAFORM_ACTION: plan
       STACK_NAME: dns
       TEMPLATE_SUBDIR: terraform/stacks/dns
@@ -246,7 +242,6 @@ jobs:
     file: pipeline-tasks/terraform-apply.yml
     input_mapping: {terraform-templates: cg-provision-repo}
     params: &tooling-params
-      TERRAFORM_BIN: terratest-14.11
       TERRAFORM_ACTION: plan
       STACK_NAME: tooling
       TEMPLATE_SUBDIR: terraform/stacks/tooling
@@ -329,7 +324,6 @@ jobs:
         - name: cg-provision-repo
         - name: terraform-state
         params:
-          TERRAFORM_BIN: terratest-14.11
           STATE_FILE_PATH: terraform-state/terraform.tfstate
         run:
           path: sh
@@ -361,7 +355,6 @@ jobs:
     file: pipeline-tasks/terraform-apply.yml
     input_mapping: {terraform-templates: cg-provision-repo}
     params: &development-params
-      TERRAFORM_BIN: terratest-14.11
       TERRAFORM_ACTION: plan
       STACK_NAME: development
       TEMPLATE_SUBDIR: terraform/stacks/main
@@ -431,7 +424,6 @@ jobs:
           - name: cg-provision-repo
           - name: terraform-state
           params:
-            TERRAFORM_BIN: terratest-14.11
             STATE_FILE_PATH: terraform-state/terraform.tfstate
           run:
             path: sh
@@ -450,7 +442,6 @@ jobs:
           - name: cg-provision-repo
           - name: terraform-state
           params:
-            TERRAFORM_BIN: terratest-14.11
             STATE_FILE_PATH: terraform-state/terraform.tfstate
           run:
             path: sh
@@ -481,7 +472,6 @@ jobs:
     file: pipeline-tasks/terraform-apply.yml
     input_mapping: {terraform-templates: cg-provision-repo}
     params: &staging-params
-      TERRAFORM_BIN: terratest-14.11
       TERRAFORM_ACTION: plan
       STACK_NAME: staging
       TEMPLATE_SUBDIR: terraform/stacks/main
@@ -568,7 +558,6 @@ jobs:
           - name: cg-provision-repo
           - name: terraform-state
           params:
-            TERRAFORM_BIN: terratest-14.11
             STATE_FILE_PATH: terraform-state/terraform.tfstate
           run:
             path: sh
@@ -580,7 +569,6 @@ jobs:
       - task: terraform-state-to-yaml
         file: pipeline-tasks/terraform12-state-to-yaml.yml
         params:
-          TERRAFORM_BIN: terratest-14.11
           STATE_FILE: terraform.tfstate
       - put: terraform-yaml-staging
         params:
@@ -600,7 +588,6 @@ jobs:
     file: pipeline-tasks/terraform-apply.yml
     input_mapping: {terraform-templates: cg-provision-repo}
     params: &production-params
-      TERRAFORM_BIN: terratest-14.11
       TERRAFORM_ACTION: plan
       STACK_NAME: production
       TEMPLATE_SUBDIR: terraform/stacks/main
@@ -669,7 +656,6 @@ jobs:
           - name: cg-provision-repo
           - name: terraform-state
           params:
-            TERRAFORM_BIN: terratest-14.11
             STATE_FILE_PATH: terraform-state/terraform.tfstate
           run:
             path: sh
@@ -688,7 +674,6 @@ jobs:
           - name: cg-provision-repo
           - name: terraform-state
           params:
-            TERRAFORM_BIN: terratest-14.11
             STATE_FILE_PATH: terraform-state/terraform.tfstate
           run:
             path: sh


### PR DESCRIPTION
## Changes proposed in this pull request:
- Terratest is removed so default "terraform" is used.

## security considerations
Nope