### PR TITLE
start using dedicated zone for dev dns

### DIFF
--- a/terraform/stacks/dns/dev.tf
+++ b/terraform/stacks/dns/dev.tf
@@ -3,15 +3,13 @@ resource "aws_route53_zone" "dev_zone" {
     name = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
 }
 
-# this is the switch we flip to make it active - before we turn this on, 
-# the new zone does nothing
-#resource "aws_route53_record" "dev_ns" {
-#  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-#  name    = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
-#  type    = "NS"
-#  ttl     = "30"
-#  records = aws_route53_zone.dev_zone.name_servers
-#}
+resource "aws_route53_record" "dev_ns" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
+  type    = "NS"
+  ttl     = "30"
+  records = aws_route53_zone.dev_zone.name_servers
+}
 
 
 module "dev_dns" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- start using dedicated zone for dev dns

## security considerations
moving dev to its own zone means better environment isolation