### PR TITLE
Make encryption bucket policy optional

### DIFF
--- a/terraform/modules/dns_logging/resolver_logging.tf
+++ b/terraform/modules/dns_logging/resolver_logging.tf
@@ -3,6 +3,9 @@ module "dns_resolver_logs_bucket" {
   bucket          = "${var.stack_description}-query-resolver-logs"
   aws_partition   = var.aws_partition
   expiration_days = 930 # 31 days * 30 months = 930 days
+  # need to exclude bucket policy otherwise we get access denied errors from rout53
+  # query resolver logging configuration
+  include_require_encrypted_put_bucket_policy = false
 }
 
 resource "aws_route53_resolver_query_log_config" "resolver_config" {

--- a/terraform/modules/dns_logging/resolver_logging.tf
+++ b/terraform/modules/dns_logging/resolver_logging.tf
@@ -3,7 +3,7 @@ module "dns_resolver_logs_bucket" {
   bucket          = "${var.stack_description}-query-resolver-logs"
   aws_partition   = var.aws_partition
   expiration_days = 930 # 31 days * 30 months = 930 days
-  # need to exclude bucket policy otherwise we get access denied errors from rout53
+  # need to exclude bucket policy otherwise we get access denied errors from Route53
   # query resolver logging configuration
   include_require_encrypted_put_bucket_policy = false
 }

--- a/terraform/modules/dns_logging/resolver_logging.tf
+++ b/terraform/modules/dns_logging/resolver_logging.tf
@@ -5,6 +5,7 @@ module "dns_resolver_logs_bucket" {
   expiration_days = 930 # 31 days * 30 months = 930 days
   # need to exclude bucket policy otherwise we get access denied errors from Route53
   # query resolver logging configuration
+  # The bucket's default encryption setting is still enforced to ensure "encryption at rest"
   include_require_encrypted_put_bucket_policy = false
 }
 

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -47,6 +47,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
 }
 
 resource "aws_s3_bucket_policy" "log_encrypted_bucket_policy" {
+  count = var.include_require_encrypted_put_bucket_policy ? 1 : 0
   bucket = aws_s3_bucket.log_encrypted_bucket.id
   policy = <<EOF
 {

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
@@ -20,3 +20,9 @@ variable "expiration_days" {
   default = 0
 }
 
+variable "include_require_encrypted_put_bucket_policy" {
+  description = "True to include bucket policy to required encrypted PUTs"
+  type = bool
+  default = true
+}
+


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove bucket policy requiring specific encryption for query resolver logging buckets

## security considerations

There shouldn't be any negative security impact here as once you have bucket encryption for S3 enabled, you can guarantee that there is some form of encryption. The bucket policy being made optional here just guarantees that all PUT requests to the bucket must use the specific form of encryption enabled on the bucket. [See this article for further explanation](https://aws-blog.com/2020/09/enforcing-encryption-standards-on-s3-objects.html).

While the bucket policy is valuable, it can't be enabled on buckets used for DNS resolver query logging because that results in "access denied" errors. And I created a bucket without this policy to prove that it could integrate successfully with Route53 resolver query logging. Since having this logging is valuable for security as well, it seems worthwhile to disable the bucket policy for these specific buckets.
