### PR TITLE
Enable production DNS for Pages

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -28,9 +28,9 @@ groups:
   - acme-certificate-staging-pages
   - acme-certificate-production
   - acme-certificate-production-apps
-  # - acme-certificate-pages
-  # - acme-certificate-wildcard-pages
-  # - acme-certificate-wildcard-pages-sites
+  - acme-certificate-pages
+  - acme-certificate-wildcard-pages
+  - acme-certificate-wildcard-pages-sites
   - acme-certificate-staging-pages
   - acme-certificate-staging-wildcard-pages
   - acme-certificate-staging-wildcard-pages-sites
@@ -979,119 +979,119 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
-# - name: acme-certificate-pages
-#   plan:
-#   - in_parallel:
-#     - get: acme-timer
-#       trigger: true
-#     - get: cg-provision-repo
-#     - get: terraform-yaml-tooling
-#       resource: terraform-yaml-tooling
-#     - get: terraform-yaml-external
-#       resource: terraform-yaml-external-production
-#   - task: check-certificates
-#     file: cg-provision-repo/ci/check-certificates.yml
-#     params:
-#       AWS_DEFAULT_REGION: ((aws_default_region))
-#       CERT_PATH: /lets-encrypt/production/
-#   - task: provision-certificate
-#     file: cg-provision-repo/ci/provision-certificate.yml
-#     params:
-#       CERT_PREFIX: pages.cloud.gov
-#       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
-#       DOMAIN: "pages.cloud.gov"
-#       EMAIL: cloud-gov-operations@gsa.gov
-#   - task: upload-certificate
-#     file: cg-provision-repo/ci/upload-certificate.yml
-#     params:
-#       AWS_DEFAULT_REGION: ((aws_default_region))
-#       CERT_PATH: /lets-encrypt/production/
-#       CERT_PREFIX: pages.cloud.gov
-#   on_failure:
-#     put: slack
-#     params:
-#       text: |
-#         :x: Failed to check ACME certificates for pages.cloud.gov
-#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-#       channel: ((slack-channel))
-#       username: ((slack-username))
-#       icon_url: ((slack-icon-url))
+- name: acme-certificate-pages
+  plan:
+  - in_parallel:
+    - get: acme-timer
+      trigger: true
+    - get: cg-provision-repo
+    - get: terraform-yaml-tooling
+      resource: terraform-yaml-tooling
+    - get: terraform-yaml-external
+      resource: terraform-yaml-external-production
+  - task: check-certificates
+    file: cg-provision-repo/ci/check-certificates.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+  - task: provision-certificate
+    file: cg-provision-repo/ci/provision-certificate.yml
+    params:
+      CERT_PREFIX: pages.cloud.gov
+      ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+      DOMAIN: "pages.cloud.gov"
+      EMAIL: cloud-gov-operations@gsa.gov
+  - task: upload-certificate
+    file: cg-provision-repo/ci/upload-certificate.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+      CERT_PREFIX: pages.cloud.gov
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Failed to check ACME certificates for pages.cloud.gov
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
 
-# - name: acme-certificate-pages
-#   plan:
-#   - in_parallel:
-#     - get: acme-timer
-#       trigger: true
-#     - get: cg-provision-repo
-#     - get: terraform-yaml-tooling
-#       resource: terraform-yaml-tooling
-#     - get: terraform-yaml-external
-#       resource: terraform-yaml-external-production
-#   - task: check-certificates
-#     file: cg-provision-repo/ci/check-certificates.yml
-#     params:
-#       AWS_DEFAULT_REGION: ((aws_default_region))
-#       CERT_PATH: /lets-encrypt/production/
-#   - task: provision-certificate
-#     file: cg-provision-repo/ci/provision-certificate.yml
-#     params:
-#       CERT_PREFIX: star.pages.cloud.gov
-#       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
-#       DOMAIN: "*.pages.cloud.gov"
-#       EMAIL: cloud-gov-operations@gsa.gov
-#   - task: upload-certificate
-#     file: cg-provision-repo/ci/upload-certificate.yml
-#     params:
-#       AWS_DEFAULT_REGION: ((aws_default_region))
-#       CERT_PATH: /lets-encrypt/production/
-#       CERT_PREFIX: star.pages.cloud.gov
-#   on_failure:
-#     put: slack
-#     params:
-#       text: |
-#         :x: Failed to check ACME certificates for *.pages.cloud.gov
-#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-#       channel: ((slack-channel))
-#       username: ((slack-username))
-#       icon_url: ((slack-icon-url))
+- name: acme-certificate-wildcard-pages
+  plan:
+  - in_parallel:
+    - get: acme-timer
+      trigger: true
+    - get: cg-provision-repo
+    - get: terraform-yaml-tooling
+      resource: terraform-yaml-tooling
+    - get: terraform-yaml-external
+      resource: terraform-yaml-external-production
+  - task: check-certificates
+    file: cg-provision-repo/ci/check-certificates.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+  - task: provision-certificate
+    file: cg-provision-repo/ci/provision-certificate.yml
+    params:
+      CERT_PREFIX: star.pages.cloud.gov
+      ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+      DOMAIN: "*.pages.cloud.gov"
+      EMAIL: cloud-gov-operations@gsa.gov
+  - task: upload-certificate
+    file: cg-provision-repo/ci/upload-certificate.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+      CERT_PREFIX: star.pages.cloud.gov
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Failed to check ACME certificates for *.pages.cloud.gov
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
 
