### PR TITLE
feat: Update and add pages support domain for new zendesk

### DIFF
--- a/terraform/stacks/dns/validators.tf
+++ b/terraform/stacks/dns/validators.tf
@@ -30,7 +30,15 @@ resource "aws_route53_record" "cloud_gov_zendesk_support_cname" {
   name    = "support.cloud.gov."
   type    = "CNAME"
   ttl     = 60
-  records = ["cloud-gov.zendesk.com."]
+  records = ["cloud-gov-new.zendesk.com."]
+}
+
+resource "aws_route53_record" "cloud_gov_zendesk_support_cname" {
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "pages-support.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["cloud-gov-pages.zendesk.com."]
 }
 
 resource "aws_route53_record" "cloud_gov_gsuite_dkim_txt" {

--- a/terraform/stacks/dns/validators.tf
+++ b/terraform/stacks/dns/validators.tf
@@ -33,7 +33,7 @@ resource "aws_route53_record" "cloud_gov_zendesk_support_cname" {
   records = ["cloud-gov-new.zendesk.com."]
 }
 
-resource "aws_route53_record" "cloud_gov_zendesk_support_cname" {
+resource "aws_route53_record" "cloud_gov_pages_zendesk_support_cname" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "pages-support.cloud.gov."
   type    = "CNAME"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updates existing support.cloud.gov domain to the new Zendesk instance
- Add `pages-support.cloud.gov` domain for the new Zendesk instance team for cloud.gov Pages.

## security considerations
Needed for Zendesk migration
