### PR TITLE
moving to 50/50 traffic

### DIFF
--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -59,11 +59,11 @@ resource "aws_lb_listener" "cf_apps" {
         }
       target_group {
         arn = aws_lb_target_group.cf_apps_target.arn
-        weight = 75
+        weight = 50
       }
       target_group {
         arn = aws_lb_target_group.cf_apps_target_https.arn
-        weight = 25
+        weight = 50
       }
     }
   }

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -59,11 +59,11 @@ resource "aws_lb_listener" "cf" {
         }
       target_group {
         arn = aws_lb_target_group.cf_target.arn
-        weight = 75
+        weight = 50
       }
       target_group {
         arn = aws_lb_target_group.cf_target_https.arn
-        weight = 25
+        weight = 50
       }
     }
   }

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -141,11 +141,11 @@ resource "aws_lb_listener" "domain_broker_v2_https" {
         }
       target_group {
         arn = aws_lb_target_group.domain_broker_v2_apps[count.index].arn
-        weight = 75
+        weight = 50
         }
         target_group {
         arn = aws_lb_target_group.domain_broker_v2_apps_https[count.index].arn
-        weight = 25
+        weight = 50
         }
       }
   }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -138,11 +138,11 @@ resource "aws_lb_listener" "domains_broker_https" {
         }
       target_group {
         arn = aws_lb_target_group.domains_broker_apps[count.index].arn
-        weight = 75
+        weight = 50
       }
       target_group {
         arn = aws_lb_target_group.domains_broker_apps_https[count.index].arn
-        weight = 25
+        weight = 50
       }
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Moving traffic flow for 10/5 to be 50% each http/https

## security considerations
Moving to all HTTPS traffic from backend of elb thru secureproxy/gorouter, to app container is more secure then HTTP
