### PR TITLE
add cloudfront-to-alb rule in count

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -865,7 +865,6 @@ jobs:
         params:
           file: terraform-yaml/state.yml
 
-
 - name: plan-bootstrap-development
   plan:
   - in_parallel:
@@ -1286,6 +1285,8 @@ jobs:
       TF_VAR_parent_stack_name: "master-east"
       TF_VAR_log_bucket_name: "cg-elb-logs-easta"
       TF_VAR_bosh_default_ssh_public_key: "((easta_bosh_ssh_public_key))"
+      TF_VAR_cloudfront_access_header_name: "((cloudfront_access_header_name))"
+      TF_VAR_cloudfront_access_header_value: "((cloudfront_access_header_value))"
   - *notify-slack
 
 - name: bootstrap-easta
@@ -1412,6 +1413,8 @@ jobs:
       TF_VAR_parent_stack_name: "master-east"
       TF_VAR_log_bucket_name: "cg-elb-logs-eastb"
       TF_VAR_bosh_default_ssh_public_key: "((eastb_bosh_ssh_public_key))"
+      TF_VAR_cloudfront_access_header_name: "((cloudfront_access_header_name))"
+      TF_VAR_cloudfront_access_header_value: "((cloudfront_access_header_value))"
   - *notify-slack
 
 - name: bootstrap-eastb
@@ -1539,6 +1542,8 @@ jobs:
       TF_VAR_parent_stack_name: "master-west"
       TF_VAR_log_bucket_name: "cg-elb-logs-westb"
       TF_VAR_bosh_default_ssh_public_key: "((westb_bosh_ssh_public_key))"
+      TF_VAR_cloudfront_access_header_name: "((cloudfront_access_header_name))"
+      TF_VAR_cloudfront_access_header_value: "((cloudfront_access_header_value))"
   - *notify-slack
 
 - name: bootstrap-westb
@@ -1665,6 +1670,8 @@ jobs:
       TF_VAR_parent_stack_name: "master-west"
       TF_VAR_log_bucket_name: "cg-elb-logs-westc"
       TF_VAR_bosh_default_ssh_public_key: "((westc_bosh_ssh_public_key))"
+      TF_VAR_cloudfront_access_header_name: "((cloudfront_access_header_name))"
+      TF_VAR_cloudfront_access_header_value: "((cloudfront_access_header_value))"
   - *notify-slack
 
 - name: bootstrap-westc

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -243,84 +243,43 @@ resource "aws_wafv2_web_acl" "cf_domains_waf_acl" {
   }
 
   rule {
-    name     = "CG-DomainsRegexPatternSets"
-    priority = 10  
+    name     = "cloudfront-only-access"
+    priority = 1
     action {
-      block {}
-    }  
+      count {}
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.stack_description}-Domains-KnownBadInputsRuleSet"
+      sampled_requests_enabled   = true
+    }
+
     statement {
       or_statement {
         statement {
-          regex_pattern_set_reference_statement {
-            arn = aws_wafv2_regex_pattern_set.jndi_regex_domains.arn
+          byte_match_statement {
+            field_to_match {
+              single_header {
+                name = var.cloudfront_access_header_name
+              }
+            }
+            positional_constraint = "EXACTLY"
+            search_string = var.cloudfront_access_header_value
+          }
+        }
+        statement {
+          byte_match_statement {
+            positional_constraint = "EXACTLY"
+            search_string = "/robots.txt"
             field_to_match {
               uri_path {}
-            }
-            text_transformation {
-              priority = 0
-              type = "NONE"
-            }
-          }
-        }
-        statement {
-          regex_pattern_set_reference_statement {
-            arn = aws_wafv2_regex_pattern_set.jndi_regex_domains.arn
-            field_to_match {
-              query_string {}
-            }
-            text_transformation {
-              priority = 0
-              type = "NONE"
-            }
-          }
-        }
-        statement {
-          regex_pattern_set_reference_statement {
-            arn = aws_wafv2_regex_pattern_set.jndi_regex_domains.arn
-            field_to_match {
-              body {}
-            }
-            text_transformation {
-              priority = 0
-              type = "NONE"
-            }
-          }
-        }
-        statement {
-          regex_pattern_set_reference_statement {
-            arn = aws_wafv2_regex_pattern_set.jndi_regex_domains.arn
-            field_to_match {
-              single_header {
-                name = "user-agent"
-              }
-            }
-            text_transformation {
-              priority = 0
-              type = "NONE"
-            }
-          }
-        }
-        statement {
-          regex_pattern_set_reference_statement {
-            arn = aws_wafv2_regex_pattern_set.jndi_regex_domains.arn
-            field_to_match {
-              single_header {
-                name = "accept"
-              }
-            }
-            text_transformation {
-              priority = 0
-              type = "NONE"
             }
           }
         }
       }
-    }  
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.stack_description}-Domains-ManagedRulesCommonRuleSet"
-      sampled_requests_enabled   = true
     }
+
+
   }
 
   rule {

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -129,3 +129,10 @@ variable "az1_index" {
 variable "az2_index" {
   default = "1"
 }
+
+variable cloudfront_access_header_name {
+
+}
+variable cloudfront_access_header_value {
+
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- add cloudfront-to-alb rule in count. This will let us set a private header on cloudfront to restrict access to our ALB, preventing direct probing
- remove JNDI rules - AWS has these built-in now

## security considerations
This should improve our security posture and resilience to DoS/DDoS on this app.