### PR TITLE
Create new bucket module to add transition

### DIFF
--- a/terraform/modules/cloudfoundry/buckets.tf
+++ b/terraform/modules/cloudfoundry/buckets.tf
@@ -23,7 +23,7 @@ module "droplets" {
 }
 
 module "logsearch-archive" {
-  source          = "../s3_bucket/encrypted_bucket"
+  source          = "../s3_bucket/log_encrypted_bucket"
   bucket          = "logsearch-${var.stack_prefix}"
   aws_partition   = var.aws_partition
   expiration_days = 930 # 31 days * 30 months = 930 days

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/outputs.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket_name" {
+  value = aws_s3_bucket.log_encrypted_bucket.bucket
+}
+

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
@@ -1,0 +1,22 @@
+variable "bucket" {
+}
+
+variable "acl" {
+  default = "private"
+}
+
+variable "versioning" {
+  default = "false"
+}
+
+variable "force_destroy" {
+  default = "false"
+}
+
+variable "aws_partition" {
+}
+
+variable "expiration_days" {
+  default = 0
+}
+

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">=4.4.0"
+    }
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- This adds a new log_encrypted_bucket module so that we can implement transitioning from standard s3 storage to onezone_ia storage

## security considerations
None
