### PR TITLE
Add zendesk email verification code 

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -166,6 +166,7 @@ resource "aws_route53_record" "cloud_gov_zendesk_verification_txt" {
 
   records = [
     "bb924f6a32697b2b",
+    "57a42f5dc9fd8c6a",
   ]
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- add verification code to allow Zendesk to send emails from pages-support@cloud.gov instead of a federalist-support zendesk email address
-
-

## security considerations
Mimics existing code for cloud support Zendesk 
