### PR TITLE
Update IAM policy for KMS encrypted bucket module

### DIFF
--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
@@ -25,11 +25,6 @@ resource "aws_s3_bucket_acl" "kms_encrypted_bucket_acl" {
   acl    = var.acl
 }
 
-resource "aws_s3_bucket_policy" "kms_bucket_policy" {
-  bucket = aws_s3_bucket.kms_encrypted_bucket.id
-  policy = data.aws_iam_policy_document.kms_encrypted_bucket_policy.json
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "kms_encrypted_bucket_lifecycle" {
   bucket = aws_s3_bucket.kms_encrypted_bucket.id
   count = length(var.lifecycle_rules) > 0 ? 1 : 0

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/iam.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/iam.tf
@@ -1,4 +1,6 @@
 data "aws_iam_policy_document" "kms_encrypted_bucket_policy" {
+  source_policy_documents = var.source_bucket_policy_documents
+  
   statement {
     sid = "DenyIncorrectEncryptionHeader"
     effect = "Deny"

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -60,6 +60,11 @@ variable "lifecycle_rules" {
   # ]
 }
 
+variable "allowed_external_account_ids" {
+  type = list(string)
+  default = []
+}
+
 variable "region" {
   type = string
   description = "AWS region (e.g. us-gov-west-1)"

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -69,3 +69,8 @@ variable "region" {
   type = string
   description = "AWS region (e.g. us-gov-west-1)"
 }
+
+variable "source_bucket_policy_documents" {
+  type = list(string)
+  default = []
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- add support for specifying external accounts that should have bucket access
- [add support for source policy documents](https://github.com/cloud-gov/cg-provision/commit/42276e14f972962ef24ce3532fd9c5d5aef2b8b8)

## security considerations

The permissions are tailored to only allow access from specified accounts
