### PR TITLE
add rule to rate limit non-CDN requests

### DIFF
--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -198,8 +198,32 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   }
 
   rule {
-    name     = "CG-RegexPatternSets"
+    name = "RateLimitNonCDN"
     priority = 4
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit = 250000
+        aggregate_key_type = "FORWARDED_IP"
+        # Requests without forwarded IP headers will be counted towards the rate limit
+        fallback_behavior = "MATCH"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.stack_description}-RateLimitNonCDN"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "CG-RegexPatternSets"
+    priority = 5
     action {
       block {}
     }


### PR DESCRIPTION
## Changes proposed in this pull request:

- add rule to rate limit non-CDN requests to 250,000 requests in 5 minutes

## security considerations

This change provides additional defense against DDoS attacks on our infrastructure.
