### PR TITLE
start moving dev to its own DNS setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ tmp/*
 # Terraform files
 *.tfstate
 *.tfstate.backup
-.terraform
+.terraform*
 *.tfvars
 
 # Eclipse IDE files

--- a/terraform/stacks/dns/dev.tf
+++ b/terraform/stacks/dns/dev.tf
@@ -5,7 +5,7 @@ resource "aws_route53_zone" "dev_zone" {
 
 # this is the switch we flip to make it active - before we turn this on, 
 # the new zone does nothing
-#resource "aws_route53_record" "west_ns" {
+#resource "aws_route53_record" "dev_ns" {
 #  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
 #  name    = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
 #  type    = "NS"

--- a/terraform/stacks/dns/dev.tf
+++ b/terraform/stacks/dns/dev.tf
@@ -1,141 +1,25 @@
-resource "aws_route53_record" "cloud_gov_star_dev_env_a" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "*.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "A"
 
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
+resource "aws_route53_zone" "dev_zone" {
+    name = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
 }
 
-resource "aws_route53_record" "cloud_gov_star_dev_env_aaaa" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "*.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
+# this is the switch we flip to make it active - before we turn this on, 
+# the new zone does nothing
+#resource "aws_route53_record" "west_ns" {
+#  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+#  name    = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
+#  type    = "NS"
+#  ttl     = "30"
+#  records = aws_route53_zone.dev_zone.name_servers
+#}
 
 
-resource "aws_route53_record" "cloud_gov_uaa_dev_env_a" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "uaa.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-resource "aws_route53_record" "cloud_gov_uaa_dev_env_aaaa" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "uaa.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_login_dev_env_a" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "login.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-resource "aws_route53_record" "cloud_gov_login_dev_env_aaaa" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "login.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_idp_dev_us_gov_west_1_cloud_gov_a" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "idp.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_idp_dev_us_gov_west_1_cloud_gov_aaaa" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "idp.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_ssh_dev_env_a" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "ssh.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.diego_elb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-resource "aws_route53_record" "cloud_gov_ssh_dev_env_aaaa" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "ssh.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.diego_elb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_logs_platform_dev_env_aaaa" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "AAAA"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_logs_platform_dev_env_a" {
-  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-  name    = "logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov."
-  type    = "A"
-
-  alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
-    zone_id                = var.cloudfront_zone_id
-    evaluate_target_health = false
-  }
+module "dev_dns" {
+  source              = "../../modules/environment_dns"
+  stack_name          = "dev"
+  zone_id             = aws_route53_zone.dev_zone.zone_id
+  app_subdomain       = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
+  admin_subdomain     = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
+  remote_state_bucket = var.remote_state_bucket
+  remote_state_region = var.remote_state_region
 }

--- a/terraform/stacks/dns/dev_old.tf
+++ b/terraform/stacks/dns/dev_old.tf
@@ -1,0 +1,141 @@
+resource "aws_route53_record" "cloud_gov_star_dev_env_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_star_dev_env_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+
+resource "aws_route53_record" "cloud_gov_uaa_dev_env_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "uaa.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+resource "aws_route53_record" "cloud_gov_uaa_dev_env_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "uaa.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_login_dev_env_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "login.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+resource "aws_route53_record" "cloud_gov_login_dev_env_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "login.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_idp_dev_us_gov_west_1_cloud_gov_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "idp.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_idp_dev_us_gov_west_1_cloud_gov_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "idp.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_ssh_dev_env_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "ssh.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.diego_elb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+resource "aws_route53_record" "cloud_gov_ssh_dev_env_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "ssh.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.diego_elb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_logs_platform_dev_env_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_logs_platform_dev_env_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.main_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}


### PR DESCRIPTION
this is phase one of the move - we're creating the new zone and adding the appropriate records to it.

once this is merged and deployed, we manually check the records. If everything looks good, we uncomment the ns record, wait for the TTL to expire, then revalidate. 
If that's good, we delete the whole dev_old.tf file, and re-re-validate, and move on to staging.

## Changes proposed in this pull request:
- start moving dev to its own DNS setup

## security considerations
None