### PR TITLE
branding: cloud.gov is always written lowercase

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@
 -
 
 ## security considerations
-[Note the any security considerations here, or make note of why there are none]
+[Note any security considerations here, or make note of why there are none]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloud.gov Provisioning System
+# cloud.gov Provisioning System
 
 This repository holds the terraform configuration (and BOSH vars and ops-files)
 to bootstrap our infrastructure.


### PR DESCRIPTION
@bengerman13 wanted me to make a PR against `main` in this repository... Here you go, Ben!

## Changes proposed in this pull request:
- lowercase cloud.gov in README


## security considerations
None, this is a text-only change in a non-functional file.