### PR TITLE
Fix opsuaa name

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -256,6 +256,7 @@ jobs:
       TF_VAR_credhub_prod_rds_password: ((credhub_prod_rds_password))
       TF_VAR_credhub_staging_rds_password: ((credhub_staging_rds_password))
       TF_VAR_opsuaa_rds_password: ((opsuaa_rds_password))
+      TF_VAR_opslogin_hostname: ((tooling_opslogin_hostname))
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_cloudtrail_bucket: ((aws_s3_cloudtrail_bucket))
       TF_VAR_vpc_cidr: ((tooling_vpc_cidr))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -256,7 +256,7 @@ jobs:
       TF_VAR_credhub_prod_rds_password: ((credhub_prod_rds_password))
       TF_VAR_credhub_staging_rds_password: ((credhub_staging_rds_password))
       TF_VAR_opsuaa_rds_password: ((opsuaa_rds_password))
-      TF_VAR_opslogin_hostname: ((tooling_opslogin_hostname))
+      TF_VAR_opslogin_hostname: opslogin.fr.cloud.gov
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_cloudtrail_bucket: ((aws_s3_cloudtrail_bucket))
       TF_VAR_vpc_cidr: ((tooling_vpc_cidr))

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -167,7 +167,6 @@ variable "oidc_client_secret" {
 }
 
 variable "opslogin_hostname" {
-  default = "opsuaa.fr.cloud.gov"
 }
 
 variable "bosh_default_ssh_public_key" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- force setting opslogin hostname in stack
- set opslogin hostname for tooling in pipeline

## security considerations
None