### PR TITLE
allow external-domain-broker user to list all certs in commercial

### DIFF
--- a/terraform/modules/external_domain_broker/policy.json
+++ b/terraform/modules/external_domain_broker/policy.json
@@ -5,13 +5,21 @@
       "Effect": "Allow",
       "Action": [
         "iam:DeleteServerCertificate",
-        "iam:ListServerCertificates",
         "iam:UploadServerCertificate",
         "iam:UpdateServerCertificate"
       ],
       "Resource": [
         "arn:aws:iam::${account_id}:server-certificate/cloudfront/external-domains-${stack}/*",
         "arn:aws:iam::${account_id}:server-certificate/cloudfront/cg-${stack}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListServerCertificates"
+      ],
+      "Resource": [
+        "arn:aws:iam::${account_id}:server-certificate/*"
       ]
     },
     {


### PR DESCRIPTION
## Changes proposed in this pull request:
- allow external-domain-broker user to list all certs in commercial. We need this because that's how the migrator finds cert data, because iam server certificates are weird.


## security considerations
None