### PR TITLE
Rbogle patch 1

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -67,6 +67,18 @@
       ]
     },
     {
+        "Action": [
+            "s3:GetBucketLocation",
+            "s3:ListAllMyBuckets",
+            "s3:ListBucket",
+            "s3:GetBucketAcl"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+            "arn:aws-us-gov:s3:::*"
+        ]
+    },
+    {
       "Effect": "Allow",
       "Action": [
         "es:ESHttpGet",

--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -67,17 +67,18 @@
       ]
     },
     {
-        "Action": [
-            "s3:GetBucketLocation",
-            "s3:ListAllMyBuckets",
-            "s3:ListBucket",
-            "s3:GetBucketAcl"
-        ],
-        "Effect": "Allow",
-        "Resource": [
-            "arn:aws-us-gov:s3:::*"
-        ]
-    },
+      "Action": [
+	"s3:GetBucketLocation",
+        "s3:ListAllMyBuckets",
+        "s3:ListBucket",
+        "s3:PutObject",
+        "s3:GetBucketAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws-us-gov:s3:::*"
+      ]
+    },    
     {
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## Changes proposed in this pull request:
- update aws-broker role perms to allow ElastiCache to export backups to s3. 
-
-

## security considerations
None, permissions allow listing buckets, putting snapshots, and accessing acls. 
Specific bucket specific permissions for get and delete objects are required for any further access. 
