### PR TITLE
update lifecycle rules for log storage tiers

### DIFF
--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -35,8 +35,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
     #if expiration_days is 0 then the rule is disabled
     status = var.expiration_days == 0 ? "Disabled" : "Enabled"
     transition {
+      days          = 90
+      storage_class = "GLACIER_IR"
+    }
+    transition {
       days          = 365
-      storage_class = "ONEZONE_IA"
+      storage_class = "DEEP_ARCHIVE"
     }
     expiration {
       # Hack: Set expiration days to 30 if unset; objects won't actually be expired because the rule will be disabled


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update storage lifecycle for buckets created by `log_encrypted_bucket` module to:
  - 0 - 3 months: s3 standard
  - 3 - 12 months: glacier instant retrieval
  - 12 - 18 months: glacier deep
  - 18 months: delete

## security considerations

None, just changing storage tiers and optimizing costs
