### PR TITLE
update monitoring SG to restrict ingress traffic to VPC CIDR

### DIFF
--- a/terraform/modules/monitoring/sg_monitoring.tf
+++ b/terraform/modules/monitoring/sg_monitoring.tf
@@ -19,7 +19,6 @@ resource "aws_security_group_rule" "self_reference" {
   from_port         = 0
   to_port           = 0
   protocol          = -1
-  cidr_blocks       = [var.vpc_cidr]
   security_group_id = aws_security_group.monitoring.id
 }
 

--- a/terraform/modules/monitoring/sg_monitoring.tf
+++ b/terraform/modules/monitoring/sg_monitoring.tf
@@ -19,6 +19,7 @@ resource "aws_security_group_rule" "self_reference" {
   from_port         = 0
   to_port           = 0
   protocol          = -1
+  cidr_blocks       = [var.vpc_cidr]
   security_group_id = aws_security_group.monitoring.id
 }
 
@@ -27,7 +28,7 @@ resource "aws_security_group_rule" "monitoring_nginx" {
   from_port         = 8080
   to_port           = 8080
   protocol          = "all"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = [var.vpc_cidr]
   security_group_id = aws_security_group.monitoring.id
 }
 

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -15,6 +15,10 @@ variable "route_table_id" {
 variable "vpc_id" {
 }
 
+variable "vpc_cidr" {
+  type = string
+}
+
 variable "listener_arn" {
 }
 

--- a/terraform/stacks/regionalmasterbosh/stack.tf
+++ b/terraform/stacks/regionalmasterbosh/stack.tf
@@ -29,7 +29,7 @@ data "aws_region" "current" {
 }
 
 data "terraform_remote_state" "target_vpc" {
-  # N.B. according to this issue comment https://github.com/hashicorp/terraform/issues/18611#issuecomment-410883474 
+  # N.B. according to this issue comment https://github.com/hashicorp/terraform/issues/18611#issuecomment-410883474
   # the backend here should use the default credentials, which actually belong to the aws.tooling provider.
   # This is what we want, since we're trying to get the tooling state from a bucket in tooling as a tooling user.
 
@@ -99,7 +99,7 @@ module "stack" {
   rds_multi_az                      = var.rds_multi_az
   rds_security_groups               = [module.stack.bosh_security_group]
   rds_security_groups_count         = "1"
-  rds_instance_type                 = var.rds_instance_type 
+  rds_instance_type                 = var.rds_instance_type
   rds_db_engine_version             = var.rds_db_engine_version
   rds_parameter_group_family        = var.rds_parameter_group_family
   rds_allow_major_version_upgrade   = var.rds_allow_major_version_upgrade
@@ -129,6 +129,7 @@ module "monitoring_production" {
   source             = "../../modules/monitoring"
   stack_description  = "production"
   vpc_id             = module.stack.vpc_id
+  vpc_cidr           = var.vpc_cidr
   monitoring_cidr    = cidrsubnet(var.vpc_cidr, 8, 32)
   monitoring_az      = data.aws_availability_zones.available.names[0]
   route_table_id     = module.stack.private_route_table_az1

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -194,6 +194,7 @@ module "monitoring_production" {
   source             = "../../modules/monitoring"
   stack_description  = "production"
   vpc_id             = module.stack.vpc_id
+  vpc_cidr           = var.vpc_cidr
   monitoring_cidr    = cidrsubnet(var.vpc_cidr, 8, 32)
   monitoring_az      = data.aws_availability_zones.available.names[0]
   route_table_id     = module.stack.private_route_table_az1
@@ -208,6 +209,7 @@ module "monitoring_staging" {
   source             = "../../modules/monitoring"
   stack_description  = "staging"
   vpc_id             = module.stack.vpc_id
+  vpc_cidr           = var.vpc_cidr
   monitoring_cidr    = cidrsubnet(var.vpc_cidr, 8, 33)
   monitoring_az      = data.aws_availability_zones.available.names[1]
   route_table_id     = module.stack.private_route_table_az2


### PR DESCRIPTION
## Changes proposed in this pull request:

- update monitoring SG to restrict ingress traffic to VPC CIDR

## security considerations

This change enhances security by removing public access on all ports and limiting access to inbound traffic from the VPC
