### PR TITLE
let the external-domain-broker touch certs created by the domain-broker

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/policy.json
+++ b/terraform/modules/external_domain_broker_govcloud/policy.json
@@ -9,7 +9,8 @@
         "iam:DeleteServerCertificate"
       ],
       "Resource": [
-        "arn:aws-us-gov:iam::${account_id}:server-certificate/alb/external-domains-${stack}/*"
+        "arn:aws-us-gov:iam::${account_id}:server-certificate/alb/external-domains-${stack}/*",
+        "arn:aws-us-gov:iam::${account_id}:server-certificate/domains/${stack}/*"
       ]
     },
     {

--- a/terraform/modules/external_domain_broker_govcloud/resources.tf
+++ b/terraform/modules/external_domain_broker_govcloud/resources.tf
@@ -8,7 +8,6 @@ data "template_file" "policy" {
   vars = {
     account_id      = var.account_id
     stack           = var.stack_description
-    iam_cert_prefix = var.iam_cert_prefix
   }
 }
 

--- a/terraform/modules/external_domain_broker_govcloud/resources.tf
+++ b/terraform/modules/external_domain_broker_govcloud/resources.tf
@@ -6,8 +6,9 @@ data "template_file" "policy" {
   template = file("${path.module}/policy.json")
 
   vars = {
-    account_id = var.account_id
-    stack      = var.stack_description
+    account_id      = var.account_id
+    stack           = var.stack_description
+    iam_cert_prefix = var.iam_cert_prefix
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- let the external-domain-broker touch certs created by the domain-broker

## security considerations
expands permissions for this role, but it's necessary