### PR TITLE
Fix tag collisions

### DIFF
--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -60,6 +60,7 @@ module "vpc_peering" {
   source_vpc_cidr        = module.base.vpc_cidr
   source_az1_route_table = module.base.private_route_table_az1
   source_az2_route_table = module.base.private_route_table_az2
+  stack_description      = var.stack_description
 }
 
 module "vpc_peering_parentbosh" {
@@ -78,7 +79,7 @@ module "vpc_peering_parentbosh" {
   source_vpc_cidr        = module.base.vpc_cidr
   source_az1_route_table = module.base.private_route_table_az1
   source_az2_route_table = module.base.private_route_table_az2
-  
+  stack_description      = var.stack_description
 }
 
  module "vpc_security_source_to_parent" {

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -60,7 +60,6 @@ module "vpc_peering" {
   source_vpc_cidr        = module.base.vpc_cidr
   source_az1_route_table = module.base.private_route_table_az1
   source_az2_route_table = module.base.private_route_table_az2
-  stack_description      = var.stack_description
 }
 
 module "vpc_peering_parentbosh" {
@@ -79,7 +78,6 @@ module "vpc_peering_parentbosh" {
   source_vpc_cidr        = module.base.vpc_cidr
   source_az1_route_table = module.base.private_route_table_az1
   source_az2_route_table = module.base.private_route_table_az2
-  stack_description      = var.stack_description
 }
 
  module "vpc_security_source_to_parent" {

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -31,8 +31,8 @@ resource "aws_vpc_peering_connection" "peering" {
 
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
-    deployment = "cf-${var.stack_description}"
-    stack = "${var.stack_description}"
+    # deployment = "cf-${var.stack_description}"
+    # stack = "${var.stack_description}"
   }
 }
 
@@ -47,8 +47,8 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
-    deployment = "cf-${var.stack_description}"
-    stack = "${var.stack_description}"
+    # deployment = "cf-${var.stack_description}"
+    # stack = "${var.stack_description}"
   }
 }
 

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -25,14 +25,12 @@ resource "aws_vpc_peering_connection" "peering" {
   auto_accept   = false
   vpc_id        = var.source_vpc_id
 
-  lifecycle {
-    ignore_changes = [tags_all]
-  }
+  # lifecycle {
+  #   ignore_changes = [tags_all]
+  # }
 
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
-    # deployment = "cf-${var.stack_description}"
-    # stack = "${var.stack_description}"
   }
 }
 
@@ -41,14 +39,12 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
   auto_accept               = true
 
-  lifecycle {
-    ignore_changes = [tags_all]
-  }
+  # lifecycle {
+  #   ignore_changes = [tags_all]
+  # }
 
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
-    # deployment = "cf-${var.stack_description}"
-    # stack = "${var.stack_description}"
   }
 }
 

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -25,8 +25,14 @@ resource "aws_vpc_peering_connection" "peering" {
   auto_accept   = false
   vpc_id        = var.source_vpc_id
 
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
+
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
+    deployment = "cf-${var.stack_description}"
+    stack = "${var.stack_description}"
   }
 }
 
@@ -35,8 +41,14 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
   auto_accept               = true
 
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
+
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
+    deployment = "cf-${var.stack_description}"
+    stack = "${var.stack_description}"
   }
 }
 

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -25,9 +25,9 @@ resource "aws_vpc_peering_connection" "peering" {
   auto_accept   = false
   vpc_id        = var.source_vpc_id
 
-  # lifecycle {
-  #   ignore_changes = [tags_all]
-  # }
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
 
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
@@ -39,9 +39,9 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
   auto_accept               = true
 
-  # lifecycle {
-  #   ignore_changes = [tags_all]
-  # }
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
 
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"

--- a/terraform/modules/vpc_peering/variables.tf
+++ b/terraform/modules/vpc_peering/variables.tf
@@ -25,3 +25,6 @@ variable "source_vpc_cidr" {
 variable "target_vpc_account_id" {
 
 }
+
+variable "stack_description" {
+}

--- a/terraform/modules/vpc_peering/variables.tf
+++ b/terraform/modules/vpc_peering/variables.tf
@@ -25,6 +25,3 @@ variable "source_vpc_cidr" {
 variable "target_vpc_account_id" {
 
 }
-
-variable "stack_description" {
-}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -18,7 +18,7 @@ provider "aws" {
   }
   default_tags {
     tags = {
-      bosh_env = "tooling"
+      stack = "tooling"
     }
   }
 }
@@ -41,7 +41,7 @@ provider "aws" {
   }
   default_tags {
     tags = {
-      bosh_env = "parent"
+      stack = "parent"
     }
   }
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -18,7 +18,7 @@ provider "aws" {
   }
   default_tags {
     tags = {
-      deployment     = "bosh-tooling"
+      bosh_env = "tooling"
     }
   }
 }
@@ -41,7 +41,7 @@ provider "aws" {
   }
   default_tags {
     tags = {
-      deployment     = "bosh-parent"
+      bosh_env = "parent"
     }
   }
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -18,7 +18,7 @@ provider "aws" {
   }
   default_tags {
     tags = {
-      stack = "tooling"
+      stack = "bosh-tooling"
     }
   }
 }
@@ -41,7 +41,7 @@ provider "aws" {
   }
   default_tags {
     tags = {
-      stack = "parent"
+      stack = "bosh-parent"
     }
   }
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -18,7 +18,7 @@ provider "aws" {
   }
   default_tags {
     tags = {
-      stack = "bosh-tooling"
+      deployment = "bosh-tooling"
     }
   }
 }
@@ -41,7 +41,7 @@ provider "aws" {
   }
   default_tags {
     tags = {
-      stack = "bosh-parent"
+      deployment = "bosh-parent"
     }
   }
 }

--- a/terraform/stacks/regionalmasterbosh/stack.tf
+++ b/terraform/stacks/regionalmasterbosh/stack.tf
@@ -185,5 +185,4 @@ module "concourse_vpc_peering" {
   source_vpc_cidr        = module.stack.vpc_cidr
   source_az1_route_table = module.stack.private_route_table_az1
   source_az2_route_table = module.stack.private_route_table_az2
-  stack_description      = var.stack_description
 }

--- a/terraform/stacks/regionalmasterbosh/stack.tf
+++ b/terraform/stacks/regionalmasterbosh/stack.tf
@@ -185,4 +185,5 @@ module "concourse_vpc_peering" {
   source_vpc_cidr        = module.stack.vpc_cidr
   source_az1_route_table = module.stack.private_route_table_az1
   source_az2_route_table = module.stack.private_route_table_az2
+  stack_description      = var.stack_description
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

As a result of #1183, we have an issue where `terraform plan` always thinks these [VPC peering resources](https://github.com/cloud-gov/cg-provision/blob/fdaced8c3f43b54da044f39ae2cd5b100e830422/terraform/modules/vpc_peering/network.tf#L21-L41) need to have their `tags` updated.

This is quite annoying because it makes our `plan-bootstrap*` job output say that there are changes that need to be deployed, even when there really aren't. For now, the easiest solution is to disable the application of default tags on these resources using the Terraform `ignore_changes` lifecycle property.

## security considerations

None, just changing resource tagging strategy
