### PR TITLE
add port specification, scale listeners more

### DIFF
--- a/terraform/modules/cloudfoundry/nlb.tf
+++ b/terraform/modules/cloudfoundry/nlb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "cf_apps_tcp" {
-  count = var.tcp_lb_count
+  count           = var.tcp_lb_count
   name            = "${var.stack_description}-cf-tcp-${count.index}"
   subnets         = var.elb_subnets
   security_groups = var.elb_security_groups
@@ -13,7 +13,7 @@ resource "aws_lb" "cf_apps_tcp" {
 }
 
 resource "aws_lb_target_group" "cf_apps_target_tcp" {
-  count = var.tcp_lb_count
+  count    = var.tcp_lb_count
   name     = "${var.stack_description}-cf-tcp-${count.index}"
   port     = 443
   protocol = "TCP"
@@ -22,12 +22,14 @@ resource "aws_lb_target_group" "cf_apps_target_tcp" {
 }
 
 resource "aws_lb_listener" "cf_apps_tcp" {
-  count = var.tcp_lb_count
-  load_balancer_arn = aws_lb.cf_apps_tcp[count.index].arn
+  count             = var.tcp_lb_count * var.listeners_per_tcp_lb
+  load_balancer_arn = aws_lb.cf_apps_tcp[floor(count.index/var.listeners_per_tcp_lb)].arn
   protocol          = "TCP"
+  port              = var.tcp_first_port + count.index
+
 
   default_action {
-    target_group_arn = aws_lb_target_group.cf_apps_target_tcp[count.index].arn
+    target_group_arn = aws_lb_target_group.cf_apps_target_tcp[floor(count.index/var.listeners_per_tcp_lb)].arn
     type             = "forward"
   }
 }

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -107,3 +107,11 @@ variable "log_bucket_name" {
 variable "tcp_lb_count" {
   default = 0
 }
+
+variable "listeners_per_tcp_lb" {
+  default = 10
+}
+
+variable "tcp_first_port" {
+  default = 10000
+}


### PR DESCRIPTION
Context: turns out with elbv2, there's a 1:1 port:listener mapping, so we need to specify which port a listener listens on and add more listeners if we want more ports.
There's a limit of 50 ports per listener that we'll need to look out for.

## Changes proposed in this pull request:
- specify port
- scale listeners so we can have more ports


## security considerations
None