### PR TITLE
update s3 endpoint policy

### DIFF
--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -11,9 +11,20 @@ resource "aws_vpc_endpoint" "private-s3" {
         "Effect": "Allow",
         "Resource": "*",
         "Principal": "*"
+        "Condition": {
+          "ForAllValues:StringEquals": {
+            "aws:PrincipalAccount": ${account_id},
+            "aws:ResourceAccount": ${account_id}"
+          }				
+        }        
     }]
 }
 EOF
 
 }
 
+data "aws_caller_identity" "current" {}
+
+locals {
+    account_id = data.aws_caller_identity.current.account_id
+}

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -13,8 +13,8 @@ resource "aws_vpc_endpoint" "private-s3" {
         "Principal": "*"
         "Condition": {
           "ForAllValues:StringEquals": {
-            "aws:PrincipalAccount": ${account_id},
-            "aws:ResourceAccount": ${account_id}"
+            "aws:PrincipalAccount": ${ data.aws_caller_identity.current.account_id},
+            "aws:ResourceAccount": ${ data.aws_caller_identity.current.account_id}"
           }				
         }        
     }]
@@ -24,7 +24,3 @@ EOF
 }
 
 data "aws_caller_identity" "current" {}
-
-locals {
-    account_id = data.aws_caller_identity.current.account_id
-}

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -32,12 +32,16 @@ resource "aws_vpc_endpoint" "customer_s3" {
   subnet_ids          = [aws_subnet.az1_public.id, aws_subnet.az2_public.id]
 }
 
-data "aws_network_interface" "vpce_customer_s3_az1"{
-  id = aws_vpc_endpoint.private-s3.network_interface_ids[0]
+data "aws_network_interface" "vpce_customer_s3_if1"{
+  id = local.network_interface_ids[0]
 }
 
-data "aws_network_interface" "vpce_customer_s3_az2"{
-  id = aws_vpc_endpoint.private-s3.network_interface_ids[1]
+data "aws_network_interface" "vpce_customer_s3_if2"{
+  id = local.network_interface_ids[1] 
 }
 
 data "aws_caller_identity" "current" {}
+
+locals {
+  network_interface_ids = tolist(aws_vpc_endpoint.customer_s3.network_interface_ids)
+}

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -1,6 +1,7 @@
 resource "aws_vpc_endpoint" "private-s3" {
   vpc_id          = aws_vpc.main_vpc.id
   service_name    = "com.amazonaws.${var.aws_default_region}.s3"
+  vpc_endpoint_type = "Gateway"
   route_table_ids = [aws_route_table.az1_private_route_table.id, aws_route_table.az2_private_route_table.id]
   policy          = <<EOF
 {
@@ -21,6 +22,22 @@ resource "aws_vpc_endpoint" "private-s3" {
 }
 EOF
 
+}
+
+resource "aws_vpc_endpoint" "customer_s3" {
+  vpc_id              = aws_vpc.main_vpc.id
+  service_name        = "com.amazonaws.${var.aws_default_region}.s3"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.bosh.id]
+  subnet_ids          = [aws_subnet.az1_public.id, aws_subnet.az2_public.id]
+}
+
+data "aws_network_interface" "vpce_customer_s3_az1"{
+  id = aws_vpc_endpoint.private-s3.network_interface_ids[0]
+}
+
+data "aws_network_interface" "vpce_customer_s3_az2"{
+  id = aws_vpc_endpoint.private-s3.network_interface_ids[1]
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/modules/bosh_vpc/outputs.tf
+++ b/terraform/modules/bosh_vpc/outputs.tf
@@ -83,14 +83,15 @@ output "default_key_name" {
 }
 
 /* S3 Private Endpoint for region*/
-output "vpc_endpoint_customer_s3_az1_ip" {
-  value = aws_network_interface.vpce_customer_s3_az1.private_ip
+output "vpc_endpoint_customer_s3_if1_ip" {
+  value = data.aws_network_interface.vpce_customer_s3_if1.private_ip
 }
 
-output "vpc_endpoint_customer_s3_az2_ip" {
-  value = aws_network_interface.vpce_customer_s3_az2.private_ip
+output "vpc_endpoint_customer_s3_if2_ip" {
+  value = data.aws_network_interface.vpce_customer_s3_if1.private_ip
 }
 
+/* DNS for the S3 Private Endpoint */
 output "vpc_endpoint_customer_s3_dns"{
   value = aws_vpc_endpoint.customer_s3.dns_entry
 }

--- a/terraform/modules/bosh_vpc/outputs.tf
+++ b/terraform/modules/bosh_vpc/outputs.tf
@@ -81,3 +81,16 @@ output "restricted_web_traffic_security_group" {
 output "default_key_name" {
   value = aws_key_pair.bosh.key_name
 }
+
+/* S3 Private Endpoint for region*/
+output "vpc_endpoint_customer_s3_az1_ip" {
+  value = aws_network_interface.vpce_customer_s3_az1.private_ip
+}
+
+output "vpc_endpoint_customer_s3_az2_ip" {
+  value = aws_network_interface.vpce_customer_s3_az2.private_ip
+}
+
+output "vpc_endpoint_customer_s3_dns"{
+  value = aws_vpc_endpoint.customer_s3.dns_entry
+}

--- a/terraform/modules/bosh_vpc/outputs.tf
+++ b/terraform/modules/bosh_vpc/outputs.tf
@@ -88,7 +88,7 @@ output "vpc_endpoint_customer_s3_if1_ip" {
 }
 
 output "vpc_endpoint_customer_s3_if2_ip" {
-  value = data.aws_network_interface.vpce_customer_s3_if1.private_ip
+  value = data.aws_network_interface.vpce_customer_s3_if2.private_ip
 }
 
 /* DNS for the S3 Private Endpoint */

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -326,6 +326,15 @@ output "elasticsearch_security_group" {
   value = module.elasticsearch_broker.elasticsearch_security_group
 }
 
+/* S3 Gateway Endpoint CIDRs for CF ASGs*/
+output "s3_gateway_endpoint_cidr_1" {
+  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[0]
+}
+
+output "s3_gateway_endpoint_cidr_2" {
+  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[1]
+}
+
 /* RDS Bosh Instance */
 output "bosh_rds_url_curr" {
   value = module.stack.bosh_rds_url_curr

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -125,6 +125,10 @@ data "aws_arn" "parent_role_arn" {
   arn = var.parent_assume_arn
 }
 
+data "aws_prefix_list" s3_gw_cidrs{
+  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+}
+
 locals {
   pages_cert_ids          = [for k, cert in data.aws_iam_server_certificate.pages : cert.arn]
   pages_wildcard_cert_ids = concat(


### PR DESCRIPTION
## Changes proposed in this pull request:
- Augments existing policy for each S3 Gateway Endpoint to limit to account principals and resources. 
- provides CIDR ranges for s3 in output for cg-deploy-cf to use for trusted_networs_egress ASGs
- deploys a private endpoint to s3 for clients to use in the public ASG to get to us-gov-west-1 s3 buckets outside of our account
-  Outputs those ips addrs for the private endpoint so cg-deploy-cf and augment the public-ASG 

## security considerations
New rule ensures that access via the existing s3 private endpoint is restricted to principals in the account and resources in the account. Access to specific resources is controlled by bucket or IAM policy. For users to access s3 buckets not brokered by the platform, they will need to use the Public ASG and in the case of needing to access a bucket in a different account but in the same region as the platform, will need to use the private endpoint deployed here. 

resolves cloud-gov/product/issues/1775