### PR TITLE
add athena database for query resolver logs

### DIFF
--- a/terraform/modules/dns_logging/resolver_logging.tf
+++ b/terraform/modules/dns_logging/resolver_logging.tf
@@ -22,3 +22,19 @@ resource "aws_route53_resolver_query_log_config_association" "resolver_config_as
   resolver_query_log_config_id = aws_route53_resolver_query_log_config.resolver_config.id
   resource_id                  = var.vpc_id
 }
+
+module "athena_query_results_bucket" {
+  source          = "../s3_bucket/encrypted_bucket"
+  bucket          = "${var.stack_description}-query-resolver-logs-results"
+  aws_partition   = var.aws_partition
+  expiration_days = 30
+  # need to exclude bucket policy otherwise we get access denied errors from Route53
+  # query resolver logging configuration
+  # The bucket's default encryption setting is still enforced to ensure "encryption at rest"
+  include_require_encrypted_put_bucket_policy = false
+}
+
+resource "aws_athena_database" "query_resolver_database" {
+  name   = "${var.stack_description}-query-resolver-logs-database"
+  bucket = module.athena_query_results_bucket.bucket_name
+}

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -43,6 +43,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
 }
 
 resource "aws_s3_bucket_policy" "encrypted_bucket_policy" {
+  count = var.include_require_encrypted_put_bucket_policy ? 1 : 0
   bucket = aws_s3_bucket.encrypted_bucket.id
   policy = <<EOF
 {

--- a/terraform/modules/s3_bucket/encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/variables.tf
@@ -20,3 +20,8 @@ variable "expiration_days" {
   default = 0
 }
 
+variable "include_require_encrypted_put_bucket_policy" {
+  description = "True to include bucket policy to required encrypted PUTs"
+  type = bool
+  default = true
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- add athena database for query resolver logs so we can easily search the query resolver logs in S3

## security considerations

None
