### PR TITLE
S3 ep policy

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -321,6 +321,7 @@ jobs:
       TF_VAR_oidc_client: ((tooling_oidc_client))
       TF_VAR_oidc_client_secret: ((tooling_oidc_client_secret))
       TF_VAR_payer_account_id: ((payer_account_id))
+      TF_VAR_s3_gateway_policy_accounts: ((tooling_s3_gateway_policy_accounts))
   - *notify-slack
 
 - name: bootstrap-tooling

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -25,7 +25,9 @@ resource "aws_vpc_endpoint" "private-s3" {
       "Principal": "*",
       "Action": "s3:*",
       "Resource": [
-        "arn:aws:s3:::prod-us-gov-west-1-starport-layer-bucket/*"
+        "arn:aws:s3:::prod-us-gov-west-1-starport-layer-bucket/*",
+        "arn:aws:s3:::prod-us-gov-east-1-starport-layer-bucket/*",
+        "arn:aws:s3:::prod-us-east-1-starport-layer-bucket/*",
       ]
     }
     ]

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -34,15 +34,6 @@ EOF
 
 }
 
-/* This needs to be in place for trusted s3 egress to work. Removing from policy ^^ due to ECR build issues with federalist
-        ,
-        "Condition": {
-          "ForAllValues:StringEquals": {
-            "aws:PrincipalAccount": ${jsonencode(local.policy_account_list)},
-            "aws:ResourceAccount": ${jsonencode(local.policy_account_list)}
-          }				
-        } 
-*/
 resource "aws_vpc_endpoint" "customer_s3" {
   vpc_id              = aws_vpc.main_vpc.id
   service_name        = "com.amazonaws.${var.aws_default_region}.s3"

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -11,8 +11,24 @@ resource "aws_vpc_endpoint" "private-s3" {
         "Action": "s3:*",
         "Effect": "Allow",
         "Resource": "*",
-        "Principal": "*"      
-    }]
+        "Principal": "*",
+        "Condition": {
+          "ForAllValues:StringEquals": {
+            "aws:PrincipalAccount": ${jsonencode(local.policy_account_list)},
+            "aws:ResourceAccount": ${jsonencode(local.policy_account_list)}
+          }				
+        }        
+    },
+    {
+      "Sid": "Access-to-ecr-buckets",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::prod-us-gov-west-1-starport-layer-bucket/*"
+      ]
+    }
+    ]
 }
 EOF
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- adds a policy to s3 endpoints to limit traffic to s3 from known sources based on account ids. 
- includes a statement for ECR service accessing s3 
- outputs the cidrs and ips for use by deploy-cf to modify the ASGs.

## security considerations
None
