### PR TITLE
add policy api calls to platform aws-broker policy

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -129,7 +129,13 @@
         "iam:PassRole",
         "iam:DetachRolePolicy",
         "iam:ListRolePolicies",
-        "iam:GetRolePolicy"
+        "iam:GetRolePolicy",
+        "iam:ListPolicies",
+        "iam:ListPolicyVersions",
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion",
+        "iam:CreatePolicyVersion",
+        "iam:DeletePolicyVersion"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
Need to give aws-broker the ability to modify existing policies for enabling snapshots on elasticsearch instances..

## Changes proposed in this pull request:
- add the following API call permissions to the policy for aws-broker:
-               "iam:ListPolicies",
                "iam:ListPolicyVersions",
                "iam:GetPolicy",
                "iam:GetPolicyVersion",
                "iam:CreatePolicyVersion",
                "iam:DeletePolicyVersion"
the elasticsearch broker needs to be able to access the existing policies on instances and modify them to allow itself to create snapshots before delete.

## security considerations
aws-broker can now modify policies, however this doesn't add any additional risk over the ability to create new policies that already exist.
