### PR TITLE
remove egress rule to PostgreSQL databases 

### DIFF
--- a/terraform/modules/rds_network/sg_postgres.tf
+++ b/terraform/modules/rds_network/sg_postgres.tf
@@ -60,13 +60,3 @@ resource "aws_security_group_rule" "ingress_tooling" {
   cidr_blocks              = var.allowed_cidrs
   security_group_id        = aws_security_group.rds_postgres.id
 }
-
-# allows egress traffic to other PostgreSQL databases
-resource "aws_security_group_rule" "egress_postgresql" {
-  type                     = "egress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  cidr_blocks              = var.allowed_cidrs
-  security_group_id        = aws_security_group.rds_postgres.id
-}


### PR DESCRIPTION
## Changes proposed in this pull request:

Reverts https://github.com/cloud-gov/cg-provision/pull/1212/files

## security considerations

There are significant security questions that need to be answered before we allow or enable traffic between PostgreSQL databases, so this PR reverts the change that was intended to support that traffic.
