### PR TITLE
drop access logs for NLB

### DIFF
--- a/terraform/modules/cloudfoundry/nlb.tf
+++ b/terraform/modules/cloudfoundry/nlb.tf
@@ -4,7 +4,6 @@ resource "aws_lb" "cf_apps_tcp" {
   load_balancer_type = "network"
   subnets            = var.elb_subnets
   ip_address_type    = "dualstack"
-  idle_timeout       = 3600
 }
 
 resource "aws_lb_target_group" "cf_apps_target_tcp" {

--- a/terraform/modules/cloudfoundry/nlb.tf
+++ b/terraform/modules/cloudfoundry/nlb.tf
@@ -5,11 +5,6 @@ resource "aws_lb" "cf_apps_tcp" {
   subnets            = var.elb_subnets
   ip_address_type    = "dualstack"
   idle_timeout       = 3600
-  access_logs {
-    bucket  = var.log_bucket_name
-    prefix  = var.stack_description
-    enabled = true
-  }
 }
 
 resource "aws_lb_target_group" "cf_apps_target_tcp" {


### PR DESCRIPTION
NLB access logs only contain TLS connection information, so they're useless to us.

## Changes proposed in this pull request:
- drop access logs for NLB
- drop idle timeout param, which also does not apply to nlbs

## security considerations
not having logs is going to be a compliance issue, but flow logs + gorouter logs should help alleviate that