### PR TITLE
moving image task to older buster image until concourse is updated

### DIFF
--- a/ci/provision-certificate.yml
+++ b/ci/provision-certificate.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: python
-    tag: "3.6"
+    tag: "3.6-buster"
 
 inputs:
 - name: cg-provision-repo


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use specific debian-buster image for this task until we upgrade concourse to a newer version where debian-bullseye images work correctly.  The docker community has moved on from buster. See https://github.com/docker-library/python/issues/634

## security considerations
n/a
