### PR TITLE
bump PostgreSQL to 12.7

### DIFF
--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -40,7 +40,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.8"
+  default = "12.7"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -40,7 +40,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.7"
+  default = "12.8"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -40,7 +40,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.6"
+  default = "12.7"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -38,7 +38,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.6"
+  default = "12.7"
 }
 
 variable "rds_username" {

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -38,7 +38,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.7"
+  default = "12.8"
 }
 
 variable "rds_username" {

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -38,7 +38,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.8"
+  default = "12.7"
 }
 
 variable "rds_username" {

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -38,7 +38,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.6"
+  default = "12.7"
 }
 
 variable "rds_username" {

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -38,7 +38,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.7"
+  default = "12.8"
 }
 
 variable "rds_username" {

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -38,7 +38,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.8"
+  default = "12.7"
 }
 
 variable "rds_username" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -25,7 +25,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.6"
+  default = "12.7"
 }
 
 variable "rds_username" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -25,7 +25,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.7"
+  default = "12.8"
 }
 
 variable "rds_username" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -25,7 +25,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.8"
+  default = "12.7"
 }
 
 variable "rds_username" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -66,7 +66,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.7"
+  default = "12.8"
 }
 
 variable "rds_parameter_group_family" {
@@ -144,7 +144,7 @@ variable "credhub_rds_password" {
 }
 
 variable "credhub_rds_db_engine_version" {
-  default = "12.7"
+  default = "12.8"
 }
 
 variable "credhub_rds_parameter_group_family" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -66,7 +66,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.8"
+  default = "12.7"
 }
 
 variable "rds_parameter_group_family" {
@@ -144,7 +144,7 @@ variable "credhub_rds_password" {
 }
 
 variable "credhub_rds_db_engine_version" {
-  default = "12.8"
+  default = "12.7"
 }
 
 variable "credhub_rds_parameter_group_family" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -66,7 +66,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.6"
+  default = "12.7"
 }
 
 variable "rds_parameter_group_family" {
@@ -144,7 +144,7 @@ variable "credhub_rds_password" {
 }
 
 variable "credhub_rds_db_engine_version" {
-  default = "12.6"
+  default = "12.7"
 }
 
 variable "credhub_rds_parameter_group_family" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -66,7 +66,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.7"
+  default = "12.8"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -66,7 +66,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.6"
+  default = "12.7"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -66,7 +66,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.8"
+  default = "12.7"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -28,7 +28,7 @@ variable "rds_apply_immediately" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.6"
+  default = "12.7"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -28,7 +28,7 @@ variable "rds_apply_immediately" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.7"
+  default = "12.8"
 }
 
 variable "rds_parameter_group_family" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -28,7 +28,7 @@ variable "rds_apply_immediately" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.8"
+  default = "12.7"
 }
 
 variable "rds_parameter_group_family" {


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Bump to 12.7
-


This is now a valid version:

```sh
aws-vault exec cg-govcloud -- aws rds describe-db-engine-versions --output=table --engine postgres --engine-version 12.5
...
|||             AutoUpgrade            |                      Description                       |           Engine             |               EngineVersion               |                     IsMajorVersionUpgrade                     |||
|||  False                             |  PostgreSQL 12.7-R1                                    |  postgres                    |  12.7                                     |  False                                                        |||
```

## security considerations

Same as prior bumps: None
