### PR TITLE
add iam:ListAttachedRolePolicies perm for aws broker

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -78,7 +78,7 @@
       "Resource": [
         "arn:aws-us-gov:s3:::*"
       ]
-    },    
+    },
     {
       "Effect": "Allow",
       "Action": [
@@ -132,6 +132,7 @@
         "iam:CreatePolicy",
         "iam:DeletePolicy",
         "iam:ListAttachedUserPolicies",
+        "iam:ListAttachedRolePolicies",
         "iam:AttachUserPolicy",
         "iam:DetachUserPolicy",
         "iam:ListRoles",


### PR DESCRIPTION
## Changes proposed in this pull request:

I had to modify the aws-broker to fix an issue where Elasticsearch domains wouldn't delete if some roles/policies already exist (https://github.com/cloud-gov/aws-broker/pull/274), because it tries to create them before deletion in order to take a final snapshot. The code I added looks up the ARNs for the roles/policies if they already exist, which requires the  iam:ListAttachedRolePolicies permission that isn't currently on the IAM policy with permissions for the aws-broker.

## security considerations

We're adding a new IAM permission used by our platform cell VMs to fix functionality for the AWS broker
