### PR TITLE
add support for blocking public access to KMS encrypted buckets

### DIFF
--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
@@ -2,6 +2,15 @@ resource "aws_s3_bucket" "kms_encrypted_bucket" {
   bucket = var.bucket_name
 }
 
+resource "aws_s3_bucket_public_access_block" "kms_encrypted_bucket_block_public" {
+  bucket = aws_s3_bucket.kms_encrypted_bucket.id
+
+  block_public_acls       = var.block_public_acls
+  block_public_policy     = var.block_public_policy
+  ignore_public_acls      = var.ignore_public_acls
+  restrict_public_buckets = var.restrict_public_buckets
+}
+
 resource "aws_s3_bucket_versioning" "kms_encrypted_bucket_versioning" {
   bucket = aws_s3_bucket.kms_encrypted_bucket.id
   versioning_configuration {

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -74,3 +74,27 @@ variable "source_bucket_policy_documents" {
   type = list(string)
   default = []
 }
+
+variable "block_public_acls" {
+  description = "Whether Amazon S3 should block public ACLs for this bucket"
+  type        = bool
+  default     = false
+}
+
+variable "block_public_policy" {
+  description = "Whether Amazon S3 should block public bucket policies for this bucket"
+  type        = bool
+  default     = false
+}
+
+variable "ignore_public_acls" {
+  description = "Whether Amazon S3 should ignore public ACLs for this bucket."
+  type        = bool
+  default     = false
+}
+
+variable "restrict_public_buckets" {
+  type        = bool
+  description = "Whether Amazon S3 should restrict public bucket policies for this bucket"
+  default     = false
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- add resource and variables to support blocking public access to buckets created by KMS encrypted bucket module
-
-

## security considerations

These variables allow KMS encrypted buckets to be configured to never be publicly accessible
