### PR TITLE
Target group

### DIFF
--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -27,6 +27,22 @@ resource "aws_lb_target_group" "cf_apps_target" {
   }
 }
 
+resource "aws_lb_target_group" "cf_apps_target_https" {
+  name     = "${var.stack_description}-cf-apps-https"
+  port     = 443
+  protocol = "HTTPS"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    interval            = 5
+    port                = 81
+    timeout             = 4
+    unhealthy_threshold = 3
+    matcher             = 200
+  }
+}
+
 resource "aws_lb_listener" "cf_apps" {
   load_balancer_arn = aws_lb.cf_apps.arn
   port              = "443"
@@ -50,6 +66,8 @@ resource "aws_lb_listener" "cf_apps_http" {
     type             = "forward"
   }
 }
+
+
 
 resource "aws_lb_listener_certificate" "pages_staging" {
   listener_arn    = aws_lb_listener.cf_apps.arn

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -53,10 +53,6 @@ resource "aws_lb_listener" "cf_apps" {
   default_action {
     type = "forward"
     forward {
-      stickiness {
-        duration = 0
-        enabled = false
-      }
       target_group {
         arn = aws_lb_target_group.cf_apps_target.arn
         weight = 90

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -52,7 +52,7 @@ resource "aws_lb_listener" "cf_apps" {
 
   default_action {
     forward {
-      stickness {
+      stickiness {
         duration = 0
         enabled = false
       }

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -51,8 +51,20 @@ resource "aws_lb_listener" "cf_apps" {
   certificate_arn   = var.elb_apps_cert_id
 
   default_action {
-    target_group_arn = aws_lb_target_group.cf_apps_target.arn
-    type             = "forward"
+    forward {
+      stickness {
+        duration = 0
+        enabled = false
+      }
+      target_group {
+        arn = aws_lb_target_group.cf_apps_target.arn
+        weight = 90
+      }
+      target_group {
+        arn = aws_lb_target_group.cf_apps_target_https.arn
+        weight = 10
+      }
+    }
   }
 }
 

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -51,6 +51,7 @@ resource "aws_lb_listener" "cf_apps" {
   certificate_arn   = var.elb_apps_cert_id
 
   default_action {
+    type = "forward"
     forward {
       stickiness {
         duration = 0

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -51,6 +51,7 @@ resource "aws_lb_listener" "cf" {
   certificate_arn   = var.elb_main_cert_id
 
   default_action {
+    type = "forward"
     forward {
       stickiness {
         duration = 0

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -53,10 +53,6 @@ resource "aws_lb_listener" "cf" {
   default_action {
     type = "forward"
     forward {
-      stickiness {
-        duration = 0
-        enabled = false
-      }
       target_group {
         arn = aws_lb_target_group.cf_target.arn
         weight = 90

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -27,6 +27,22 @@ resource "aws_lb_target_group" "cf_target" {
   }
 }
 
+resource "aws_lb_target_group" "cf_target_https" {
+  name     = "${var.stack_description}-cf-https"
+  port     = 443
+  protocol = "HTTPS"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    interval            = 5
+    port                = 81
+    timeout             = 4
+    unhealthy_threshold = 3
+    matcher             = 200
+  }
+}
+
 resource "aws_lb_listener" "cf" {
   load_balancer_arn = aws_lb.cf.arn
   port              = "443"
@@ -50,4 +66,3 @@ resource "aws_lb_listener" "cf_http" {
     type             = "forward"
   }
 }
-

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -51,8 +51,20 @@ resource "aws_lb_listener" "cf" {
   certificate_arn   = var.elb_main_cert_id
 
   default_action {
-    target_group_arn = aws_lb_target_group.cf_target.arn
-    type             = "forward"
+    forward {
+      stickness {
+        duration = 0
+        enabled = false
+      }
+      target_group {
+        arn = aws_lb_target_group.cf_target.arn
+        weight = 90
+      }
+      target_group {
+        arn = aws_lb_target_group.cf_target_https.arn
+        weight = 10
+      }
+    }
   }
 }
 

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -52,7 +52,7 @@ resource "aws_lb_listener" "cf" {
 
   default_action {
     forward {
-      stickness {
+      stickiness {
         duration = 0
         enabled = false
       }

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -17,9 +17,15 @@ output "apps_lb_dns_name" {
 output "lb_target_group" {
   value = aws_lb_target_group.cf_target.name
 }
+output "lb_target_https_group" {
+  value = aws_lb_target_group.cf_target_https.name
+}
 
 output "apps_lb_target_group" {
   value = aws_lb_target_group.cf_apps_target.name
+}
+output "apps_lb_target_https_group" {
+  value = aws_lb_target_group.cf_apps_target_https.name
 }
 
 output "cf_rds_url" {
@@ -83,5 +89,3 @@ output "droplets_bucket_name" {
 output "logsearch_archive_bucket_name" {
   value = module.logsearch-archive.bucket_name
 }
-
-

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -209,6 +209,8 @@ output "cf_router_target_groups" {
   value = concat(
     [module.cf.lb_target_group],
     [module.cf.apps_lb_target_group],
+    [module.cf.lb_target_https_group],  
+    [module.cf.apps_lb_target_https_group],
     aws_lb_target_group.domains_broker_apps.*.name,
     aws_lb_target_group.domains_broker_challenge.*.name,
     aws_lb_target_group.domain_broker_v2_apps.*.name,
@@ -538,4 +540,3 @@ output "master_bosh_static_ip" {
 output "nessus_static_ip" {
   value = data.terraform_remote_state.target_vpc.outputs.nessus_static_ip
 }
-


### PR DESCRIPTION
## Changes proposed in this pull request:
- Create new target groups using HTTPS backend
- Modify forward rules for ELB to use both target groups
- Modify forward rules to allow split of traffic - to start 90 % http / 10% https to allow us to monitor impact

## security considerations
This starts the move from HTTPS traffic direct from points outside the platform straight through to the app container.
