### PR TITLE
[BLOCKED] Add port 443 as a listener for TCP routing NLBs

### DIFF
--- a/terraform/modules/cloudfoundry/nlb.tf
+++ b/terraform/modules/cloudfoundry/nlb.tf
@@ -1,5 +1,9 @@
+locals {
+  additional_tcp_targets = var.tcp_lb_count * length(var.tcp_additional_ports)
+}
+
 resource "aws_security_group" "nlb_traffic" {
-  count = var.tcp_lb_count > 0 ? 1 : 0
+  count       = var.tcp_lb_count > 0 ? 1 : 0
   description = "Allow traffic in to NLB"
   vpc_id      = var.vpc_id
 
@@ -7,8 +11,19 @@ resource "aws_security_group" "nlb_traffic" {
     from_port        = var.tcp_first_port
     to_port          = var.tcp_lb_count * var.listeners_per_tcp_lb + var.tcp_first_port
     protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    cidr_blocks      = var.tcp_allow_cidrs_ipv4
+    ipv6_cidr_blocks = var.tcp_allow_cidrs_ipv6
+  }
+
+  dynamic "ingress" {
+    for_each = var.tcp_additional_ports
+    content {
+      from_port        = setting.value
+      to_port          = setting.value
+      protocol         = "tcp"
+      cidr_blocks      = var.tcp_allow_cidrs_ipv4
+      ipv6_cidr_blocks = var.tcp_allow_cidrs_ipv6
+    }
   }
 
   tags = {
@@ -30,18 +45,36 @@ resource "aws_lb_target_group" "cf_apps_target_tcp" {
   port     = var.tcp_first_port + count.index
   protocol = "TCP"
   vpc_id   = var.vpc_id
+}
 
+resource "aws_lb_target_group" "cf_apps_target_tcp_additional" {
+  count    = local.additional_tcp_targets
+  name     = "${var.stack_description}-cf-tcp-additional-${count.index}"
+  port     = var.tcp_additional_ports[floor(count.index / local.additional_tcp_targets)]
+  protocol = "TCP"
+  vpc_id   = var.vpc_id
 }
 
 resource "aws_lb_listener" "cf_apps_tcp" {
   count             = var.tcp_lb_count * var.listeners_per_tcp_lb
-  load_balancer_arn = aws_lb.cf_apps_tcp[floor(count.index/var.listeners_per_tcp_lb)].arn
+  load_balancer_arn = aws_lb.cf_apps_tcp[floor(count.index / var.listeners_per_tcp_lb)].arn
   protocol          = "TCP"
   port              = var.tcp_first_port + count.index
-
 
   default_action {
     target_group_arn = aws_lb_target_group.cf_apps_target_tcp[count.index].arn
     type             = "forward"
   }
 }
+
+# resource "aws_lb_listener" "cf_apps_tcp_additional" {
+#   count             = var.tcp_lb_count
+#   load_balancer_arn = aws_lb.cf_apps_tcp[count.index].arn
+#   protocol          = "TCP"
+#   port              = 443
+
+#   default_action {
+#     target_group_arn = aws_lb_target_group.cf_apps_target_tcp_443[count.index].arn
+#     type             = "forward"
+#   }
+# }

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -109,11 +109,17 @@ output "tcp_lb_dns_names" {
 }
 
 output "tcp_lb_target_groups" {
-  value = aws_lb_target_group.cf_apps_target_tcp.*.name
+  value = concat(
+    aws_lb_target_group.cf_apps_target_tcp.*.name,
+    aws_lb_target_group.cf_apps_target_tcp_additional.*.name,
+  )
 }
 
 output "tcp_lb_listener_ports" {
-  value = aws_lb_listener.cf_apps_tcp.*.port
+  value = distinct(concat(
+    aws_lb_listener.cf_apps_tcp.*.port,
+    # aws_lb_listener.cf_apps_tcp_additional.*.port
+  ))
 }
 
 output "tcp_lb_security_groups" {

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -111,14 +111,14 @@ output "tcp_lb_dns_names" {
 output "tcp_lb_target_groups" {
   value = concat(
     aws_lb_target_group.cf_apps_target_tcp.*.name,
-    aws_lb_target_group.cf_apps_target_tcp_additional.*.name,
+    aws_lb_target_group.cf_apps_target_tcp_443.*.name,
   )
 }
 
 output "tcp_lb_listener_ports" {
   value = distinct(concat(
     aws_lb_listener.cf_apps_tcp.*.port,
-    # aws_lb_listener.cf_apps_tcp_additional.*.port
+    aws_lb_listener.cf_apps_tcp_443.*.port
   ))
 }
 

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -118,10 +118,6 @@ variable "tcp_first_port" {
   default = 10000
 }
 
-variable "tcp_additional_ports" {
-  default = [443]
-}
-
 variable "tcp_allow_cidrs_ipv4" {
   default = ["0.0.0.0/0"]
 }

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -6,12 +6,12 @@ variable "elb_apps_cert_id" {
 
 variable "pages_cert_ids" {
   default = []
-  type = set(string)
+  type    = set(string)
 }
 
 variable "pages_wildcard_cert_ids" {
   default = []
-  type = set(string)
+  type    = set(string)
 }
 
 variable "elb_subnets" {
@@ -118,9 +118,14 @@ variable "tcp_first_port" {
   default = 10000
 }
 
+variable "tcp_additional_ports" {
+  default = [443]
+}
+
 variable "tcp_allow_cidrs_ipv4" {
   default = ["0.0.0.0/0"]
 }
+
 variable "tcp_allow_cidrs_ipv6" {
   default = ["::/0"]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds port 443 as a listener for TCP routing NLBs

## security considerations

Apps accessed over TCP routing on port 443 will be required to perform their own TLS termination, which is something we'll need to make very clear
