### PR TITLE
feat: Add CNAMES to provision custom domains for pages templates

### DIFF
--- a/terraform/stacks/dns/pages.tf
+++ b/terraform/stacks/dns/pages.tf
@@ -56,6 +56,57 @@ resource "aws_route53_record" "cloud_gov_star_sites_pages_cloud_gov_aaaa" {
     evaluate_target_health = false
   }
 }
+
+## Templates ##
+
+resource "aws_route53_record" "cloud_gov_uswds-11ty_pages_cloud_gov" {
+    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+    name    = "uswds-11ty.pages.cloud.gov."
+    type    = "CNAME"
+    ttl     = 60
+    records = ["uswds-11ty.pages.cloud.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "cloud_gov__acme-challenge_uswds-11ty_pages_cloud_gov" {
+    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+    name    = "_acme-challenge.uswds-11ty.pages.cloud.gov."
+    type    = "CNAME"
+    ttl     = 60
+    records = ["_acme-challenge.uswds-11ty.pages.cloud.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "cloud_gov_uswds-gatsby_pages_cloud_gov" {
+    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+    name    = "uswds-gatsby.pages.cloud.gov."
+    type    = "CNAME"
+    ttl     = 60
+    records = ["uswds-gatsby.pages.cloud.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "cloud_gov__acme-challenge_uswds-gatsby_pages_cloud_gov" {
+    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+    name    = "_acme-challenge.uswds-gatsby.pages.cloud.gov."
+    type    = "CNAME"
+    ttl     = 60
+    records = ["_acme-challenge.uswds-gatsby.pages.cloud.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "cloud_gov_uswds-jekyll_pages_cloud_gov" {
+    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+    name    = "uswds-jekyll.pages.cloud.gov."
+    type    = "CNAME"
+    ttl     = 60
+    records = ["uswds-jekyll.pages.cloud.gov.external-domains-production.cloud.gov."]
+}
+
+resource "aws_route53_record" "cloud_gov__acme-challenge_uswds-jekyll_pages_cloud_gov" {
+    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+    name    = "_acme-challenge.uswds-jekyll.pages.cloud.gov."
+    type    = "CNAME"
+    ttl     = 60
+    records = ["_acme-challenge.uswds-jekyll.pages.cloud.gov.external-domains-production.cloud.gov."]
+}
+
 ## End Production ##
 
 #############


### PR DESCRIPTION
## Changes proposed in this pull request:
- feat: Add CNAMES to provision custom domains for pages templates - [11ty template](https://github.com/cloud-gov/pages-uswds-11ty)
- feat: Add CNAMES to provision custom domains for pages templates - [Gatsby template](https://github.com/cloud-gov/pages-uswds-gatsby)
- feat: Add CNAMES to provision custom domains for pages templates - [Jekyll template](https://github.com/cloud-gov/pages-uswds-jekyll)

## security considerations
None
