### PR TITLE
dns records for uaa elb for stage

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -282,6 +282,52 @@ resource "aws_route53_record" "cloud_gov_star_fr-stage_cloud_gov_aaaa" {
   }
 }
 
+resource "aws_route53_record" "cloud_gov_uaa_fr-stage_env_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "uaa.fr-stage.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+resource "aws_route53_record" "cloud_gov_uaa_fr-stage_env_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "uaa.fr-stage.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_login_fr-stage_env_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "login.fr-stage.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+resource "aws_route53_record" "cloud_gov_login_fr-stage_env_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "login.fr-stage.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "cloud_gov_prometheus_fr-stage_cloud_gov_a" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "prometheus.fr-stage.cloud.gov."


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add dns records to move uaa/login.fr-stage.cloud.gov to point to uaa elb

## security considerations
Moving to uaa elb with WAF allow us to better secure the uaa/login path of the platform
