### PR TITLE
update expiration on logsearch buckets to 914 days/30 months

### DIFF
--- a/terraform/modules/cloudfoundry/buckets.tf
+++ b/terraform/modules/cloudfoundry/buckets.tf
@@ -26,6 +26,6 @@ module "logsearch-archive" {
   source          = "../s3_bucket/encrypted_bucket"
   bucket          = "logsearch-${var.stack_prefix}"
   aws_partition   = var.aws_partition
-  expiration_days = 914
+  expiration_days = 930 # 31 days * 30 months = 930 days
 }
 

--- a/terraform/modules/cloudfoundry/buckets.tf
+++ b/terraform/modules/cloudfoundry/buckets.tf
@@ -26,6 +26,6 @@ module "logsearch-archive" {
   source          = "../s3_bucket/encrypted_bucket"
   bucket          = "logsearch-${var.stack_prefix}"
   aws_partition   = var.aws_partition
-  expiration_days = 548
+  expiration_days = 914
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- update expiration on logsearch buckets to 914 days/30 months to comply with M-21-31

## security considerations

None
