### PR TITLE
add sq rule to allow rds to reach s3

### DIFF
--- a/terraform/modules/rds_network/sg_postgres.tf
+++ b/terraform/modules/rds_network/sg_postgres.tf
@@ -4,6 +4,12 @@
  *   vpc_id
  */
 
+data "aws_region" "current" {}
+
+data "aws_prefix_list" "s3" {
+  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+}
+
 resource "aws_security_group" "rds_postgres" {
   description = "Allow access to incoming postgresql traffic"
   vpc_id      = var.vpc_id
@@ -32,6 +38,16 @@ resource "aws_security_group_rule" "egress_default" {
   to_port                  = 0
   protocol                 = "-1"
   source_security_group_id = element(var.security_groups, count.index)
+  security_group_id        = aws_security_group.rds_postgres.id
+}
+
+# allows pg rds to get to s3 for import and export
+resource "aws_security_group_rule" "egress_s3" {
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  prefix_list_ids          = [data.aws_prefix_list.s3.id]
   security_group_id        = aws_security_group.rds_postgres.id
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- This changes gives the RDS Postgres subnet the ability to access the s3 private endpoint
- With this change customers can imoort/export data between their s3 service instance into their pg service instances. 
- This will assist with seeding or ETL of data into client databases, especially with very large datasets. 

## security considerations
None