### PR TITLE
Bump postgres to most current AWS version: 12.6

### DIFF
--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -32,7 +32,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.5"
+  default = "12.6"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -38,7 +38,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.5"
+  default = "12.6"
 }
 
 variable "rds_username" {

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -38,7 +38,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.5"
+  default = "12.6"
 }
 
 variable "rds_username" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -25,7 +25,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.5"
+  default = "12.6"
 }
 
 variable "rds_username" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -66,7 +66,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.5"
+  default = "12.6"
 }
 
 variable "rds_parameter_group_family" {
@@ -144,7 +144,7 @@ variable "credhub_rds_password" {
 }
 
 variable "credhub_rds_db_engine_version" {
-  default = "12.5"
+  default = "12.6"
 }
 
 variable "credhub_rds_parameter_group_family" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -66,7 +66,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.5"
+  default = "12.6"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -28,7 +28,7 @@ variable "rds_apply_immediately" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.5"
+  default = "12.6"
 }
 
 variable "rds_parameter_group_family" {


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Bump postgres to most current AWS version: 12.6
-

These are the valid upgrade targets as of today:

```
+-------------------------------------------------------------------------------------------+||
|||                                    ValidUpgradeTarget                                     |||
||+-------------+---------------------+-----------+----------------+--------------------------+||
||| AutoUpgrade |     Description     |  Engine   | EngineVersion  |  IsMajorVersionUpgrade   |||
||+-------------+---------------------+-----------+----------------+--------------------------+||
|||  False      |  PostgreSQL 12.6-R1 |  postgres |  12.6          |  False                   |||
|||  False      |  PostgreSQL 13.1-R1 |  postgres |  13.1          |  True                    |||
|||  False      |  PostgreSQL 13.2-R1 |  postgres |  13.2          |  True                    |||
||+-------------+---------------------+-----------+----------------+--------------------------+||
```
## security considerations

PR is not an info leak, code change upgrades to most patched available version
