### PR TITLE
Add dev env, add commented out prod env, add dns for main subdomain for all envs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -375,16 +375,7 @@ jobs:
       TF_VAR_domains_broker_alb_count: "2"
       TF_VAR_domains_broker_rds_username: ((development_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((development_domains_broker_rds_password))
-      # Not used in dev
-      # TF_VAR_pages_certificate_name_prefix: pages.cloud.gov
-      # TF_VAR_wildcard_pages_certificate_name_prefix: star.pages.cloud.gov
-      # TF_VAR_wildcard_sites_pages_certificate_name_prefix: star.sites.pages.cloud.gov
-      TF_VAR_pages_staging_certificate_name_prefix: pages-staging.cloud.gov
-      TF_VAR_wildcard_pages_staging_certificate_name_prefix: star.pages-staging.cloud.gov
-      TF_VAR_wildcard_sites_pages_staging_certificate_name_prefix: star.sites.pages-staging.cloud.gov
-      TF_VAR_pages_dev_certificate_name_prefix: pages-dev.cloud.gov
-      TF_VAR_wildcard_pages_dev_certificate_name_prefix: star.pages-dev.cloud.gov
-      TF_VAR_wildcard_sites_pages_dev_certificate_name_prefix: star.sites.pages-dev.cloud.gov
+      TF_VAR_pages_cert_patterns: '[]'
   - *notify-slack
 
 - name: bootstrap-development
@@ -498,16 +489,7 @@ jobs:
       TF_VAR_domains_broker_alb_count: "2"
       TF_VAR_domains_broker_rds_username: ((staging_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((staging_domains_broker_rds_password))
-      # Not used in staging
-      # TF_VAR_pages_certificate_name_prefix: pages.cloud.gov
-      # TF_VAR_wildcard_pages_certificate_name_prefix: star.pages.cloud.gov
-      # TF_VAR_wildcard_sites_pages_certificate_name_prefix: star.sites.pages.cloud.gov
-      TF_VAR_pages_staging_certificate_name_prefix: pages-staging.cloud.gov
-      TF_VAR_wildcard_pages_staging_certificate_name_prefix: star.pages-staging.cloud.gov
-      TF_VAR_wildcard_sites_pages_staging_certificate_name_prefix: star.sites.pages-staging.cloud.gov
-      TF_VAR_pages_dev_certificate_name_prefix: pages-dev.cloud.gov
-      TF_VAR_wildcard_pages_dev_certificate_name_prefix: star.pages-dev.cloud.gov
-      TF_VAR_wildcard_sites_pages_dev_certificate_name_prefix: star.sites.pages-dev.cloud.gov
+      TF_VAR_pages_cert_patterns: '[]'
   - *notify-slack
 
 - name: bootstrap-staging
@@ -620,15 +602,7 @@ jobs:
       TF_VAR_domains_broker_alb_count: "6"
       TF_VAR_domains_broker_rds_username: ((production_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((production_domains_broker_rds_password))
-      # TF_VAR_pages_certificate_name_prefix: pages.cloud.gov
-      # TF_VAR_wildcard_pages_certificate_name_prefix: star.pages.cloud.gov
-      # TF_VAR_wildcard_sites_pages_certificate_name_prefix: star.sites.pages.cloud.gov
-      TF_VAR_pages_staging_certificate_name_prefix: pages-staging.cloud.gov
-      TF_VAR_wildcard_pages_staging_certificate_name_prefix: star.pages-staging.cloud.gov
-      TF_VAR_wildcard_sites_pages_staging_certificate_name_prefix: star.sites.pages-staging.cloud.gov
-      TF_VAR_pages_dev_certificate_name_prefix: pages-dev.cloud.gov
-      TF_VAR_wildcard_pages_dev_certificate_name_prefix: star.pages-dev.cloud.gov
-      TF_VAR_wildcard_sites_pages_dev_certificate_name_prefix: star.sites.pages-dev.cloud.gov
+      TF_VAR_pages_cert_patterns: '["pages-staging.cloud.gov","pages-dev.cloud.gov"]'
   - *notify-slack
 
 - name: bootstrap-production

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -24,8 +24,15 @@ groups:
   - acme-certificate-staging-pages-sites
   - acme-certificate-production
   - acme-certificate-production-apps
+  # - acme-certificate-pages
+  # - acme-certificate-wildcard-pages
+  # - acme-certificate-wildcard-pages-sites
   - acme-certificate-staging-pages
-  - acme-certificate-staging-pages-sites
+  - acme-certificate-staging-wildcard-pages
+  - acme-certificate-staging-wildcard-pages-sites
+  - acme-certificate-dev-pages
+  - acme-certificate-dev-wildcard-pages
+  - acme-certificate-dev-wildcard-pages-sites
 
 jobs:
 - name: pull-status-check
@@ -369,8 +376,15 @@ jobs:
       TF_VAR_domains_broker_rds_username: ((development_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((development_domains_broker_rds_password))
       # Not used in dev
+      # TF_VAR_pages_certificate_name_prefix: pages.cloud.gov
+      # TF_VAR_wildcard_pages_certificate_name_prefix: star.pages.cloud.gov
+      # TF_VAR_wildcard_sites_pages_certificate_name_prefix: star.sites.pages.cloud.gov
+      TF_VAR_pages_staging_certificate_name_prefix: pages-staging.cloud.gov
       TF_VAR_wildcard_pages_staging_certificate_name_prefix: star.pages-staging.cloud.gov
       TF_VAR_wildcard_sites_pages_staging_certificate_name_prefix: star.sites.pages-staging.cloud.gov
+      TF_VAR_pages_dev_certificate_name_prefix: pages-dev.cloud.gov
+      TF_VAR_wildcard_pages_dev_certificate_name_prefix: star.pages-dev.cloud.gov
+      TF_VAR_wildcard_sites_pages_dev_certificate_name_prefix: star.sites.pages-dev.cloud.gov
   - *notify-slack
 
 - name: bootstrap-development
@@ -485,8 +499,15 @@ jobs:
       TF_VAR_domains_broker_rds_username: ((staging_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((staging_domains_broker_rds_password))
       # Not used in staging
+      # TF_VAR_pages_certificate_name_prefix: pages.cloud.gov
+      # TF_VAR_wildcard_pages_certificate_name_prefix: star.pages.cloud.gov
+      # TF_VAR_wildcard_sites_pages_certificate_name_prefix: star.sites.pages.cloud.gov
+      TF_VAR_pages_staging_certificate_name_prefix: pages-staging.cloud.gov
       TF_VAR_wildcard_pages_staging_certificate_name_prefix: star.pages-staging.cloud.gov
       TF_VAR_wildcard_sites_pages_staging_certificate_name_prefix: star.sites.pages-staging.cloud.gov
+      TF_VAR_pages_dev_certificate_name_prefix: pages-dev.cloud.gov
+      TF_VAR_wildcard_pages_dev_certificate_name_prefix: star.pages-dev.cloud.gov
+      TF_VAR_wildcard_sites_pages_dev_certificate_name_prefix: star.sites.pages-dev.cloud.gov
   - *notify-slack
 
 - name: bootstrap-staging
@@ -599,8 +620,15 @@ jobs:
       TF_VAR_domains_broker_alb_count: "6"
       TF_VAR_domains_broker_rds_username: ((production_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((production_domains_broker_rds_password))
+      # TF_VAR_pages_certificate_name_prefix: pages.cloud.gov
+      # TF_VAR_wildcard_pages_certificate_name_prefix: star.pages.cloud.gov
+      # TF_VAR_wildcard_sites_pages_certificate_name_prefix: star.sites.pages.cloud.gov
+      TF_VAR_pages_staging_certificate_name_prefix: pages-staging.cloud.gov
       TF_VAR_wildcard_pages_staging_certificate_name_prefix: star.pages-staging.cloud.gov
       TF_VAR_wildcard_sites_pages_staging_certificate_name_prefix: star.sites.pages-staging.cloud.gov
+      TF_VAR_pages_dev_certificate_name_prefix: pages-dev.cloud.gov
+      TF_VAR_wildcard_pages_dev_certificate_name_prefix: star.pages-dev.cloud.gov
+      TF_VAR_wildcard_sites_pages_dev_certificate_name_prefix: star.sites.pages-dev.cloud.gov
   - *notify-slack
 
 - name: bootstrap-production
@@ -817,7 +845,159 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
+# - name: acme-certificate-pages
+#   plan:
+#   - in_parallel:
+#     - get: acme-timer
+#       trigger: true
+#     - get: cg-provision-repo
+#     - get: terraform-yaml-tooling
+#       resource: terraform-yaml-tooling
+#     - get: terraform-yaml-external
+#       resource: terraform-yaml-external-production
+#   - task: check-certificates
+#     file: cg-provision-repo/ci/check-certificates.yml
+#     params:
+#       AWS_DEFAULT_REGION: ((aws_default_region))
+#       CERT_PATH: /lets-encrypt/production/
+#   - task: provision-certificate
+#     file: cg-provision-repo/ci/provision-certificate.yml
+#     params:
+#       CERT_PREFIX: pages.cloud.gov
+#       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+#       DOMAIN: "pages.cloud.gov"
+#       EMAIL: cloud-gov-operations@gsa.gov
+#   - task: upload-certificate
+#     file: cg-provision-repo/ci/upload-certificate.yml
+#     params:
+#       AWS_DEFAULT_REGION: ((aws_default_region))
+#       CERT_PATH: /lets-encrypt/production/
+#       CERT_PREFIX: pages.cloud.gov
+#   on_failure:
+#     put: slack
+#     params:
+#       text: |
+#         :x: Failed to check ACME certificates for pages.cloud.gov
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+#       channel: ((slack-channel))
+#       username: ((slack-username))
+#       icon_url: ((slack-icon-url))
+
+# - name: acme-certificate-pages
+#   plan:
+#   - in_parallel:
+#     - get: acme-timer
+#       trigger: true
+#     - get: cg-provision-repo
+#     - get: terraform-yaml-tooling
+#       resource: terraform-yaml-tooling
+#     - get: terraform-yaml-external
+#       resource: terraform-yaml-external-production
+#   - task: check-certificates
+#     file: cg-provision-repo/ci/check-certificates.yml
+#     params:
+#       AWS_DEFAULT_REGION: ((aws_default_region))
+#       CERT_PATH: /lets-encrypt/production/
+#   - task: provision-certificate
+#     file: cg-provision-repo/ci/provision-certificate.yml
+#     params:
+#       CERT_PREFIX: star.pages.cloud.gov
+#       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+#       DOMAIN: "*.pages.cloud.gov"
+#       EMAIL: cloud-gov-operations@gsa.gov
+#   - task: upload-certificate
+#     file: cg-provision-repo/ci/upload-certificate.yml
+#     params:
+#       AWS_DEFAULT_REGION: ((aws_default_region))
+#       CERT_PATH: /lets-encrypt/production/
+#       CERT_PREFIX: star.pages.cloud.gov
+#   on_failure:
+#     put: slack
+#     params:
+#       text: |
+#         :x: Failed to check ACME certificates for *.pages.cloud.gov
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+#       channel: ((slack-channel))
+#       username: ((slack-username))
+#       icon_url: ((slack-icon-url))
+
+# - name: acme-certificate-pages-sites
+#   plan:
+#   - in_parallel:
+#     - get: acme-timer
+#       trigger: true
+#     - get: cg-provision-repo
+#     - get: terraform-yaml-tooling
+#       resource: terraform-yaml-tooling
+#     - get: terraform-yaml-external
+#       resource: terraform-yaml-external-production
+#   - task: check-certificates
+#     file: cg-provision-repo/ci/check-certificates.yml
+#     params:
+#       AWS_DEFAULT_REGION: ((aws_default_region))
+#       CERT_PATH: /lets-encrypt/production/
+#   - task: provision-certificate
+#     file: cg-provision-repo/ci/provision-certificate.yml
+#     params:
+#       CERT_PREFIX: star.sites.pages.cloud.gov
+#       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+#       DOMAIN: "*.sites.pages.cloud.gov"
+#       EMAIL: cloud-gov-operations@gsa.gov
+#   - task: upload-certificate
+#     file: cg-provision-repo/ci/upload-certificate.yml
+#     params:
+#       AWS_DEFAULT_REGION: ((aws_default_region))
+#       CERT_PATH: /lets-encrypt/production/
+#       CERT_PREFIX: star.sites.pages.cloud.gov
+#   on_failure:
+#     put: slack
+#     params:
+#       text: |
+#         :x: Failed to check ACME certificates for *.sites.pages.cloud.gov
+#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+#       channel: ((slack-channel))
+#       username: ((slack-username))
+#       icon_url: ((slack-icon-url))
+
 - name: acme-certificate-staging-pages
+  plan:
+  - in_parallel:
+    - get: acme-timer
+      trigger: true
+    - get: cg-provision-repo
+    - get: terraform-yaml-tooling
+      resource: terraform-yaml-tooling
+    - get: terraform-yaml-external
+      resource: terraform-yaml-external-production
+  - task: check-certificates
+    file: cg-provision-repo/ci/check-certificates.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+  - task: provision-certificate
+    file: cg-provision-repo/ci/provision-certificate.yml
+    params:
+      CERT_PREFIX: pages-staging.cloud.gov
+      ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+      DOMAIN: "pages-staging.cloud.gov"
+      EMAIL: cloud-gov-operations@gsa.gov
+  - task: upload-certificate
+    file: cg-provision-repo/ci/upload-certificate.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+      CERT_PREFIX: pages-staging.cloud.gov
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Failed to check ACME certificates for pages-staging.cloud.gov
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
+- name: acme-certificate-staging-wildcard-pages
   plan:
   - in_parallel:
     - get: acme-timer
@@ -855,7 +1035,7 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
-- name: acme-certificate-staging-pages-sites
+- name: acme-certificate-staging-wildcard-pages-sites
   plan:
   - in_parallel:
     - get: acme-timer
@@ -888,6 +1068,120 @@ jobs:
     params:
       text: |
         :x: Failed to check ACME certificates for *.sites.pages-staging.cloud.gov
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
+- name: acme-certificate-dev-pages
+  plan:
+  - in_parallel:
+    - get: acme-timer
+      trigger: true
+    - get: cg-provision-repo
+    - get: terraform-yaml-tooling
+      resource: terraform-yaml-tooling
+    - get: terraform-yaml-external
+      resource: terraform-yaml-external-production
+  - task: check-certificates
+    file: cg-provision-repo/ci/check-certificates.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+  - task: provision-certificate
+    file: cg-provision-repo/ci/provision-certificate.yml
+    params:
+      CERT_PREFIX: pages-dev.cloud.gov
+      ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+      DOMAIN: "pages-dev.cloud.gov"
+      EMAIL: cloud-gov-operations@gsa.gov
+  - task: upload-certificate
+    file: cg-provision-repo/ci/upload-certificate.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+      CERT_PREFIX: pages-dev.cloud.gov
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Failed to check ACME certificates for pages-dev.cloud.gov
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
+- name: acme-certificate-dev-wildcard-pages
+  plan:
+  - in_parallel:
+    - get: acme-timer
+      trigger: true
+    - get: cg-provision-repo
+    - get: terraform-yaml-tooling
+      resource: terraform-yaml-tooling
+    - get: terraform-yaml-external
+      resource: terraform-yaml-external-production
+  - task: check-certificates
+    file: cg-provision-repo/ci/check-certificates.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+  - task: provision-certificate
+    file: cg-provision-repo/ci/provision-certificate.yml
+    params:
+      CERT_PREFIX: star.pages-dev.cloud.gov
+      ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+      DOMAIN: "*.pages-dev.cloud.gov"
+      EMAIL: cloud-gov-operations@gsa.gov
+  - task: upload-certificate
+    file: cg-provision-repo/ci/upload-certificate.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+      CERT_PREFIX: star.pages-dev.cloud.gov
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Failed to check ACME certificates for *.pages-dev.cloud.gov
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+
+- name: acme-certificate-dev-wildcard-pages-sites
+  plan:
+  - in_parallel:
+    - get: acme-timer
+      trigger: true
+    - get: cg-provision-repo
+    - get: terraform-yaml-tooling
+      resource: terraform-yaml-tooling
+    - get: terraform-yaml-external
+      resource: terraform-yaml-external-production
+  - task: check-certificates
+    file: cg-provision-repo/ci/check-certificates.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+  - task: provision-certificate
+    file: cg-provision-repo/ci/provision-certificate.yml
+    params:
+      CERT_PREFIX: star.sites.pages-dev.cloud.gov
+      ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+      DOMAIN: "*.sites.pages-dev.cloud.gov"
+      EMAIL: cloud-gov-operations@gsa.gov
+  - task: upload-certificate
+    file: cg-provision-repo/ci/upload-certificate.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+      CERT_PREFIX: star.sites.pages-dev.cloud.gov
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Failed to check ACME certificates for *.sites.pages-dev.cloud.gov
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: ((slack-channel))
       username: ((slack-username))

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -51,51 +51,16 @@ resource "aws_lb_listener" "cf_apps_http" {
   }
 }
 
-
-
-# resource "aws_lb_listener_certificate" "main_pages" {
-#   listener_arn    = aws_lb_listener.cf_apps.arn
-#   certificate_arn = var.main_pages_cert_id
-# }
-
-# resource "aws_lb_listener_certificate" "pages" {
-#   listener_arn    = aws_lb_listener.cf_apps.arn
-#   certificate_arn = var.pages_cert_id
-# }
-
-# resource "aws_lb_listener_certificate" "sites_pages" {
-#   listener_arn    = aws_lb_listener.cf_apps.arn
-#   certificate_arn = var.sites_pages_cert_id
-# }
-
-resource "aws_lb_listener_certificate" "main_pages_staging" {
+resource "aws_lb_listener_certificate" "pages" {
+  for_each        = var.pages_cert_ids
   listener_arn    = aws_lb_listener.cf_apps.arn
-  certificate_arn = var.main_pages_staging_cert_id
+  certificate_arn = each.key
 }
 
-resource "aws_lb_listener_certificate" "pages_staging" {
+resource "aws_lb_listener_certificate" "pages_wildcard" {
+  for_each        = var.pages_wildcard_cert_ids
   listener_arn    = aws_lb_listener.cf_apps.arn
-  certificate_arn = var.pages_staging_cert_id
-}
-
-resource "aws_lb_listener_certificate" "sites_pages_staging" {
-  listener_arn    = aws_lb_listener.cf_apps.arn
-  certificate_arn = var.sites_pages_staging_cert_id
-}
-
-resource "aws_lb_listener_certificate" "main_pages_dev" {
-  listener_arn    = aws_lb_listener.cf_apps.arn
-  certificate_arn = var.main_pages_dev_cert_id
-}
-
-resource "aws_lb_listener_certificate" "pages_dev" {
-  listener_arn    = aws_lb_listener.cf_apps.arn
-  certificate_arn = var.pages_dev_cert_id
-}
-
-resource "aws_lb_listener_certificate" "sites_pages_dev" {
-  listener_arn    = aws_lb_listener.cf_apps.arn
-  certificate_arn = var.sites_pages_dev_cert_id
+  certificate_arn = each.key
 }
 
 resource "aws_wafv2_web_acl_association" "cf_apps_waf_core" {

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -53,6 +53,26 @@ resource "aws_lb_listener" "cf_apps_http" {
 
 
 
+# resource "aws_lb_listener_certificate" "main_pages" {
+#   listener_arn    = aws_lb_listener.cf_apps.arn
+#   certificate_arn = var.main_pages_cert_id
+# }
+
+# resource "aws_lb_listener_certificate" "pages" {
+#   listener_arn    = aws_lb_listener.cf_apps.arn
+#   certificate_arn = var.pages_cert_id
+# }
+
+# resource "aws_lb_listener_certificate" "sites_pages" {
+#   listener_arn    = aws_lb_listener.cf_apps.arn
+#   certificate_arn = var.sites_pages_cert_id
+# }
+
+resource "aws_lb_listener_certificate" "main_pages_staging" {
+  listener_arn    = aws_lb_listener.cf_apps.arn
+  certificate_arn = var.main_pages_staging_cert_id
+}
+
 resource "aws_lb_listener_certificate" "pages_staging" {
   listener_arn    = aws_lb_listener.cf_apps.arn
   certificate_arn = var.pages_staging_cert_id
@@ -61,6 +81,21 @@ resource "aws_lb_listener_certificate" "pages_staging" {
 resource "aws_lb_listener_certificate" "sites_pages_staging" {
   listener_arn    = aws_lb_listener.cf_apps.arn
   certificate_arn = var.sites_pages_staging_cert_id
+}
+
+resource "aws_lb_listener_certificate" "main_pages_dev" {
+  listener_arn    = aws_lb_listener.cf_apps.arn
+  certificate_arn = var.main_pages_dev_cert_id
+}
+
+resource "aws_lb_listener_certificate" "pages_dev" {
+  listener_arn    = aws_lb_listener.cf_apps.arn
+  certificate_arn = var.pages_dev_cert_id
+}
+
+resource "aws_lb_listener_certificate" "sites_pages_dev" {
+  listener_arn    = aws_lb_listener.cf_apps.arn
+  certificate_arn = var.sites_pages_dev_cert_id
 }
 
 resource "aws_wafv2_web_acl_association" "cf_apps_waf_core" {

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -4,40 +4,14 @@ variable "elb_main_cert_id" {
 variable "elb_apps_cert_id" {
 }
 
-# variable "main_pages_cert_id" {
-
-# }
-
-# variable "pages_cert_id" {
-
-# }
-
-# variable "sites_pages_cert_id" {
-  
-# }
-
-variable "main_pages_staging_cert_id" {
-
+variable "pages_cert_ids" {
+  default = []
+  type = set(string)
 }
 
-variable "pages_staging_cert_id" {
-
-}
-
-variable "sites_pages_staging_cert_id" {
-  
-}
-
-variable "main_pages_dev_cert_id" {
-
-}
-
-variable "pages_dev_cert_id" {
-
-}
-
-variable "sites_pages_dev_cert_id" {
-  
+variable "pages_wildcard_cert_ids" {
+  default = []
+  type = set(string)
 }
 
 variable "elb_subnets" {

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -4,11 +4,39 @@ variable "elb_main_cert_id" {
 variable "elb_apps_cert_id" {
 }
 
+# variable "main_pages_cert_id" {
+
+# }
+
+# variable "pages_cert_id" {
+
+# }
+
+# variable "sites_pages_cert_id" {
+  
+# }
+
+variable "main_pages_staging_cert_id" {
+
+}
+
 variable "pages_staging_cert_id" {
 
 }
 
 variable "sites_pages_staging_cert_id" {
+  
+}
+
+variable "main_pages_dev_cert_id" {
+
+}
+
+variable "pages_dev_cert_id" {
+
+}
+
+variable "sites_pages_dev_cert_id" {
   
 }
 

--- a/terraform/stacks/dns/pages.tf
+++ b/terraform/stacks/dns/pages.tf
@@ -1,3 +1,74 @@
+################
+## Production ##
+################
+# resource "aws_route53_record" "cloud_gov_pages_cloud_gov_cname" {
+#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+#   name    = "pages.cloud.gov."
+#   type    = "CNAME"
+#   ttl     = 60
+#   records = ["dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"]
+# }
+
+# resource "aws_route53_record" "cloud_gov_star_pages_cloud_gov_a" {
+#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+#   name    = "*.pages.cloud.gov."
+#   type    = "A"
+
+#   alias {
+#     name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+#     zone_id                = var.cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+
+# resource "aws_route53_record" "cloud_gov_star_pages_cloud_gov_aaaa" {
+#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+#   name    = "*.pages.cloud.gov."
+#   type    = "AAAA"
+
+#   alias {
+#     name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+#     zone_id                = var.cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+
+# resource "aws_route53_record" "cloud_gov_star_sites_pages_cloud_gov_a" {
+#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+#   name    = "*.sites.pages.cloud.gov."
+#   type    = "A"
+
+#   alias {
+#     name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+#     zone_id                = var.cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+
+# resource "aws_route53_record" "cloud_gov_star_sites_pages_cloud_gov_aaaa" {
+#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+#   name    = "*.sites.pages.cloud.gov."
+#   type    = "AAAA"
+
+#   alias {
+#     name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+#     zone_id                = var.cloudfront_zone_id
+#     evaluate_target_health = false
+#   }
+# }
+## End Production ##
+
+#############
+## Staging ##
+#############
+resource "aws_route53_record" "cloud_gov_pages_staging_cloud_gov_cname" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "pages-staging.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"]
+}
+
 resource "aws_route53_record" "cloud_gov_star_pages_staging_cloud_gov_a" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "*.pages-staging.cloud.gov."
@@ -45,4 +116,64 @@ resource "aws_route53_record" "cloud_gov_star_sites_pages_staging_cloud_gov_aaaa
     evaluate_target_health = false
   }
 }
+## End Staging ##
 
+#################
+## Development ##
+#################
+resource "aws_route53_record" "cloud_gov_pages_dev_cloud_gov_cname" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "pages-dev.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"]
+}
+
+resource "aws_route53_record" "cloud_gov_star_pages_dev_cloud_gov_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.pages-dev.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_star_pages_dev_cloud_gov_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.pages-dev.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_star_sites_pages_dev_cloud_gov_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.sites.pages-dev.cloud.gov."
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_star_sites_pages_dev_cloud_gov_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.sites.pages-dev.cloud.gov."
+  type    = "AAAA"
+
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+## End Development ##

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -72,6 +72,26 @@ data "aws_iam_server_certificate" "wildcard_apps" {
   latest      = true
 }
 
+# data "aws_iam_server_certificate" "pages" {
+#   name_prefix = var.pages_certificate_name_prefix
+#   latest      = true
+# }
+
+# data "aws_iam_server_certificate" "wildcard_pages" {
+#   name_prefix = var.wildcard_pages_certificate_name_prefix
+#   latest      = true
+# }
+
+# data "aws_iam_server_certificate" "wildcard_sites_pages" {
+#   name_prefix = var.wildcard_sites_pages_certificate_name_prefix
+#   latest      = true
+# }
+
+data "aws_iam_server_certificate" "pages_staging" {
+  name_prefix = var.pages_staging_certificate_name_prefix
+  latest      = true
+}
+
 data "aws_iam_server_certificate" "wildcard_pages_staging" {
   name_prefix = var.wildcard_pages_staging_certificate_name_prefix
   latest      = true
@@ -79,6 +99,21 @@ data "aws_iam_server_certificate" "wildcard_pages_staging" {
 
 data "aws_iam_server_certificate" "wildcard_sites_pages_staging" {
   name_prefix = var.wildcard_sites_pages_staging_certificate_name_prefix
+  latest      = true
+}
+
+data "aws_iam_server_certificate" "pages_dev" {
+  name_prefix = var.pages_dev_certificate_name_prefix
+  latest      = true
+}
+
+data "aws_iam_server_certificate" "wildcard_pages_dev" {
+  name_prefix = var.wildcard_pages_dev_certificate_name_prefix
+  latest      = true
+}
+
+data "aws_iam_server_certificate" "wildcard_sites_pages_dev" {
+  name_prefix = var.wildcard_sites_pages_dev_certificate_name_prefix
   latest      = true
 }
 
@@ -190,8 +225,15 @@ module "cf" {
   aws_partition               = data.aws_partition.current.partition
   elb_main_cert_id            = data.aws_iam_server_certificate.wildcard.arn
   elb_apps_cert_id            = data.aws_iam_server_certificate.wildcard_apps.arn
+  # main_pages_cert_id          = data.aws_iam_server_certificate.pages.arn
+  # pages_cert_id               = data.aws_iam_server_certificate.wildcard_pages.arn
+  # sites_pages_cert_id         = data.aws_iam_server_certificate.wildcard_sites_pages.arn
+  main_pages_staging_cert_id  = data.aws_iam_server_certificate.pages_staging.arn
   pages_staging_cert_id       = data.aws_iam_server_certificate.wildcard_pages_staging.arn
   sites_pages_staging_cert_id = data.aws_iam_server_certificate.wildcard_sites_pages_staging.arn
+  main_pages_dev_cert_id      = data.aws_iam_server_certificate.pages_dev.arn
+  pages_dev_cert_id           = data.aws_iam_server_certificate.wildcard_pages_dev.arn
+  sites_pages_dev_cert_id     = data.aws_iam_server_certificate.wildcard_sites_pages_dev.arn
   elb_subnets                 = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
 
   elb_security_groups = [

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -39,40 +39,9 @@ variable "wildcard_apps_certificate_name_prefix" {
   default = ""
 }
 
-# variable "pages_certificate_name_prefix" {
-#   default = ""
-# }
-
-# variable "wildcard_pages_certificate_name_prefix" {
-#   default = ""
-# }
-
-# variable "wildcard_sites_pages_certificate_name_prefix" {
-#   default = ""
-# }
-
-variable "pages_staging_certificate_name_prefix" {
-  default = ""
-}
-
-variable "wildcard_pages_staging_certificate_name_prefix" {
-  default = ""
-}
-
-variable "wildcard_sites_pages_staging_certificate_name_prefix" {
-  default = ""
-}
-
-variable "pages_dev_certificate_name_prefix" {
-  default = ""
-}
-
-variable "wildcard_pages_dev_certificate_name_prefix" {
-  default = ""
-}
-
-variable "wildcard_sites_pages_dev_certificate_name_prefix" {
-  default = ""
+variable "pages_cert_patterns" {
+  default = []
+  type = set(string)
 }
 
 variable "admin_hosts" {

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -39,11 +39,39 @@ variable "wildcard_apps_certificate_name_prefix" {
   default = ""
 }
 
+# variable "pages_certificate_name_prefix" {
+#   default = ""
+# }
+
+# variable "wildcard_pages_certificate_name_prefix" {
+#   default = ""
+# }
+
+# variable "wildcard_sites_pages_certificate_name_prefix" {
+#   default = ""
+# }
+
+variable "pages_staging_certificate_name_prefix" {
+  default = ""
+}
+
 variable "wildcard_pages_staging_certificate_name_prefix" {
   default = ""
 }
 
 variable "wildcard_sites_pages_staging_certificate_name_prefix" {
+  default = ""
+}
+
+variable "pages_dev_certificate_name_prefix" {
+  default = ""
+}
+
+variable "wildcard_pages_dev_certificate_name_prefix" {
+  default = ""
+}
+
+variable "wildcard_sites_pages_dev_certificate_name_prefix" {
   default = ""
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- DNS for development pages environment
- Stubs DNS for production pages environment
- DNS for main subdomain (ex pages.cloud.gov) for all envs

The diff is a little messy but the only domain being added for pages-staging is `pages-staging.cloud.gov`. All "dev" domains are new as well as the commented out ones for "prod".

## security considerations
Additional DNS and certificates for pages environments

## Questions
1. Can the DNS for pages(-env).cloud.gov be a CNAME? The wildcards ones are A/AAAA