### PR TITLE
Add caching back to distribution

### DIFF
--- a/terraform/modules/cloudfront/distribution.tf
+++ b/terraform/modules/cloudfront/distribution.tf
@@ -29,7 +29,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
   default_cache_behavior {
     allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-    cached_methods  = []
+    cached_methods  = ["GET", "HEAD"]
     forwarded_values {
       cookies {
         forward = "all"


### PR DESCRIPTION
## Changes proposed in this pull request:

I removed this in hope of keeping the CloudFront distribution's impact to a minimum, but it's required. Since we won't put distributions in front of customer applications -- only our own -- I'm not as worried about it as before.

## security considerations

Caching will keep responses in memory on CloudFront machines, but our existing access controls will prevent unauthorized users from accessing responses not meant for them.