### PR TITLE
disable GenericLFI_BODY rule

### DIFF
--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -165,6 +165,10 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
         }
 
         excluded_rule {
+          name = "GenericLFI_BODY"
+        }
+
+        excluded_rule {
           name = "GenericRFI_BODY"
         }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- disable GenericLFI_BODY rule which was blocking customer traffic

## security considerations

Disabling this rule does have security implications, as it would be a helpful line of defense against malicious traffic. However, since it is misidentifying some legitimate customer traffic as malicious, we have to disable it.
