### PR TITLE
fix issue with default tags on waf resource

### DIFF
--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -65,7 +65,9 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   scope       = "REGIONAL"
 
   # see https://github.com/hashicorp/terraform-provider-aws/issues/24386#issuecomment-1109340765
-  ignore_changes = [tags_all]
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
 
   default_action {
     allow {}

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -64,6 +64,9 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   description = "UAA ELB WAF Rules"
   scope       = "REGIONAL"
 
+  # see https://github.com/hashicorp/terraform-provider-aws/issues/24386#issuecomment-1109340765
+  ignore_changes = [tags_all]
+
   default_action {
     allow {}
   }


### PR DESCRIPTION
## Changes proposed in this pull request:

There is an issue with when using `default_tags` at the provider level with WAF resources. This PR applies a temporary workaround for the issue.

## security considerations

None
