### PR TITLE
Fix scope to work with CloudFront

### DIFF
--- a/terraform/stacks/cloudfront/stack.tf
+++ b/terraform/stacks/cloudfront/stack.tf
@@ -36,7 +36,7 @@ data "terraform_remote_state" "govcloud" {
 resource "aws_wafv2_web_acl" "commercial_acl" {
   name        = "${var.stack_description}-commercial-acl"
   description = "ACL for use with CloudFront and Shield Advanced."
-  scope       = "REGIONAL"
+  scope       = "CLOUDFRONT"
 
   default_action {
     # no rules needed; they'll be added by Shield Advanced.


### PR DESCRIPTION
## Changes proposed in this pull request:
- Change to the CLOUDFRONT scope, required for use with CloudFront. See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#scope

## security considerations
None.