### PR TITLE
change override action from count to none for AWSManagedRule-CoreRuleSet

### DIFF
--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -144,7 +144,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
     priority = 3
 
     override_action {
-      count {}
+      none {}
     }
 
     statement {
@@ -199,7 +199,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
   rule {
     name     = "CG-RegexPatternSets"
-    priority = 5
+    priority = 4
     action {
       block {}
     }


### PR DESCRIPTION
## Changes proposed in this pull request:

Upon closer inspection, I noticed that the deploy changes were overriding the group rule action to "count" for the AWSManagedRule-CoreRuleSet, meaning no traffic would be blocked by this rule set. In production we are leaving the group rule action to the default of "block", so that traffic does get blocked by default. So I fixed the configuration to match how things are set in production

## security considerations

Ensuring that our TF configuration properly deploys the WAF rules that we have manually configured in production to give us the best defense against malicious traffic