-# - name: acme-certificate-pages-sites
-#   plan:
-#   - in_parallel:
-#     - get: acme-timer
-#       trigger: true
-#     - get: cg-provision-repo
-#     - get: terraform-yaml-tooling
-#       resource: terraform-yaml-tooling
-#     - get: terraform-yaml-external
-#       resource: terraform-yaml-external-production
-#   - task: check-certificates
-#     file: cg-provision-repo/ci/check-certificates.yml
-#     params:
-#       AWS_DEFAULT_REGION: ((aws_default_region))
-#       CERT_PATH: /lets-encrypt/production/
-#   - task: provision-certificate
-#     file: cg-provision-repo/ci/provision-certificate.yml
-#     params:
-#       CERT_PREFIX: star.sites.pages.cloud.gov
-#       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
-#       DOMAIN: "*.sites.pages.cloud.gov"
-#       EMAIL: cloud-gov-operations@gsa.gov
-#   - task: upload-certificate
-#     file: cg-provision-repo/ci/upload-certificate.yml
-#     params:
-#       AWS_DEFAULT_REGION: ((aws_default_region))
-#       CERT_PATH: /lets-encrypt/production/
-#       CERT_PREFIX: star.sites.pages.cloud.gov
-#   on_failure:
-#     put: slack
-#     params:
-#       text: |
-#         :x: Failed to check ACME certificates for *.sites.pages.cloud.gov
-#         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-#       channel: ((slack-channel))
-#       username: ((slack-username))
-#       icon_url: ((slack-icon-url))
+- name: acme-certificate-wildcard-pages-sites
+  plan:
+  - in_parallel:
+    - get: acme-timer
+      trigger: true
+    - get: cg-provision-repo
+    - get: terraform-yaml-tooling
+      resource: terraform-yaml-tooling
+    - get: terraform-yaml-external
+      resource: terraform-yaml-external-production
+  - task: check-certificates
+    file: cg-provision-repo/ci/check-certificates.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+  - task: provision-certificate
+    file: cg-provision-repo/ci/provision-certificate.yml
+    params:
+      CERT_PREFIX: star.sites.pages.cloud.gov
+      ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
+      DOMAIN: "*.sites.pages.cloud.gov"
+      EMAIL: cloud-gov-operations@gsa.gov
+  - task: upload-certificate
+    file: cg-provision-repo/ci/upload-certificate.yml
+    params:
+      AWS_DEFAULT_REGION: ((aws_default_region))
+      CERT_PATH: /lets-encrypt/production/
+      CERT_PREFIX: star.sites.pages.cloud.gov
+  on_failure:
+    put: slack
+    params:
+      text: |
+        :x: Failed to check ACME certificates for *.sites.pages.cloud.gov
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
 
 - name: acme-certificate-staging-pages
   plan:

--- a/terraform/stacks/dns/pages.tf
+++ b/terraform/stacks/dns/pages.tf
@@ -1,61 +1,61 @@
 ################
 ## Production ##
 ################
-# resource "aws_route53_record" "cloud_gov_pages_cloud_gov_cname" {
-#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-#   name    = "pages.cloud.gov."
-#   type    = "CNAME"
-#   ttl     = 60
-#   records = ["dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"]
-# }
+resource "aws_route53_record" "cloud_gov_pages_cloud_gov_cname" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "pages.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"]
+}
 
-# resource "aws_route53_record" "cloud_gov_star_pages_cloud_gov_a" {
-#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-#   name    = "*.pages.cloud.gov."
-#   type    = "A"
+resource "aws_route53_record" "cloud_gov_star_pages_cloud_gov_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.pages.cloud.gov."
+  type    = "A"
 
-#   alias {
-#     name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
-#     zone_id                = var.cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 
-# resource "aws_route53_record" "cloud_gov_star_pages_cloud_gov_aaaa" {
-#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-#   name    = "*.pages.cloud.gov."
-#   type    = "AAAA"
+resource "aws_route53_record" "cloud_gov_star_pages_cloud_gov_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.pages.cloud.gov."
+  type    = "AAAA"
 
-#   alias {
-#     name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
-#     zone_id                = var.cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 
-# resource "aws_route53_record" "cloud_gov_star_sites_pages_cloud_gov_a" {
-#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-#   name    = "*.sites.pages.cloud.gov."
-#   type    = "A"
+resource "aws_route53_record" "cloud_gov_star_sites_pages_cloud_gov_a" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.sites.pages.cloud.gov."
+  type    = "A"
 
-#   alias {
-#     name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
-#     zone_id                = var.cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 
-# resource "aws_route53_record" "cloud_gov_star_sites_pages_cloud_gov_aaaa" {
-#   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-#   name    = "*.sites.pages.cloud.gov."
-#   type    = "AAAA"
+resource "aws_route53_record" "cloud_gov_star_sites_pages_cloud_gov_aaaa" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "*.sites.pages.cloud.gov."
+  type    = "AAAA"
 
-#   alias {
-#     name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
-#     zone_id                = var.cloudfront_zone_id
-#     evaluate_target_health = false
-#   }
-# }
+  alias {
+    name                   = "dualstack.${data.terraform_remote_state.production.outputs.cf_apps_lb_dns_name}"
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
 ## End Production ##
 
 #############


### PR DESCRIPTION
## Changes proposed in this pull request:
- Enables DNS for Pages production
  - pages.cloud.gov, *pages.cloud.gov, *.site.pages.cloud.gov
- See https://github.com/cloud-gov/product/issues/2100 for more details

## security considerations
Needed for Pages SCR
