### PR TITLE
variable to add multiple accounts to s3 gw policy

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -436,6 +436,7 @@ jobs:
       TF_VAR_domains_broker_rds_password: ((development_domains_broker_rds_password))
       TF_VAR_pages_cert_patterns: '[]'
       TF_VAR_waf_regular_expressions: ((development_waf_regular_expressions))
+      TF_VAR_s3_gateway_policy_accounts: ((development_s3_gateway_policy_accounts))
   - *notify-slack
 
 - name: bootstrap-development
@@ -584,6 +585,7 @@ jobs:
       TF_VAR_domains_broker_rds_password: ((staging_domains_broker_rds_password))
       TF_VAR_pages_cert_patterns: '[]'
       TF_VAR_waf_regular_expressions: ((staging_waf_regular_expressions))
+      TF_VAR_s3_gateway_policy_accounts: ((staging_s3_gateway_policy_accounts))
   - *notify-slack
 
 - name: bootstrap-staging
@@ -731,6 +733,7 @@ jobs:
       TF_VAR_domains_broker_rds_password: ((production_domains_broker_rds_password))
       TF_VAR_pages_cert_patterns: '["pages.cloud.gov","pages-staging.cloud.gov","pages-dev.cloud.gov"]'
       TF_VAR_waf_regular_expressions: ((production_waf_regular_expressions))
+      TF_VAR_s3_gateway_policy_accounts: ((production_s3_gateway_policy_accounts))
   - *notify-slack
 
 - name: bootstrap-production

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -14,8 +14,8 @@ resource "aws_vpc_endpoint" "private-s3" {
         "Principal": "*",
         "Condition": {
           "ForAllValues:StringEquals": {
-            "aws:PrincipalAccount": ${data.aws_caller_identity.current.account_id},
-            "aws:ResourceAccount": ${data.aws_caller_identity.current.account_id}
+            "aws:PrincipalAccount": ${jsonencode(local.policy_account_list)}
+            "aws:ResourceAccount": ${jsonencode(local.policy_account_list)}
           }				
         }        
     }]
@@ -44,4 +44,5 @@ data "aws_caller_identity" "current" {}
 
 locals {
   network_interface_ids = tolist(aws_vpc_endpoint.customer_s3.network_interface_ids)
+  policy_account_list = concat(var.s3_gateway_policy_accounts, data.aws_caller_identity.current.account_id)
 }

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -14,7 +14,7 @@ resource "aws_vpc_endpoint" "private-s3" {
         "Principal": "*",
         "Condition": {
           "ForAllValues:StringEquals": {
-            "aws:PrincipalAccount": ${jsonencode(local.policy_account_list)}
+            "aws:PrincipalAccount": ${jsonencode(local.policy_account_list)},
             "aws:ResourceAccount": ${jsonencode(local.policy_account_list)}
           }				
         }        

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -44,5 +44,5 @@ data "aws_caller_identity" "current" {}
 
 locals {
   network_interface_ids = tolist(aws_vpc_endpoint.customer_s3.network_interface_ids)
-  policy_account_list = concat(var.s3_gateway_policy_accounts, data.aws_caller_identity.current.account_id)
+  policy_account_list = concat(var.s3_gateway_policy_accounts, [data.aws_caller_identity.current.account_id])
 }

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -60,3 +60,8 @@ variable "concourse_security_group_cidrs" {
 variable "bosh_default_ssh_public_key" {
 
 }
+
+variable "s3_gateway_policy_accounts"{
+  type    = list(string)
+  default = []
+}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -16,6 +16,7 @@ module "vpc" {
   monitoring_security_group_cidrs        = var.target_monitoring_security_group_cidrs
   concourse_security_group_cidrs         = var.target_concourse_security_group_cidrs
   bosh_default_ssh_public_key            = var.bosh_default_ssh_public_key
+  s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
 }
 
 module "rds_network" {

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -16,7 +16,7 @@ module "vpc" {
   monitoring_security_group_cidrs        = var.target_monitoring_security_group_cidrs
   concourse_security_group_cidrs         = var.target_concourse_security_group_cidrs
   bosh_default_ssh_public_key            = var.bosh_default_ssh_public_key
-  s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
+  s3_gateway_policy_accounts             = var.s3_gateway_policy_accounts
 }
 
 module "rds_network" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -171,3 +171,8 @@ variable "credhub_rds_force_ssl" {
 variable "bosh_default_ssh_public_key" {
 
 }
+
+variable "s3_gateway_policy_accounts"{
+  type    = list(string)
+  default = []
+}

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -26,7 +26,8 @@ module "base" {
   restricted_ingress_web_cidrs      = var.restricted_ingress_web_cidrs
   restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
   bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
-
+  s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
+  
   rds_security_groups = [
     module.base.bosh_security_group,
   ]

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -154,3 +154,8 @@ variable "parent_account_id" {
 variable "bosh_default_ssh_public_key" {
 
 }
+
+variable "s3_gateway_policy_accounts"{
+  type    = list(string)
+  default = []
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -205,6 +205,7 @@ module "stack" {
   parent_account_id                 = data.aws_arn.parent_role_arn.account
   target_account_id                 = data.aws_caller_identity.tooling.account_id
   bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
+  s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
 
   target_vpc_id              = data.terraform_remote_state.target_vpc.outputs.vpc_id
   target_vpc_cidr            = data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -130,3 +130,8 @@ variable "include_tcp_routes" {
 variable "waf_regular_expressions" {
   type = list(string)
 }
+
+variable "s3_gateway_policy_accounts"{
+  type    = list(string)
+  default = []
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- This will let us add multiple accounts to the s3 gateway policy via variables
- adding federal / pages s3 bucket account to pipeline via credentials file
-

## security considerations
none
