### PR TITLE
Add pages.cloud.gov to cert pattern in TF_VAR

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -729,7 +729,7 @@ jobs:
       TF_VAR_domains_broker_alb_count: "6"
       TF_VAR_domains_broker_rds_username: ((production_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((production_domains_broker_rds_password))
-      TF_VAR_pages_cert_patterns: '["pages-staging.cloud.gov","pages-dev.cloud.gov"]'
+      TF_VAR_pages_cert_patterns: '["pages.cloud.gov","pages-staging.cloud.gov","pages-dev.cloud.gov"]'
       TF_VAR_waf_regular_expressions: ((production_waf_regular_expressions))
   - *notify-slack
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add pages.cloud.gov domain to TF_VAR_pages_cert_patterns array

## security considerations
Needed for Pages SCR
