### PR TITLE
remove public ingress on ports 22 and 443 for diego proxy

### DIFF
--- a/terraform/modules/diego/diego_elb_main.tf
+++ b/terraform/modules/diego/diego_elb_main.tf
@@ -19,21 +19,6 @@ resource "aws_security_group" "diego-elb-sg" {
     cidr_blocks = var.ingress_cidrs
   }
 
-  # 22 / 443 are alternate ports available for manually use by customers with restrictive firewalls
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = var.ingress_cidrs
-  }
-
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = var.ingress_cidrs
-  }
-
   # outbound internet access
   egress {
     from_port   = 0
@@ -54,21 +39,7 @@ resource "aws_elb" "diego_elb_main" {
     instance_port     = 2222
     instance_protocol = "TCP"
   }
-
-  listener {
-    lb_port           = 22
-    lb_protocol       = "TCP"
-    instance_port     = 2222
-    instance_protocol = "TCP"
-  }
-
-  listener {
-    lb_port           = 443
-    lb_protocol       = "TCP"
-    instance_port     = 2222
-    instance_protocol = "TCP"
-  }
-
+  
   health_check {
     healthy_threshold   = 10
     interval            = 30


### PR DESCRIPTION
## Background

Security scans of our infrastructure revealed some cases where port 22 was exposed to the public internet. After some investigation](https://github.com/cloud-gov/private/issues/582), I determined that these ports were exposed on the [diego SSH proxy](https://github.com/cloudfoundry/diego-ssh), which is the system component that makes `cf ssh` possible. 

Before `cf ssh`, users had to use `ssh` directly over port 2222 to get a shell in their application containers [as described in this documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/ssh-apps.html#app-guid). It is still possible to use that method today, but it's more cumbersome than using `cf ssh`. Furthermore, even using `ssh` directly only requires port 2222 to be open, not ports 22 or 443. 

Apparently we exposed ports 22 and 443 for users being restrictive firewalls who couldn't SSH over port 2222. Given the security risks of exposing port 22 publicly and the fact that isn't necessary for SSH access to application containers, this PR removes ports 22 and 443 being exposed on the diego proxy load balancer.

I have confirmed via manual testing in staging that `cf ssh` and `ssh -p 2222` still work for accessing application containers after these changes are made.

## Changes proposed in this pull request:

- Remove public ingress on ports 22 and 443 for the diego proxy load balancer

## security considerations

We are improving security by removing public ingress on ports 22 and 443 to a publicly available load balancer.
