### PR TITLE
add security group rule allowing egress to PostgreSQL

### DIFF
--- a/terraform/modules/rds_network/sg_postgres.tf
+++ b/terraform/modules/rds_network/sg_postgres.tf
@@ -60,3 +60,13 @@ resource "aws_security_group_rule" "ingress_tooling" {
   cidr_blocks              = var.allowed_cidrs
   security_group_id        = aws_security_group.rds_postgres.id
 }
+
+# allows egress traffic to other PostgreSQL databases
+resource "aws_security_group_rule" "egress_postgresql" {
+  type                     = "egress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  cidr_blocks              = var.allowed_cidrs
+  security_group_id        = aws_security_group.rds_postgres.id
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

This change updates the security group to allow egress traffic to other PostgreSQL databases (port 5432) in the allowed CIDR ranges. 

[This change is intended to support "foreign data wrappers" between RDS databases](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.Extensions.foreign-data-wrappers.html), as requested by a customer.

## security considerations

This change theoretically allows requests between databases in the same CIDR range, but username/password authentication should still be required to make the connection.
