### PR TITLE
update kms key policy to allow cross account permissions

### DIFF
--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
@@ -81,6 +81,30 @@ data "aws_iam_policy_document" "kms_key_policy" {
       values = [var.kms_account_id]
     }
   }
+
+  dynamic "statement" {
+    for_each = var.allowed_external_account_ids
+    iterator = account
+
+    content {
+      sid = "AllowExternalKMSKeyAccess_${account.value}"
+      effect = "Allow"
+
+      principals {
+        type = "AWS"
+        identifiers = ["arn:${var.aws_partition}:iam::${account.value}:root"]
+      }
+
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ]
+
+      resources = [
+        "*"
+      ]
+    }
+  }
 }
 
 resource "aws_kms_key" "encryption_key" {


### PR DESCRIPTION
## Changes proposed in this pull request:

One use case for this module could be deploying a KMS encrypted bucket in one AWS account and accessing it/writing to it from a different account. In that case, these changes are necessary to support allowing access to the KMS key from the source account to the account where the KMS key resides.

## security considerations

The code updates allow specifying access to a KMS key from different AWS accounts
