### PR TITLE
Add route53 records for *.pages-staging.cloud.gov and *.sites.pages-staging.cloud.gov

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -395,6 +395,9 @@ jobs:
       TF_VAR_domains_broker_rds_password: ((development_domains_broker_rds_password))
       TF_VAR_domain_broker_v2_rds_username: ((development_domain_broker_v2_rds_username))
       TF_VAR_domain_broker_v2_rds_password: ((development_domain_broker_v2_rds_password))
+      # Not used in dev
+      TF_VAR_wildcard_pages_staging_certificate_name_prefix: star.pages-staging.cloud.gov
+      TF_VAR_wildcard_sites_pages_staging_certificate_name_prefix: star.sites.pages-staging.cloud.gov
   - *notify-slack
 
 - name: bootstrap-development
@@ -511,6 +514,9 @@ jobs:
       TF_VAR_domains_broker_rds_password: ((staging_domains_broker_rds_password))
       TF_VAR_domain_broker_v2_rds_username: ((staging_domain_broker_v2_rds_username))
       TF_VAR_domain_broker_v2_rds_password: ((staging_domain_broker_v2_rds_password))
+      # Not used in staging
+      TF_VAR_wildcard_pages_staging_certificate_name_prefix: star.pages-staging.cloud.gov
+      TF_VAR_wildcard_sites_pages_staging_certificate_name_prefix: star.sites.pages-staging.cloud.gov
   - *notify-slack
 
 - name: bootstrap-staging
@@ -627,6 +633,8 @@ jobs:
       TF_VAR_domains_broker_rds_password: ((production_domains_broker_rds_password))
       TF_VAR_domain_broker_v2_rds_username: ((production_domain_broker_v2_rds_username))
       TF_VAR_domain_broker_v2_rds_password: ((production_domain_broker_v2_rds_password))
+      TF_VAR_wildcard_pages_staging_certificate_name_prefix: star.pages-staging.cloud.gov
+      TF_VAR_wildcard_sites_pages_staging_certificate_name_prefix: star.sites.pages-staging.cloud.gov
   - *notify-slack
 
 - name: bootstrap-production
@@ -838,6 +846,82 @@ jobs:
     params:
       text: |
         :x: Failed to check ACME certificates for *.app.cloud.gov
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
+- name: acme-certificate-staging-pages
+  plan:
+  - in_parallel:
+    - get: acme-timer
+      trigger: true
+    - get: cg-provision-repo
+    - get: terraform-yaml-tooling
+      resource: terraform-yaml-tooling
+    - get: terraform-yaml-external
+      resource: terraform-yaml-external-production
+  - task: check-certificates
+    file: cg-provision-repo/ci/check-certificates.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+  - task: provision-certificate
+    file: cg-provision-repo/ci/provision-certificate.yml
+    params:
+      CERT_PREFIX: star.pages-staging.cloud.gov
+      ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+      DOMAIN: "*.pages-staging.cloud.gov"
+      EMAIL: cloud-gov-operations@gsa.gov
+  - task: upload-certificate
+    file: cg-provision-repo/ci/upload-certificate.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+      CERT_PREFIX: star.pages-staging.cloud.gov
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Failed to check ACME certificates for *.pages-staging.cloud.gov
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
+- name: acme-certificate-staging-pages-sites
+  plan:
+  - in_parallel:
+    - get: acme-timer
+      trigger: true
+    - get: cg-provision-repo
+    - get: terraform-yaml-tooling
+      resource: terraform-yaml-tooling
+    - get: terraform-yaml-external
+      resource: terraform-yaml-external-production
+  - task: check-certificates
+    file: cg-provision-repo/ci/check-certificates.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+  - task: provision-certificate
+    file: cg-provision-repo/ci/provision-certificate.yml
+    params:
+      CERT_PREFIX: star.sites.pages-staging.cloud.gov
+      ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+      DOMAIN: "*.sites.pages-staging.cloud.gov"
+      EMAIL: cloud-gov-operations@gsa.gov
+  - task: upload-certificate
+    file: cg-provision-repo/ci/upload-certificate.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+      CERT_PREFIX: star.sites.pages-staging.cloud.gov
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Failed to check ACME certificates for *.sites.pages-staging.cloud.gov
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: ((slack-channel))
       username: ((slack-username))

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -51,3 +51,12 @@ resource "aws_lb_listener" "cf_apps_http" {
   }
 }
 
+resource "aws_lb_listener_certificate" "pages_staging" {
+  listener_arn    = aws_lb_listener.cf_apps.arn
+  certificate_arn = var.pages_staging_cert_id
+}
+
+resource "aws_lb_listener_certificate" "sites_pages_staging" {
+  listener_arn    = aws_lb_listener.cf_apps.arn
+  certificate_arn = var.sites_pages_staging_cert_id
+}

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -4,6 +4,14 @@ variable "elb_main_cert_id" {
 variable "elb_apps_cert_id" {
 }
 
+variable "pages_staging_cert_id" {
+
+}
+
+variable "sites_pages_staging_cert_id" {
+  
+}
+
 variable "elb_subnets" {
   type = list(string)
 }

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -1060,6 +1060,30 @@ resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_aaaa" {
   }
 }
 
+resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.sites.pages-staging.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.sites.pages-staging.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 output "cloud_gov_ns" {
   value = aws_route53_zone.cloud_gov_zone.name_servers
 }

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -1036,6 +1036,30 @@ resource "aws_route53_record" "dev2_delegate" {
   ]
 }
 
+resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.pages-staging.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.pages-staging.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 output "cloud_gov_ns" {
   value = aws_route53_zone.cloud_gov_zone.name_servers
 }

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -1042,7 +1042,7 @@ resource "aws_route53_record" "cloud_gov_star_pages_staging_cloud_gov_a" {
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
@@ -1054,7 +1054,7 @@ resource "aws_route53_record" "cloud_gov_star_pages_staging_cloud_gov_aaaa" {
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
@@ -1066,7 +1066,7 @@ resource "aws_route53_record" "cloud_gov_star_sites_pages_staging_cloud_gov_a" {
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
@@ -1078,7 +1078,7 @@ resource "aws_route53_record" "cloud_gov_star_sites_pages_staging_cloud_gov_aaaa
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -1036,7 +1036,7 @@ resource "aws_route53_record" "dev2_delegate" {
   ]
 }
 
-resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_a" {
+resource "aws_route53_record" "cloud_gov_star_pages_staging_cloud_gov_a" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.pages-staging.cloud.gov."
   type    = "A"
@@ -1048,7 +1048,7 @@ resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_a" {
   }
 }
 
-resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_aaaa" {
+resource "aws_route53_record" "cloud_gov_star_pages_staging_cloud_gov_aaaa" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.pages-staging.cloud.gov."
   type    = "AAAA"
@@ -1060,7 +1060,7 @@ resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_aaaa" {
   }
 }
 
-resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_a" {
+resource "aws_route53_record" "cloud_gov_star_sites_pages_staging_cloud_gov_a" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.sites.pages-staging.cloud.gov."
   type    = "A"
@@ -1072,7 +1072,7 @@ resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_a" {
   }
 }
 
-resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_aaaa" {
+resource "aws_route53_record" "cloud_gov_star_sites_pages_staging_cloud_gov_aaaa" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.sites.pages-staging.cloud.gov."
   type    = "AAAA"

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -37,6 +37,16 @@ data "aws_iam_server_certificate" "wildcard_apps" {
   latest      = true
 }
 
+data "aws_iam_server_certificate" "wildcard_pages_staging" {
+  name_prefix = var.wildcard_pages_staging_certificate_name_prefix
+  latest      = true
+}
+
+data "aws_iam_server_certificate" "wildcard_sites_pages_staging" {
+  name_prefix = var.wildcard_sites_pages_staging_certificate_name_prefix
+  latest      = true
+}
+
 resource "aws_lb" "main" {
   name    = "${var.stack_description}-main"
   subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
@@ -119,11 +129,13 @@ module "stack" {
 module "cf" {
   source = "../../modules/cloudfoundry"
 
-  stack_description = var.stack_description
-  aws_partition     = data.aws_partition.current.partition
-  elb_main_cert_id  = data.aws_iam_server_certificate.wildcard.arn
-  elb_apps_cert_id  = data.aws_iam_server_certificate.wildcard_apps.arn
-  elb_subnets       = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
+  stack_description           = var.stack_description
+  aws_partition               = data.aws_partition.current.partition
+  elb_main_cert_id            = data.aws_iam_server_certificate.wildcard.arn
+  elb_apps_cert_id            = data.aws_iam_server_certificate.wildcard_apps.arn
+  pages_staging_cert_id       = data.aws_iam_server_certificate.wildcard_pages_staging.arn
+  sites_pages_staging_cert_id = data.aws_iam_server_certificate.wildcard_sites_pages_staging.arn
+  elb_subnets                 = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
 
   elb_security_groups = [
     var.force_restricted_network == "no" ? module.stack.web_traffic_security_group : module.stack.restricted_web_traffic_security_group,

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -36,6 +36,14 @@ variable "wildcard_apps_certificate_name_prefix" {
   default = ""
 }
 
+variable "wildcard_pages_staging_certificate_name_prefix" {
+  default = ""
+}
+
+variable "wildcard_sites_pages_staging_certificate_name_prefix" {
+  default = ""
+}
+
 variable "admin_hosts" {
   type = list(string)
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds wildcard DNS record/certs for
  - `*.pages-staging.cloud.gov`
  - `*.sites.pages-staging.cloud.gov`

My understanding is that this will allow us to create the following domains in CF via `create-domain`:
- `pages-staging.cloud.gov`
- `sites.pages-staging.cloud.gov`

enabling the creation of routes in CF via `create-route` such as:
- `app.pages-staging.cloud.gov`
- `admin.pages-staging.cloud.gov`
- `*.sites.pages-staging.cloud.gov`
- ...

## security considerations
[Note the any security considerations here, or make note of why there are none]
???
