### PR TITLE
add bucket for container scanning config

### DIFF
--- a/terraform/modules/iam_role_policy/concourse_worker/policy.json
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.json
@@ -43,7 +43,9 @@
         "arn:${aws_partition}:s3:::${concourse_varz_bucket}",
         "arn:${aws_partition}:s3:::${concourse_varz_bucket}/*",
         "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}",
-        "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}/*"
+        "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}/*",
+        "arn:${aws_partition}:s3:::${container_scanning_bucket_name}",
+        "arn:${aws_partition}:s3:::${container_scanning_bucket_name}/*"
       ]
     },
     {

--- a/terraform/modules/iam_role_policy/concourse_worker/policy.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.tf
@@ -2,19 +2,20 @@ data "template_file" "policy" {
   template = file("${path.module}/policy.json")
 
   vars = {
-    aws_partition           = var.aws_partition
-    varz_bucket             = var.varz_bucket
-    varz_staging_bucket     = var.varz_staging_bucket
-    bosh_release_bucket     = var.bosh_release_bucket
-    build_artifacts_bucket  = var.build_artifacts_bucket
-    terraform_state_bucket  = var.terraform_state_bucket
-    semver_bucket           = var.semver_bucket
-    buildpack_notify_bucket = var.buildpack_notify_bucket
-    billing_bucket          = var.billing_bucket
-    cg_binaries_bucket      = var.cg_binaries_bucket
-    log_bucket              = var.log_bucket
-    concourse_varz_bucket   = var.concourse_varz_bucket
-    pgp_keys_bucket_name    = var.pgp_keys_bucket_name
+    aws_partition                  = var.aws_partition
+    varz_bucket                    = var.varz_bucket
+    varz_staging_bucket            = var.varz_staging_bucket
+    bosh_release_bucket            = var.bosh_release_bucket
+    build_artifacts_bucket         = var.build_artifacts_bucket
+    terraform_state_bucket         = var.terraform_state_bucket
+    semver_bucket                  = var.semver_bucket
+    buildpack_notify_bucket        = var.buildpack_notify_bucket
+    billing_bucket                 = var.billing_bucket
+    cg_binaries_bucket             = var.cg_binaries_bucket
+    log_bucket                     = var.log_bucket
+    concourse_varz_bucket          = var.concourse_varz_bucket
+    pgp_keys_bucket_name           = var.pgp_keys_bucket_name
+    container_scanning_bucket_name = var.container_scanning_bucket_name
   }
 }
 

--- a/terraform/modules/iam_role_policy/concourse_worker/variables.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/variables.tf
@@ -41,3 +41,8 @@ variable "pgp_keys_bucket_name" {
     type = string
     description = "Name of S3 bucket for PGP keys"
 }
+
+variable "container_scanning_bucket_name" {
+    type = string
+    description = "Name of S3 bucket for container scanning config"
+}

--- a/terraform/stacks/tooling/buckets.tf
+++ b/terraform/stacks/tooling/buckets.tf
@@ -65,3 +65,10 @@ module "pgp_keys_bucket" {
   aws_partition = data.aws_partition.current.partition
   versioning    = "true"
 }
+
+module "container_scanning_bucket" {
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = var.container_scanning_bucket_name
+  aws_partition = data.aws_partition.current.partition
+  versioning    = "true"
+}

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -60,21 +60,22 @@ module "bosh_compilation_policy" {
 }
 
 module "concourse_worker_policy" {
-  source                  = "../../modules/iam_role_policy/concourse_worker"
-  policy_name             = "concourse-worker"
-  aws_partition           = data.aws_partition.current.partition
-  varz_bucket             = var.varz_bucket
-  varz_staging_bucket     = var.varz_bucket_stage
-  bosh_release_bucket     = var.bosh_release_bucket
-  terraform_state_bucket  = var.terraform_state_bucket
-  build_artifacts_bucket  = var.build_artifacts_bucket
-  semver_bucket           = var.semver_bucket
-  buildpack_notify_bucket = var.buildpack_notify_bucket
-  billing_bucket          = var.billing_bucket
-  cg_binaries_bucket      = var.cg_binaries_bucket
-  log_bucket              = var.log_bucket_name
-  concourse_varz_bucket   = var.concourse_varz_bucket
-  pgp_keys_bucket_name    = var.pgp_keys_bucket_name
+  source                         = "../../modules/iam_role_policy/concourse_worker"
+  policy_name                    = "concourse-worker"
+  aws_partition                  = data.aws_partition.current.partition
+  varz_bucket                    = var.varz_bucket
+  varz_staging_bucket            = var.varz_bucket_stage
+  bosh_release_bucket            = var.bosh_release_bucket
+  terraform_state_bucket         = var.terraform_state_bucket
+  build_artifacts_bucket         = var.build_artifacts_bucket
+  semver_bucket                  = var.semver_bucket
+  buildpack_notify_bucket        = var.buildpack_notify_bucket
+  billing_bucket                 = var.billing_bucket
+  cg_binaries_bucket             = var.cg_binaries_bucket
+  log_bucket                     = var.log_bucket_name
+  concourse_varz_bucket          = var.concourse_varz_bucket
+  pgp_keys_bucket_name           = var.pgp_keys_bucket_name
+  container_scanning_bucket_name = var.container_scanning_bucket_name
 }
 
 module "concourse_iaas_worker_policy" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -164,6 +164,10 @@ variable "pgp_keys_bucket_name" {
   default = "cg-pgp-keys"
 }
 
+variable "container_scanning_bucket_name" {
+  default = "cg-container-scanning"
+}
+
 variable "oidc_client" {
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- add bucket for container scanning config, cg-container-scanning
- add permissions for concourse worker to read bucket

## security considerations

We are adding permissions for another bucket to be read by our concourse worker, but this is internal to our boundary and isn't exposing any new public access
