### PR TITLE
Domains https & 75/25

### DIFF
--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -55,11 +55,11 @@ resource "aws_lb_listener" "cf_apps" {
     forward {
       target_group {
         arn = aws_lb_target_group.cf_apps_target.arn
-        weight = 90
+        weight = 75
       }
       target_group {
         arn = aws_lb_target_group.cf_apps_target_https.arn
-        weight = 10
+        weight = 25
       }
     }
   }

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -59,11 +59,11 @@ resource "aws_lb_listener" "cf_apps" {
         }
       target_group {
         arn = aws_lb_target_group.cf_apps_target.arn
-        weight = 75
+        weight = 76
       }
       target_group {
         arn = aws_lb_target_group.cf_apps_target_https.arn
-        weight = 25
+        weight = 24
       }
     }
   }

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -53,6 +53,10 @@ resource "aws_lb_listener" "cf_apps" {
   default_action {
     type = "forward"
     forward {
+      stickiness {
+        duration = 1
+        enabled  = false
+        }
       target_group {
         arn = aws_lb_target_group.cf_apps_target.arn
         weight = 75

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -59,11 +59,11 @@ resource "aws_lb_listener" "cf_apps" {
         }
       target_group {
         arn = aws_lb_target_group.cf_apps_target.arn
-        weight = 76
+        weight = 75
       }
       target_group {
         arn = aws_lb_target_group.cf_apps_target_https.arn
-        weight = 24
+        weight = 25
       }
     }
   }

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -55,11 +55,11 @@ resource "aws_lb_listener" "cf" {
     forward {
       target_group {
         arn = aws_lb_target_group.cf_target.arn
-        weight = 90
+        weight = 75
       }
       target_group {
         arn = aws_lb_target_group.cf_target_https.arn
-        weight = 10
+        weight = 25
       }
     }
   }

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -53,6 +53,10 @@ resource "aws_lb_listener" "cf" {
   default_action {
     type = "forward"
     forward {
+      stickiness {
+        duration = 1
+        enabled  = false
+        }
       target_group {
         arn = aws_lb_target_group.cf_target.arn
         weight = 75

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -136,11 +136,11 @@ resource "aws_lb_listener" "domain_broker_v2_https" {
     type = "forward"
     forward {
       target_group {
-        arn = aws_lb_target_group.domains_broker_v2_apps[count.index].arn
+        arn = aws_lb_target_group.domain_broker_v2_apps[count.index].arn
         weight = 90
         }
         target_group {
-        arn = aws_lb_target_group.domains_broker_v2_apps_https[count.index].arn
+        arn = aws_lb_target_group.domain_broker_v2_apps_https[count.index].arn
         weight = 10
         }
       }

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -137,11 +137,11 @@ resource "aws_lb_listener" "domain_broker_v2_https" {
     forward {
       target_group {
         arn = aws_lb_target_group.domain_broker_v2_apps[count.index].arn
-        weight = 90
+        weight = 75
         }
         target_group {
         arn = aws_lb_target_group.domain_broker_v2_apps_https[count.index].arn
-        weight = 10
+        weight = 25
         }
       }
   }

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -135,6 +135,10 @@ resource "aws_lb_listener" "domain_broker_v2_https" {
   default_action {
     type = "forward"
     forward {
+      stickiness {
+        duration = 1
+        enabled  = false
+        }
       target_group {
         arn = aws_lb_target_group.domain_broker_v2_apps[count.index].arn
         weight = 75

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -3,7 +3,7 @@
 // =====================================
 // OK, so DO NOT DELETE THESE RESOURCES
 // =====================================
-// 
+//
 // ...unless you're prepared to spend ~2 days doing terraform state surgery.
 //
 // https://docs.google.com/document/d/19LDEX8ac46JkPgoJUoSAJCf2B0K5D_QpX6O1IdO8w7Q/edit
@@ -13,9 +13,9 @@
 // https://github.com/cloud-gov/cg-provision/issues/735
 //
 // Basically, these resources are pointed at the same AWS resources (LB,
-// listeners, etc) as the other domains_broker resources in this directory.  
+// listeners, etc) as the other domains_broker resources in this directory.
 // We attempted to delete these resources.  `terraform plan` looked good, but
-// `terraform apply` got real mad.  
+// `terraform apply` got real mad.
 
 variable "domain_broker_v2_rds_username" {
 }
@@ -133,8 +133,17 @@ resource "aws_lb_listener" "domain_broker_v2_https" {
   certificate_arn   = data.aws_iam_server_certificate.wildcard.arn
 
   default_action {
-    target_group_arn = aws_lb_target_group.domain_broker_v2_apps[count.index].arn
-    type             = "forward"
+    type = "forward"
+    forward {
+      target_group {
+        arn = aws_lb_target_group.domains_broker_v2_apps[count.index].arn
+        weight = 90
+        }
+        target_group {
+        arn = aws_lb_target_group.domains_broker_v2_apps_https[count.index].arn
+        weight = 10
+        }
+      }
   }
 }
 
@@ -181,6 +190,24 @@ resource "aws_lb_target_group" "domain_broker_v2_apps" {
   name     = "${var.stack_description}-domains-apps-${count.index}"
   port     = 80
   protocol = "HTTP"
+  vpc_id   = module.stack.vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 4
+    interval            = 5
+    port                = 81
+    matcher             = 200
+  }
+}
+
+resource "aws_lb_target_group" "domain_broker_v2_apps_https" {
+  count = var.domain_broker_v2_alb_count
+
+  name     = "${var.stack_description}-domains-apps-https-${count.index}"
+  port     = 443
+  protocol = "HTTPS"
   vpc_id   = module.stack.vpc_id
 
   health_check {
@@ -242,6 +269,10 @@ output "domain_broker_v2_alb_names" {
 
 output "domain_broker_v2_target_group_apps_names" {
   value = aws_lb_target_group.domain_broker_v2_apps.*.name
+}
+
+output "domain_broker_v2_target_group_apps_https_names" {
+  value = aws_lb_target_group.domain_broker_v2_apps_https.*.name
 }
 
 output "domain_broker_v2_target_group_challenge_names" {

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -132,6 +132,10 @@ resource "aws_lb_listener" "domains_broker_https" {
   default_action {
     type = "forward"
     forward {
+      stickiness {
+        duration = 1
+        enabled  = false
+        }
       target_group {
         arn = aws_lb_target_group.domains_broker_apps[count.index].arn
         weight = 75

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -134,11 +134,11 @@ resource "aws_lb_listener" "domains_broker_https" {
     forward {
       target_group {
         arn = aws_lb_target_group.domains_broker_apps[count.index].arn
-        weight = 90
+        weight = 75
       }
       target_group {
         arn = aws_lb_target_group.domains_broker_apps_https[count.index].arn
-        weight = 10
+        weight = 25
       }
     }
   }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -235,7 +235,7 @@ output "domains_broker_target_group_apps_names" {
   value = aws_lb_target_group.domains_broker_apps.*.name
 }
 
-output "domains_broker_target_group_apps_names" {
+output "domains_broker_target_group_apps_https_names" {
   value = aws_lb_target_group.domains_broker_apps_https.*.name
 }
 

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -209,9 +209,10 @@ output "cf_router_target_groups" {
   value = concat(
     [module.cf.lb_target_group],
     [module.cf.apps_lb_target_group],
-    [module.cf.lb_target_https_group],  
+    [module.cf.lb_target_https_group],
     [module.cf.apps_lb_target_https_group],
     aws_lb_target_group.domains_broker_apps.*.name,
+    aws_lb_target_group.domains_broker_apps_https.*.name,
     aws_lb_target_group.domains_broker_challenge.*.name,
     aws_lb_target_group.domain_broker_v2_apps.*.name,
     aws_lb_target_group.domain_broker_v2_challenge.*.name,

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -215,6 +215,7 @@ output "cf_router_target_groups" {
     aws_lb_target_group.domains_broker_apps_https.*.name,
     aws_lb_target_group.domains_broker_challenge.*.name,
     aws_lb_target_group.domain_broker_v2_apps.*.name,
+    aws_lb_target_group.domain_broker_v2_apps_https.*.name,
     aws_lb_target_group.domain_broker_v2_challenge.*.name,
   )
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Bring domain-broker ELBs into the ratio mix besides CF domain and CF apps
- Move ratio from 90/10 to 75/25
- Add stickiness block to cover TF bug

## security considerations
By moving towards HTTPS thru the ELB/SecureProxy/Gorouter/App container we don't have any HTTP traffic for apps coming through
