### PR TITLE
Groups in wrong place

### DIFF
--- a/terraform/modules/cloudfoundry/nlb.tf
+++ b/terraform/modules/cloudfoundry/nlb.tf
@@ -25,9 +25,9 @@ resource "aws_lb" "cf_apps_tcp" {
 }
 
 resource "aws_lb_target_group" "cf_apps_target_tcp" {
-  count    = var.tcp_lb_count
+  count    = var.tcp_lb_count * var.listeners_per_tcp_lb
   name     = "${var.stack_description}-cf-tcp-${count.index}"
-  port     = 443
+  port     = var.tcp_first_port + count.index
   protocol = "TCP"
   vpc_id   = var.vpc_id
 

--- a/terraform/modules/cloudfoundry/nlb.tf
+++ b/terraform/modules/cloudfoundry/nlb.tf
@@ -22,7 +22,6 @@ resource "aws_lb" "cf_apps_tcp" {
   load_balancer_type = "network"
   subnets            = var.elb_subnets
   ip_address_type    = "dualstack"
-  security_groups    = [aws_security_group.nlb_traffic[0].id]
 }
 
 resource "aws_lb_target_group" "cf_apps_target_tcp" {

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -115,3 +115,7 @@ output "tcp_lb_target_groups" {
 output "tcp_lb_listener_ports" {
   value = aws_lb_listener.cf_apps_tcp.*.port
 }
+
+output "tcp_lb_security_groups" {
+  value = aws_security_group.nlb_traffic.*
+}

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -610,3 +610,7 @@ output "tcp_lb_target_groups" {
 output "tcp_lb_listener_ports" {
   value = module.cf.tcp_lb_listener_ports
 }
+
+output "tcp_lb_security_groups" {
+  value = [module.cf.tcp_lb_security_groups.*, module.stack.bosh_security_group]
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- remove security group from NLB, since it doesn't go there
- create target group for each port, since apparently that's what AWS wants


## security considerations
allows more traffic into our VPC, but only where expected