### PR TITLE
add option to include custom IAM policy documents in KMS key policy

### DIFF
--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
@@ -1,4 +1,6 @@
 data "aws_iam_policy_document" "kms_key_policy" {
+  source_policy_documents = var.source_kms_key_policy_documents
+
   statement {
     sid = "Enable IAM User Permissions"
     effect = "Allow"

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -71,6 +71,13 @@ variable "region" {
 }
 
 variable "source_bucket_policy_documents" {
+  description = "IAM policy documents to include in the S3 bucket policy"
+  type = list(string)
+  default = []
+}
+
+variable "source_kms_key_policy_documents" {
+  description = "IAM policy documents to include in the KMS key policy"
   type = list(string)
   default = []
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

In some cases, we may want to add additional statements to the IAM policy document used for the KMS key policy. For example, the GuardDuty service principal needs access to the KMS key policy for a bucket in order to publish its findings to an S3 bucket encrypted using KMS: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_exportfindings.html#guardduty_exportfindings-key-policy

## security considerations

None, we're just allowing consumers of this module to update the KMS key policy as necessary
