### PR TITLE
add missing perms for KMS key policy

### DIFF
--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
@@ -1,5 +1,55 @@
 data "aws_iam_policy_document" "kms_key_policy" {
   statement {
+    sid = "Enable IAM User Permissions"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${var.aws_partition}:iam::${var.kms_account_id}:root"]
+    }
+
+    actions = [
+      "kms:*"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    sid = "Allow access for Key Administrators"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [for role in var.kms_admin_roles : "arn:${var.aws_partition}:iam::${var.kms_account_id}:role/${role}"]
+    }
+
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:TagResource",
+      "kms:UntagResource",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
+    ]
+
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    sid = "AllowKeyUse"
     effect = "Allow"
 
     principals {

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -24,6 +24,11 @@ variable "kms_account_id" {
   description = "Account ID making requests to KMS key"
 }
 
+variable "kms_admin_roles" {
+  type = list(string)
+  default = ["Administrator"]
+}
+
 variable "lifecycle_rules" {
   description = "List of maps containing configuration of object lifecycle management."
   type        = any


### PR DESCRIPTION
## Changes proposed in this pull request:

- add missing perms for KMS key policy to address Terraform deployment error

## security considerations

These permission updates give admin users the ability to manage this KMS key