### PR TITLE
Expand rds subnet group

### DIFF
--- a/terraform/modules/rds_network/network.tf
+++ b/terraform/modules/rds_network/network.tf
@@ -2,8 +2,10 @@
  * Variables required:
  *   stack_description
  *   vpc_id
- *   rds_private_cidr1
- *   rds_private_cidr2
+ *   rds_private_cidr_1
+ *   rds_private_cidr_3
+ *   rds_private_cidr_2
+ *   rds_private_cidr_4
  *   az1
  *   az2
  */
@@ -18,6 +20,16 @@ resource "aws_subnet" "az1_rds" {
   }
 }
 
+resource "aws_subnet" "az3_rds" {
+  vpc_id            = var.vpc_id
+  cidr_block        = var.rds_private_cidr_3
+  availability_zone = var.az1
+
+  tags = {
+    Name = "${var.stack_description} (RDS AZ3)"
+  }
+}
+
 resource "aws_subnet" "az2_rds" {
   vpc_id            = var.vpc_id
   cidr_block        = var.rds_private_cidr_2
@@ -28,10 +40,20 @@ resource "aws_subnet" "az2_rds" {
   }
 }
 
+resource "aws_subnet" "az4_rds" {
+  vpc_id            = var.vpc_id
+  cidr_block        = var.rds_private_cidr_4
+  availability_zone = var.az2
+
+  tags = {
+    Name = "${var.stack_description} (RDS AZ4)"
+  }
+}
+
 resource "aws_db_subnet_group" "rds" {
   name        = var.stack_description
   description = "${var.stack_description} (Multi-AZ Subnet Group)"
-  subnet_ids  = [aws_subnet.az1_rds.id, aws_subnet.az2_rds.id]
+  subnet_ids  = [aws_subnet.az1_rds.id, aws_subnet.az3_rds.id, aws_subnet.az2_rds.id, aws_subnet.az4_rds.id]
 }
 
 resource "aws_route_table_association" "az1_rds_rta" {
@@ -39,8 +61,18 @@ resource "aws_route_table_association" "az1_rds_rta" {
   route_table_id = var.az1_route_table
 }
 
+resource "aws_route_table_association" "az3_rds_rta" {
+  subnet_id      = aws_subnet.az3_rds.id
+  route_table_id = var.az1_route_table
+}
+
 resource "aws_route_table_association" "az2_rds_rta" {
   subnet_id      = aws_subnet.az2_rds.id
+  route_table_id = var.az2_route_table
+}
+
+resource "aws_route_table_association" "az4_rds_rta" {
+  subnet_id      = aws_subnet.az4_rds.id
   route_table_id = var.az2_route_table
 }
 

--- a/terraform/modules/rds_network/outputs.tf
+++ b/terraform/modules/rds_network/outputs.tf
@@ -2,16 +2,33 @@ output "rds_subnet_az1" {
   value = aws_subnet.az1_rds.id
 }
 
+output "rds_subnet_az3" {
+  value = aws_subnet.az3_rds.id
+}
+
 output "rds_subnet_az2" {
   value = aws_subnet.az2_rds.id
 }
+
+output "rds_subnet_az4" {
+  value = aws_subnet.az4_rds.id
+}
+
 
 output "rds_private_cidr_1" {
   value = aws_subnet.az1_rds.cidr_block
 }
 
+output "rds_private_cidr_3" {
+  value = aws_subnet.az3_rds.cidr_block
+}
+
 output "rds_private_cidr_2" {
   value = aws_subnet.az2_rds.cidr_block
+}
+
+output "rds_private_cidr_4" {
+  value = aws_subnet.az4_rds.cidr_block
 }
 
 output "rds_subnet_group" {

--- a/terraform/modules/rds_network/variables.tf
+++ b/terraform/modules/rds_network/variables.tf
@@ -15,6 +15,12 @@ variable "rds_private_cidr_1" {
 variable "rds_private_cidr_2" {
 }
 
+variable "rds_private_cidr_3" {
+}
+
+variable "rds_private_cidr_4" {
+}
+
 variable "az1_route_table" {
 }
 

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -31,6 +31,8 @@ module "rds_network" {
   security_groups_count = var.rds_security_groups_count
   rds_private_cidr_1    = var.rds_private_cidr_1
   rds_private_cidr_2    = var.rds_private_cidr_2
+  rds_private_cidr_3    = var.rds_private_cidr_3
+  rds_private_cidr_4    = var.rds_private_cidr_4
   az1_route_table       = module.vpc.private_route_table_az1
   az2_route_table       = module.vpc.private_route_table_az2
 }

--- a/terraform/modules/stack/base/outputs.tf
+++ b/terraform/modules/stack/base/outputs.tf
@@ -99,12 +99,28 @@ output "rds_subnet_az2" {
   value = module.rds_network.rds_subnet_az2
 }
 
+output "rds_subnet_az3" {
+  value = module.rds_network.rds_subnet_az3
+}
+
+output "rds_subnet_az4" {
+  value = module.rds_network.rds_subnet_az4
+}
+
 output "rds_private_cidr_1" {
   value = module.rds_network.rds_private_cidr_1
 }
 
 output "rds_private_cidr_2" {
   value = module.rds_network.rds_private_cidr_2
+}
+
+output "rds_private_cidr_3" {
+  value = module.rds_network.rds_private_cidr_3
+}
+
+output "rds_private_cidr_4" {
+  value = module.rds_network.rds_private_cidr_4
 }
 
 output "rds_subnet_group" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -41,6 +41,12 @@ variable "rds_private_cidr_1" {
 variable "rds_private_cidr_2" {
 }
 
+variable "rds_private_cidr_3" {
+}
+
+variable "rds_private_cidr_4" {
+}
+
 variable "rds_instance_type" {
   default = "db.m4.large"
 }

--- a/terraform/modules/stack/spoke/outputs.tf
+++ b/terraform/modules/stack/spoke/outputs.tf
@@ -99,12 +99,28 @@ output "rds_subnet_az2" {
   value = module.base.rds_subnet_az2
 }
 
+output "rds_subnet_az3" {
+  value = module.base.rds_subnet_az3
+}
+
+output "rds_subnet_az4" {
+  value = module.base.rds_subnet_az4
+}
+
 output "rds_private_cidr_1" {
   value = module.base.rds_private_cidr_1
 }
 
 output "rds_private_cidr_2" {
   value = module.base.rds_private_cidr_2
+}
+
+output "rds_private_cidr_3" {
+  value = module.base.rds_private_cidr_3
+}
+
+output "rds_private_cidr_4" {
+  value = module.base.rds_private_cidr_4
 }
 
 output "rds_subnet_group" {

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -12,6 +12,8 @@ module "base" {
   nat_gateway_instance_type         = var.nat_gateway_instance_type
   rds_private_cidr_1                = var.rds_private_cidr_1
   rds_private_cidr_2                = var.rds_private_cidr_2
+  rds_private_cidr_3                = var.rds_private_cidr_3
+  rds_private_cidr_4                = var.rds_private_cidr_4
   rds_instance_type                 = var.rds_instance_type
   rds_db_size                       = var.rds_db_size
   rds_db_name                       = var.rds_db_name

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -41,6 +41,12 @@ variable "rds_private_cidr_1" {
 variable "rds_private_cidr_2" {
 }
 
+variable "rds_private_cidr_3" {
+}
+
+variable "rds_private_cidr_4" {
+}
+
 variable "rds_instance_type" {
   default = "db.m4.large"
 }

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -245,7 +245,7 @@ output "rds_subnet_az2" {
 }
 
 output "rds_subnet_az3" {
-  value = module.stack.rds_subnet_az1
+  value = module.stack.rds_subnet_az3
 }
 
 output "rds_subnet_az4" {

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -244,12 +244,29 @@ output "rds_subnet_az2" {
   value = module.stack.rds_subnet_az2
 }
 
+output "rds_subnet_az3" {
+  value = module.stack.rds_subnet_az1=3
+}
+
+output "rds_subnet_az4" {
+  value = module.stack.rds_subnet_az4
+}
+
+
 output "rds_subnet_cidr_az1" {
   value = module.stack.rds_private_cidr_1
 }
 
 output "rds_subnet_cidr_az2" {
   value = module.stack.rds_private_cidr_2
+}
+
+output "rds_subnet_cidr_az3" {
+  value = module.stack.rds_private_cidr_3
+}
+
+output "rds_subnet_cidr_az4" {
+  value = module.stack.rds_private_cidr_4
 }
 
 output "rds_subnet_group" {

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -245,7 +245,7 @@ output "rds_subnet_az2" {
 }
 
 output "rds_subnet_az3" {
-  value = module.stack.rds_subnet_az1=3
+  value = module.stack.rds_subnet_az1
 }
 
 output "rds_subnet_az4" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -220,6 +220,8 @@ module "stack" {
   private_cidr_2                    = cidrsubnet(var.vpc_cidr, 8, 2)
   rds_private_cidr_1                = cidrsubnet(var.vpc_cidr, 8, 20)
   rds_private_cidr_2                = cidrsubnet(var.vpc_cidr, 8, 21)
+  rds_private_cidr_3                = cidrsubnet(var.vpc_cidr, 7, 11) # This will give 22-23
+  rds_private_cidr_4                = cidrsubnet(var.vpc_cidr, 7, 12) # This will give 24-25
   restricted_ingress_web_cidrs      = var.restricted_ingress_web_cidrs
   restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
   rds_password                      = var.rds_password

--- a/terraform/stacks/regionalmasterbosh/stack.tf
+++ b/terraform/stacks/regionalmasterbosh/stack.tf
@@ -109,6 +109,8 @@ module "stack" {
   restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
   rds_private_cidr_1                = cidrsubnet(var.vpc_cidr, 8, 20)
   rds_private_cidr_2                = cidrsubnet(var.vpc_cidr, 8, 21)
+  rds_private_cidr_3                = cidrsubnet(var.vpc_cidr, 7, 11) # This will give 22-23
+  rds_private_cidr_4                = cidrsubnet(var.vpc_cidr, 7, 12) # This will give 24-25
   rds_password                      = var.rds_password
   credhub_rds_password              = var.credhub_rds_password
   rds_multi_az                      = var.rds_multi_az

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -203,6 +203,14 @@ output "rds_subnet_az2" {
   value = module.stack.rds_subnet_az2
 }
 
+output "rds_subnet_az3" {
+  value = module.stack.rds_subnet_az3
+}
+
+output "rds_subnet_az4" {
+  value = module.stack.rds_subnet_az4
+}
+
 output "rds_subnet_group" {
   value = module.stack.rds_subnet_group
 }

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -88,6 +88,8 @@ module "stack" {
   restricted_ingress_web_ipv6_cidrs      = var.restricted_ingress_web_ipv6_cidrs
   rds_private_cidr_1                     = cidrsubnet(var.vpc_cidr, 8, 20)
   rds_private_cidr_2                     = cidrsubnet(var.vpc_cidr, 8, 21)
+  rds_private_cidr_3                = cidrsubnet(var.vpc_cidr, 7, 11) # This will give 22-23
+  rds_private_cidr_4                = cidrsubnet(var.vpc_cidr, 7, 12) # This will give 24-25
   rds_password                           = var.rds_password
   credhub_rds_password                   = var.credhub_rds_password
   rds_multi_az                           = var.rds_multi_az


### PR DESCRIPTION
## Changes proposed in this pull request:
- New AZ3 for rds subnet groups
- New AZ4 for rds subnet groups
- For routing reasons AZ3 will be using AZ1's route tables and AZ4 is using AZ2
- Each new subnet will have double the capacity of previous

## security considerations
None