### PR TITLE
Add default tags

### DIFF
--- a/terraform/accounts/root/stack.tf
+++ b/terraform/accounts/root/stack.tf
@@ -3,8 +3,16 @@ terraform {
   }
 }
 
+data "aws_iam_account_alias" "current" {}
+
 provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   region     = var.aws_region
+
+  default_tags {
+    tags = {
+      account    = data.aws_iam_account_alias.current.account_alias
+    }
+  }
 }

--- a/terraform/stacks/cloudfront/stack.tf
+++ b/terraform/stacks/cloudfront/stack.tf
@@ -16,10 +16,19 @@ terraform {
   }
 }
 
+data "aws_iam_account_alias" "current" {}
+
 provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   region     = var.aws_region
+
+  default_tags {
+    tags = {
+      deployment = "cloudfront-${var.stack_description}"
+      account    = data.aws_iam_account_alias.current.account_alias
+    }
+  }
 }
 
 data "terraform_remote_state" "govcloud" {

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -15,10 +15,19 @@ terraform {
   }
 }
 
+data "aws_iam_account_alias" "current" {}
+
 provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   region     = var.aws_region
+
+  default_tags {
+    tags = {
+      deployment = "dns"
+      account    = data.aws_iam_account_alias.current.account_alias
+    }
+  }
 }
 
 variable "cloudfront_zone_id" {

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -3,7 +3,15 @@ terraform {
   }
 }
 
+data "aws_iam_account_alias" "current" {}
+
 provider "aws" {
+  default_tags {
+    tags = {
+      deployment = "external-${var.stack_description}"
+      account    = data.aws_iam_account_alias.current.account_alias
+    }
+  }
 }
 
 data "aws_partition" "current" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -16,6 +16,11 @@ provider "aws" {
     lambda = "https://lambda-fips.${var.aws_default_region}.amazonaws.com"
     wafv2 = "https://wafv2-fips.${var.aws_default_region}.amazonaws.com"
   }
+  default_tags {
+    tags = {
+      deployment     = "bosh-tooling"
+    }
+  }
 }
 provider "aws" {
   # this is for the tooling bosh
@@ -34,6 +39,11 @@ provider "aws" {
     lambda = "https://lambda-fips.${var.aws_default_region}.amazonaws.com"
     wafv2 = "https://wafv2-fips.${var.aws_default_region}.amazonaws.com"
   }
+  default_tags {
+    tags = {
+      deployment     = "bosh-parent"
+    }
+  }
 }
 provider "aws" {
   region = var.aws_default_region
@@ -48,6 +58,12 @@ provider "aws" {
     kms = "https://kms-fips.${var.aws_default_region}.amazonaws.com"
     lambda = "https://lambda-fips.${var.aws_default_region}.amazonaws.com"
     wafv2 = "https://wafv2-fips.${var.aws_default_region}.amazonaws.com"
+  }
+  default_tags {
+    tags = {
+      deployment = "cf-${var.stack_description}"
+      account    = data.aws_iam_account_alias.current.account_alias
+    }
   }
 }
 
@@ -88,6 +104,8 @@ data "aws_caller_identity" "current" {
 
 data "aws_region" "current" {
 }
+
+data "aws_iam_account_alias" "current" {}
 
 data "aws_iam_server_certificate" "wildcard" {
   name_prefix = var.wildcard_certificate_name_prefix

--- a/terraform/stacks/managedaccount/iam.tf
+++ b/terraform/stacks/managedaccount/iam.tf
@@ -1,4 +1,12 @@
+data "aws_iam_account_alias" "current" {}
+
 provider "aws" {
+  default_tags {
+    tags = {
+      deployment = "managed-account-${var.environment_name}"
+      account    = data.aws_iam_account_alias.current.account_alias
+    }
+  }
 }
 
 resource "aws_iam_role" "tfrole" {

--- a/terraform/stacks/regionalmasterbosh/stack.tf
+++ b/terraform/stacks/regionalmasterbosh/stack.tf
@@ -3,13 +3,28 @@ terraform {
   }
 }
 
+data "aws_iam_account_alias" "current" {}
+
 provider "aws" {
   alias = "tooling"
+
+  default_tags {
+    tags = {
+      deployment = "bosh-tooling"
+    }
+  }
 }
+
 provider "aws" {
   region = var.aws_default_region
   assume_role {
     role_arn = var.assume_arn
+  }
+  default_tags {
+    tags = {
+      deployment = "regional-master-bosh-${var.stack_description}"
+      account    = data.aws_iam_account_alias.current.account_alias
+    }
   }
 }
 

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -4,7 +4,15 @@ terraform {
 }
 
 provider "aws" {
+  default_tags {
+    tags = {
+      deployment = "tooling"
+      account    = data.aws_iam_account_alias.current.account_alias
+    }
+  }
 }
+
+data "aws_iam_account_alias" "current" {}
 
 data "aws_partition" "current" {
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add default tags to all AWS provider blocks: https://developer.hashicorp.com/terraform/tutorials/aws/aws-default-tags

These changes should ensure that all of our resources are tagged on deployment, which should then make doing cost rollups easier

## security considerations

None, just adding resource tags
