### PR TITLE
Add DNS resolver query logging

### DIFF
--- a/terraform/modules/environment_dns/logs.tf
+++ b/terraform/modules/environment_dns/logs.tf
@@ -16,5 +16,5 @@ resource "aws_route53_resolver_query_log_config" "resolver_config" {
 
 resource "aws_route53_resolver_query_log_config_association" "resolver_config_association" {
   resolver_query_log_config_id = aws_route53_resolver_query_log_config.resolver_config.id
-  resource_id                  = data.terraform_remote_state.stack.output.vpc_id
+  resource_id                  = data.terraform_remote_state.stack.outputs.vpc_id
 }

--- a/terraform/modules/environment_dns/logs.tf
+++ b/terraform/modules/environment_dns/logs.tf
@@ -5,11 +5,16 @@ module "dns_resolver_logs_bucket" {
   expiration_days = 930 # 31 days * 30 months = 930 days
 }
 
-resource "aws_route53_resolver_query_log_config" "example" {
+resource "aws_route53_resolver_query_log_config" "resolver_config" {
   name            = "${var.stack_name}-query-resolver-logs"
   destination_arn = module.dns_resolver_logs_bucket.bucket_arn
 
   tags = {
     Environment = var.stack_name
   }
+}
+
+resource "aws_route53_resolver_query_log_config_association" "resolver_config_association" {
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.resolver_config.id
+  resource_id                  = data.terraform_remote_state.stack.output.vpc_id
 }

--- a/terraform/modules/environment_dns/logs.tf
+++ b/terraform/modules/environment_dns/logs.tf
@@ -1,0 +1,15 @@
+module "dns_resolver_logs_bucket" {
+  source          = "../s3_bucket/log_encrypted_bucket"
+  bucket          = "${var.stack_name}-query-resolver-logs"
+  aws_partition   = var.aws_partition
+  expiration_days = 930 # 31 days * 30 months = 930 days
+}
+
+resource "aws_route53_resolver_query_log_config" "example" {
+  name            = "${var.stack_name}-query-resolver-logs"
+  destination_arn = module.dns_resolver_logs_bucket.bucket_arn
+
+  tags = {
+    Environment = var.stack_name
+  }
+}

--- a/terraform/modules/environment_dns/variables.tf
+++ b/terraform/modules/environment_dns/variables.tf
@@ -30,3 +30,7 @@ variable "remote_state_bucket" {
 variable "remote_state_region" {
 
 }
+
+variable "aws_partition" {
+  type = string
+}

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/outputs.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/outputs.tf
@@ -2,3 +2,6 @@ output "bucket_name" {
   value = aws_s3_bucket.log_encrypted_bucket.bucket
 }
 
+output "bucket_arn" {
+  value = aws_s3_bucket.log_encrypted_bucket.arn
+}

--- a/terraform/stacks/dns/dev.tf
+++ b/terraform/stacks/dns/dev.tf
@@ -21,4 +21,5 @@ module "dev_dns" {
   admin_subdomain     = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
   remote_state_bucket = var.remote_state_bucket
   remote_state_region = var.remote_state_region
+  aws_partition       = data.aws_partition.current.partition
 }

--- a/terraform/stacks/dns/production.tf
+++ b/terraform/stacks/dns/production.tf
@@ -7,4 +7,5 @@ module "production_dns" {
   admin_subdomain     = "fr.cloud.gov"
   remote_state_bucket = var.remote_state_bucket
   remote_state_region = var.remote_state_region
+  aws_partition       = data.aws_partition.current.partition
 }

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -80,6 +80,9 @@ data "terraform_remote_state" "development" {
   }
 }
 
+data "aws_partition" "current" {
+}
+
 resource "aws_route53_zone" "cloud_gov_zone" {
   name = "cloud.gov."
 

--- a/terraform/stacks/dns/staging.tf
+++ b/terraform/stacks/dns/staging.tf
@@ -20,4 +20,5 @@ module "staging_dns" {
   admin_subdomain     = "fr-stage.cloud.gov"
   remote_state_bucket = var.remote_state_bucket
   remote_state_region = var.remote_state_region
+  aws_partition       = data.aws_partition.current.partition
 }

--- a/terraform/stacks/main/buckets.tf
+++ b/terraform/stacks/main/buckets.tf
@@ -5,10 +5,16 @@ module "bosh_blobstore_bucket" {
   force_destroy = "true"
 }
 
-
 module "log_bucket" {
   source          = "../../modules/log_bucket"
   aws_partition   = data.aws_partition.current.partition
   log_bucket_name = "${var.stack_description}-elb-logs"
   aws_region      = data.aws_region.current.name
+}
+
+module "dns_resolver_logs_bucket" {
+  source        = "../../modules/s3_bucket/log_encrypted_bucket"
+  bucket          = "${var.stack_prefix}-query-resolver-logs"
+  aws_partition   = var.aws_partition
+  expiration_days = 930 # 31 days * 30 months = 930 days
 }

--- a/terraform/stacks/main/buckets.tf
+++ b/terraform/stacks/main/buckets.tf
@@ -11,10 +11,3 @@ module "log_bucket" {
   log_bucket_name = "${var.stack_description}-elb-logs"
   aws_region      = data.aws_region.current.name
 }
-
-module "dns_resolver_logs_bucket" {
-  source        = "../../modules/s3_bucket/log_encrypted_bucket"
-  bucket          = "${var.stack_prefix}-query-resolver-logs"
-  aws_partition   = var.aws_partition
-  expiration_days = 930 # 31 days * 30 months = 930 days
-}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add DNS resolver query logging to all environments

## security considerations

This change enhances security as DNS resolver query logging will allow us to monitor all DNS queries originating in our infrastructure. Beyond giving us more insight into our platform, these logs could help identify DNS queries for malicious resources and compromised infrastructure.

These changes are the first step in implementing the [passive DNS ADR](https://github.com/cloud-gov/product/blob/master/adr/ADR-0008-passive-dns.md).
