### PR TITLE
moving to 25% http 75% https

### DIFF
--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -59,11 +59,11 @@ resource "aws_lb_listener" "cf_apps" {
         }
       target_group {
         arn = aws_lb_target_group.cf_apps_target.arn
-        weight = 50
+        weight = 25
       }
       target_group {
         arn = aws_lb_target_group.cf_apps_target_https.arn
-        weight = 50
+        weight = 75
       }
     }
   }

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -59,11 +59,11 @@ resource "aws_lb_listener" "cf" {
         }
       target_group {
         arn = aws_lb_target_group.cf_target.arn
-        weight = 50
+        weight = 25
       }
       target_group {
         arn = aws_lb_target_group.cf_target_https.arn
-        weight = 50
+        weight = 75
       }
     }
   }

--- a/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
+++ b/terraform/stacks/main/domain_broker_v2_do_not_delete.tf
@@ -141,11 +141,11 @@ resource "aws_lb_listener" "domain_broker_v2_https" {
         }
       target_group {
         arn = aws_lb_target_group.domain_broker_v2_apps[count.index].arn
-        weight = 50
+        weight = 25
         }
         target_group {
         arn = aws_lb_target_group.domain_broker_v2_apps_https[count.index].arn
-        weight = 50
+        weight = 75
         }
       }
   }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -138,11 +138,11 @@ resource "aws_lb_listener" "domains_broker_https" {
         }
       target_group {
         arn = aws_lb_target_group.domains_broker_apps[count.index].arn
-        weight = 50
+        weight = 25
       }
       target_group {
         arn = aws_lb_target_group.domains_broker_apps_https[count.index].arn
-        weight = 50
+        weight = 75
       }
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Shift to 25% http and 75% https traffic in secureproxy

## security considerations
By removing http from secureproxy we are removing any non-tls from the path of elb to container
