### PR TITLE
Configure DNS stack like external stack

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -1,21 +1,9 @@
-variable "aws_access_key" {
-}
-
-variable "aws_secret_key" {
-}
-
-variable "aws_region" {
-}
-
 terraform {
   backend "s3" {
   }
 }
 
 provider "aws" {
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-  region     = var.aws_region
 }
 
 variable "cloudfront_zone_id" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Taking a shot at making this pipeline consistent with the others in how it authenticates to AWS. `stacks/external` "just works" without having these vars set.

## security considerations
Security improvement, related to https://github.com/cloud-gov/private/issues/594