### PR TITLE
require all child checks to be healthy

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -316,7 +316,7 @@ resource "aws_route53_health_check" "stage_app_healthcheck" {
 
 resource "aws_route53_health_check" "stage_aggregate_health" {
   type                   = "CALCULATED"
-  child_health_threshold = 1
+  child_health_threshold = 3
   child_healthchecks     = [aws_route53_health_check.stage_api_healthcheck.id, aws_route53_health_check.stage_app_healthcheck.id, aws_route53_health_check.stage_uaa_healthcheck.id]
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- require all child checks to be healthy. I had the threshold reversed initially: the `1` before meant `consider this healthy if at least 1 child is healthy`, but what we want is for all the children to be healthy

## security considerations
None