### PR TITLE
Fix tagging collision for VPC network peering resources

### DIFF
--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -29,15 +29,17 @@ resource "aws_vpc_peering_connection" "peering" {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
   }
 
-  lifecycle {
-    ignore_changes = [tags_all]
-  }
+
 }
 
 resource "aws_vpc_peering_connection_accepter" "peer" {
   provider                  = aws.tooling
   vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
   auto_accept               = true
+
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
 }
 
 # Add peering connection to target_az1_route_table with source_vpc_cidr

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -38,6 +38,10 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
   }
+
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
 }
 
 # Add peering connection to target_az1_route_table with source_vpc_cidr

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -28,6 +28,10 @@ resource "aws_vpc_peering_connection" "peering" {
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
   }
+
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
 }
 
 resource "aws_vpc_peering_connection_accepter" "peer" {

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -28,10 +28,6 @@ resource "aws_vpc_peering_connection" "peering" {
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
   }
-
-  lifecycle {
-    ignore_changes = [tags_all]
-  }
 }
 
 resource "aws_vpc_peering_connection_accepter" "peer" {

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -25,10 +25,6 @@ resource "aws_vpc_peering_connection" "peering" {
   auto_accept   = false
   vpc_id        = var.source_vpc_id
 
-  lifecycle {
-    ignore_changes = [tags_all]
-  }
-
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
   }
@@ -38,10 +34,6 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   provider                  = aws.tooling
   vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
   auto_accept               = true
-
-  lifecycle {
-    ignore_changes = [tags_all]
-  }
 
   tags = {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -38,14 +38,6 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   provider                  = aws.tooling
   vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
   auto_accept               = true
-
-  tags = {
-    Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
-  }
-
-  lifecycle {
-    ignore_changes = [tags_all]
-  }
 }
 
 # Add peering connection to target_az1_route_table with source_vpc_cidr

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -29,7 +29,9 @@ resource "aws_vpc_peering_connection" "peering" {
     Name = "${var.source_vpc_id} to ${var.target_vpc_id}"
   }
 
-
+  lifecycle {
+    ignore_changes = [tags_all]
+  }
 }
 
 resource "aws_vpc_peering_connection_accepter" "peer" {

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -40,7 +40,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   auto_accept               = true
 
   lifecycle {
-    ignore_changes = [tags_all]
+    ignore_changes = [tags, tags_all]
   }
 }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -16,11 +16,6 @@ provider "aws" {
     lambda = "https://lambda-fips.${var.aws_default_region}.amazonaws.com"
     wafv2 = "https://wafv2-fips.${var.aws_default_region}.amazonaws.com"
   }
-  default_tags {
-    tags = {
-      deployment = "bosh-tooling"
-    }
-  }
 }
 provider "aws" {
   # this is for the tooling bosh
@@ -38,11 +33,6 @@ provider "aws" {
     kms = "https://kms-fips.${var.aws_default_region}.amazonaws.com"
     lambda = "https://lambda-fips.${var.aws_default_region}.amazonaws.com"
     wafv2 = "https://wafv2-fips.${var.aws_default_region}.amazonaws.com"
-  }
-  default_tags {
-    tags = {
-      deployment = "bosh-parent"
-    }
   }
 }
 provider "aws" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -8,6 +8,11 @@ provider "aws" {
   # this is for CI
   # run deployments, provide jumpboxes, check on things, etc
   alias = "tooling"
+  default_tags {
+    tags = {
+      deployment = "bosh-tooling"
+    }
+  }
 }
 provider "aws" {
   use_fips_endpoint = true
@@ -17,6 +22,11 @@ provider "aws" {
   region = var.aws_default_region
   assume_role {
     role_arn = var.parent_assume_arn
+  }
+  default_tags {
+    tags = {
+      deployment = "bosh-parent"
+    }
   }
 }
 provider "aws" {


### PR DESCRIPTION
## Changes proposed in this pull request:

Due to a collision in the tags applied on the `aws_vpc_peering_connection` and `aws_vpc_peering_connection_accepter` resources, Terraform always thinks there are changes to apply for one resource, even when nothing has changed. The output from `terraform plan` looks something like:

```
  # module.stack.module.vpc_peering_parentbosh.aws_vpc_peering_connection_accepter.peer will be updated in-place
  ~ resource "aws_vpc_peering_connection_accepter" "peer" {
        id                        = <redacted>
      ~ tags                      = {
          - "deployment" = "cf-<deployment>" -> null
            # (1 unchanged element hidden)
        }
        # (8 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }
```

This behavior is problematic because it causes our CI system to send us a message in Slack telling us to review the `terraform plan` output, when in reality nothing has changed or needs to change.

The problem turned out to be caused by the fact that the Terraform `aws_vpc_peering_connection` and `aws_vpc_peering_connection_accepter` resources actually managed a single AWS VPC peering connection resource. So defining `tags` on both Terraform resources and having default tags (`tags_all`) from different providers apply to each resource was causing Terraform to get persistently confused about which tags to apply. 

The changes in this PR update the `aws_vpc_peering_connection_accepter` Terraform resource to ignore changes to `tags` and `tags_all` (default tags), which is fine, because tags (including `Name`) are set on the `aws_vpc_peering_connection` resource. And this change resolves the persistent confusion and detection of changes by Terraform.

## security considerations

None
