### PR TITLE
Backfill auto-upgraded minor version change from AWS

### DIFF
--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -25,7 +25,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "12.8"
+  default = "12.11"
 }
 
 variable "rds_username" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- AWS automatically updated several Postgres instances to this engine version. This change backfills the new version into Terraform.

## security considerations

* Minor version changes are regularly required to maintain security.