### PR TITLE
use FIPS endpoints for all providers

### DIFF
--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -53,7 +53,7 @@ data "aws_canonical_user_id" "current_user" {
 }
 
 resource "aws_s3_bucket" "cloudfront_log_bucket" {
-  provider = aws.standard
+  # provider = aws.standard
   bucket = "external-domain-broker-cloudfront-logs-${var.stack_description}"
 }
 

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -53,8 +53,10 @@ data "aws_canonical_user_id" "current_user" {
 }
 
 resource "aws_s3_bucket" "cloudfront_log_bucket" {
+  provider = aws.no-fips
   bucket = "external-domain-broker-cloudfront-logs-${var.stack_description}"
-} 
+}
+
 resource "aws_s3_bucket_acl" "cloudfront_log_bucket_acl" {
   bucket = aws_s3_bucket.cloudfront_log_bucket.id
 

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -53,7 +53,7 @@ data "aws_canonical_user_id" "current_user" {
 }
 
 resource "aws_s3_bucket" "cloudfront_log_bucket" {
-  provider = aws.no-fips
+  provider = aws.standard
   bucket = "external-domain-broker-cloudfront-logs-${var.stack_description}"
 }
 

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -53,7 +53,7 @@ data "aws_canonical_user_id" "current_user" {
 }
 
 resource "aws_s3_bucket" "cloudfront_log_bucket" {
-  # provider = aws.standard
+  provider = aws.foo
   bucket = "external-domain-broker-cloudfront-logs-${var.stack_description}"
 }
 

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -54,7 +54,6 @@ data "aws_canonical_user_id" "current_user" {
 }
 
 resource "aws_s3_bucket" "cloudfront_log_bucket" {
-  provider = aws.standard
   bucket = "external-domain-broker-cloudfront-logs-${var.stack_description}"
 }
 

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -50,6 +50,7 @@ resource "aws_iam_user_policy" "iam_policy" {
 }
 
 data "aws_canonical_user_id" "current_user" {
+  provider = aws.foo
 }
 
 resource "aws_s3_bucket" "cloudfront_log_bucket" {

--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -50,11 +50,11 @@ resource "aws_iam_user_policy" "iam_policy" {
 }
 
 data "aws_canonical_user_id" "current_user" {
-  provider = aws.foo
+  provider = aws.standard
 }
 
 resource "aws_s3_bucket" "cloudfront_log_bucket" {
-  provider = aws.foo
+  provider = aws.standard
   bucket = "external-domain-broker-cloudfront-logs-${var.stack_description}"
 }
 

--- a/terraform/stacks/cloudfront/stack.tf
+++ b/terraform/stacks/cloudfront/stack.tf
@@ -20,6 +20,7 @@ provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   region     = var.aws_region
+  use_fips_endpoint = true
 
   default_tags {
     tags = {

--- a/terraform/stacks/cloudfront/stack.tf
+++ b/terraform/stacks/cloudfront/stack.tf
@@ -22,6 +22,12 @@ provider "aws" {
   region     = var.aws_region
   use_fips_endpoint = true
 
+  endpoints {
+    # see https://github.com/hashicorp/terraform-provider-aws/issues/23619#issuecomment-1169369626
+    # and https://aws.amazon.com/compliance/fips/#FIPS_Endpoints_by_Service
+    cloudfront = "https://cloudfront-fips.amazonaws.com"
+  }
+
   default_tags {
     tags = {
       deployment = "cloudfront-${var.stack_description}"

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -19,6 +19,7 @@ provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   region     = var.aws_region
+  use_fips_endpoint = true
 
   default_tags {
     tags = {

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -17,9 +17,6 @@ provider "aws" {
 # see https://github.com/hashicorp/terraform-provider-aws/issues/25717#issuecomment-1179797910
 provider "aws" {
   alias = "no-fips"
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-  region     = var.aws_region
 
   default_tags {
     tags = {

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -63,31 +63,16 @@ module "cdn_broker" {
   bucket            = "cdn-broker-le-verify-${var.stack_description}"
   cloudfront_prefix = "cg-${var.stack_description}/*"
   hosted_zone       = var.cdn_broker_hosted_zone
-
-  providers = {
-    aws = aws.fips
-    aws.standard = aws.standard
-  }
 }
 
 module "limit_check_user" {
   source   = "../../modules/iam_user/limit_check_user"
   username = "limit-check-${var.stack_description}"
-
-  providers = {
-    aws = aws.fips
-    aws.standard = aws.standard
-  }
 }
 
 module "health_check_user" {
   source   = "../../modules/iam_user/health_check"
   username = "health-check-${var.stack_description}"
-
-  providers = {
-    aws = aws.fips
-    aws.standard = aws.standard
-  }
 }
 
 module "lets_encrypt_user" {
@@ -95,9 +80,4 @@ module "lets_encrypt_user" {
   aws_partition = data.aws_partition.current.partition
   hosted_zone   = var.lets_encrypt_hosted_zone
   username      = "lets-encrypt-${var.stack_description}"
-
-  providers = {
-    aws = aws.fips
-    aws.standard = aws.standard
-  }
 }

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -42,8 +42,8 @@ module "external_domain_broker" {
   aws_partition     = data.aws_partition.current.partition
 
   providers = {
-    aws = aws.standard
-    # aws.standard = aws.standard
+    aws.foo = aws.standard
+    aws = aws.fips
   }
 }
 

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -42,8 +42,8 @@ module "external_domain_broker" {
   aws_partition     = data.aws_partition.current.partition
 
   providers = {
-    aws = aws.fips
-    aws.standard = aws.standard
+    aws = aws.standard
+    # aws.standard = aws.standard
   }
 }
 

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -22,7 +22,7 @@ provider "aws" {
 
   default_tags {
     tags = {
-      deployment = "cloudfront-${var.stack_description}"
+      deployment = "external-${var.stack_description}"
       stack = "${var.stack_description}"
     }
   }

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -52,11 +52,6 @@ module "external_domain_broker_tests" {
 
   aws_partition     = data.aws_partition.current.partition
   stack_description = var.stack_description
-
-  providers = {
-    aws = aws.fips
-    aws.standard = aws.standard
-  }
 }
 
 module "cdn_broker" {

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -15,7 +15,7 @@ provider "aws" {
 
 # We can't use FIPS for all S3 resources
 # see https://github.com/hashicorp/terraform-provider-aws/issues/25717#issuecomment-1179797910
-provider "aws_no_fips" {
+provider "aws" {
   alias = "no-fips"
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
@@ -44,7 +44,7 @@ module "external_domain_broker" {
 
   providers = {
     aws = aws
-    aws = aws.no-fips
+    aws.no-fips = aws.no-fips
   }
 }
 

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -4,6 +4,8 @@ terraform {
 }
 
 provider "aws" {
+  alias = "fips"
+
   use_fips_endpoint = true
   default_tags {
     tags = {
@@ -16,7 +18,7 @@ provider "aws" {
 # We can't use FIPS for all S3 resources
 # see https://github.com/hashicorp/terraform-provider-aws/issues/25717#issuecomment-1179797910
 provider "aws" {
-  alias = "no-fips"
+  alias = "standard"
 
   default_tags {
     tags = {
@@ -40,8 +42,8 @@ module "external_domain_broker" {
   aws_partition     = data.aws_partition.current.partition
 
   providers = {
-    aws = aws
-    aws.no-fips = aws.no-fips
+    aws = aws.fips
+    aws.standard = aws.standard
   }
 }
 
@@ -50,6 +52,11 @@ module "external_domain_broker_tests" {
 
   aws_partition     = data.aws_partition.current.partition
   stack_description = var.stack_description
+
+  providers = {
+    aws = aws.fips
+    aws.standard = aws.standard
+  }
 }
 
 module "cdn_broker" {
@@ -61,16 +68,31 @@ module "cdn_broker" {
   bucket            = "cdn-broker-le-verify-${var.stack_description}"
   cloudfront_prefix = "cg-${var.stack_description}/*"
   hosted_zone       = var.cdn_broker_hosted_zone
+
+  providers = {
+    aws = aws.fips
+    aws.standard = aws.standard
+  }
 }
 
 module "limit_check_user" {
   source   = "../../modules/iam_user/limit_check_user"
   username = "limit-check-${var.stack_description}"
+
+  providers = {
+    aws = aws.fips
+    aws.standard = aws.standard
+  }
 }
 
 module "health_check_user" {
   source   = "../../modules/iam_user/health_check"
   username = "health-check-${var.stack_description}"
+
+  providers = {
+    aws = aws.fips
+    aws.standard = aws.standard
+  }
 }
 
 module "lets_encrypt_user" {
@@ -78,4 +100,9 @@ module "lets_encrypt_user" {
   aws_partition = data.aws_partition.current.partition
   hosted_zone   = var.lets_encrypt_hosted_zone
   username      = "lets-encrypt-${var.stack_description}"
+
+  providers = {
+    aws = aws.fips
+    aws.standard = aws.standard
+  }
 }

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -4,6 +4,7 @@ terraform {
 }
 
 provider "aws" {
+  use_fips_endpoint = true
   default_tags {
     tags = {
       deployment = "external-${var.stack_description}"

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -42,8 +42,8 @@ module "external_domain_broker" {
   aws_partition     = data.aws_partition.current.partition
 
   providers = {
-    aws.foo = aws.standard
     aws = aws.fips
+    aws.standard = aws.standard
   }
 }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -34,6 +34,7 @@ provider "aws" {
   region = var.aws_default_region
 
   endpoints {
+    # see https://github.com/hashicorp/terraform-provider-aws/issues/23619#issuecomment-1100198434
     route53resolver = "https://route53resolver.${var.aws_default_region}.amazonaws.com"
   }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -32,6 +32,11 @@ provider "aws" {
 provider "aws" {
   use_fips_endpoint = true
   region = var.aws_default_region
+
+  endpoints {
+    route53resolver = "https://route53.${var.aws_partition}.amazonaws.com"
+  }
+
   assume_role {
     role_arn = var.assume_arn
   }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -4,18 +4,10 @@ terraform {
 }
 
 provider "aws" {
+  use_fips_endpoint = true
   # this is for CI
   # run deployments, provide jumpboxes, check on things, etc
   alias = "tooling"
-  endpoints {
-    ecr = "https://ecr-fips.${var.aws_default_region}.amazonaws.com"
-    efs = "https://elasticfilesystem-fips.${var.aws_default_region}.amazonaws.com"
-    es = "https://es-fips.${var.aws_default_region}.amazonaws.com"
-    firehose = "https://firehose-fips.${var.aws_default_region}.amazonaws.com"
-    kms = "https://kms-fips.${var.aws_default_region}.amazonaws.com"
-    lambda = "https://lambda-fips.${var.aws_default_region}.amazonaws.com"
-    wafv2 = "https://wafv2-fips.${var.aws_default_region}.amazonaws.com"
-  }
   default_tags {
     tags = {
       deployment = "bosh-tooling"
@@ -23,21 +15,13 @@ provider "aws" {
   }
 }
 provider "aws" {
+  use_fips_endpoint = true
   # this is for the tooling bosh
   # deploy and monitor vms, scrape metrics, compliance agents, and smtp
   alias = "parentbosh"
   region = var.aws_default_region
   assume_role {
     role_arn = var.parent_assume_arn
-  }
-  endpoints {
-    ecr = "https://ecr-fips.${var.aws_default_region}.amazonaws.com"
-    efs = "https://elasticfilesystem-fips.${var.aws_default_region}.amazonaws.com"
-    es = "https://es-fips.${var.aws_default_region}.amazonaws.com"
-    firehose = "https://firehose-fips.${var.aws_default_region}.amazonaws.com"
-    kms = "https://kms-fips.${var.aws_default_region}.amazonaws.com"
-    lambda = "https://lambda-fips.${var.aws_default_region}.amazonaws.com"
-    wafv2 = "https://wafv2-fips.${var.aws_default_region}.amazonaws.com"
   }
   default_tags {
     tags = {
@@ -46,18 +30,10 @@ provider "aws" {
   }
 }
 provider "aws" {
+  use_fips_endpoint = true
   region = var.aws_default_region
   assume_role {
     role_arn = var.assume_arn
-  }
-  endpoints {
-    ecr = "https://ecr-fips.${var.aws_default_region}.amazonaws.com"
-    efs = "https://elasticfilesystem-fips.${var.aws_default_region}.amazonaws.com"
-    es = "https://es-fips.${var.aws_default_region}.amazonaws.com"
-    firehose = "https://firehose-fips.${var.aws_default_region}.amazonaws.com"
-    kms = "https://kms-fips.${var.aws_default_region}.amazonaws.com"
-    lambda = "https://lambda-fips.${var.aws_default_region}.amazonaws.com"
-    wafv2 = "https://wafv2-fips.${var.aws_default_region}.amazonaws.com"
   }
   default_tags {
     tags = {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -34,7 +34,7 @@ provider "aws" {
   region = var.aws_default_region
 
   endpoints {
-    route53resolver = "https://route53.${var.aws_partition}.amazonaws.com"
+    route53resolver = "https://route53resolver.${var.aws_default_region}.amazonaws.com"
   }
 
   assume_role {

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -5,6 +5,10 @@ variable "aws_default_region" {
   default = "us-gov-west-1"
 }
 
+variable "aws_partition" {
+  default = "us-gov"
+}
+
 variable "vpc_cidr" {
 }
 

--- a/terraform/stacks/managedaccount/iam.tf
+++ b/terraform/stacks/managedaccount/iam.tf
@@ -1,4 +1,5 @@
 provider "aws" {
+  use_fips_endpoint = true
   default_tags {
     tags = {
       deployment = "managed-account-${var.environment_name}"

--- a/terraform/stacks/regionalmasterbosh/stack.tf
+++ b/terraform/stacks/regionalmasterbosh/stack.tf
@@ -5,6 +5,7 @@ terraform {
 
 provider "aws" {
   alias = "tooling"
+  use_fips_endpoint = true
 
   default_tags {
     tags = {
@@ -14,6 +15,7 @@ provider "aws" {
 }
 
 provider "aws" {
+  use_fips_endpoint = true
   region = var.aws_default_region
   assume_role {
     role_arn = var.assume_arn

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -4,6 +4,7 @@ terraform {
 }
 
 provider "aws" {
+  use_fips_endpoint = true
   default_tags {
     tags = {
       deployment = "tooling"
@@ -86,7 +87,7 @@ module "stack" {
   private_cidr_2                         = cidrsubnet(var.vpc_cidr, 8, 2)
   restricted_ingress_web_cidrs           = var.restricted_ingress_web_cidrs
   restricted_ingress_web_ipv6_cidrs      = var.restricted_ingress_web_ipv6_cidrs
-  rds_private_cidr_1                     = cidrsubnet(var.vpc_cidr, 8, 20) 
+  rds_private_cidr_1                     = cidrsubnet(var.vpc_cidr, 8, 20)
   rds_private_cidr_2                     = cidrsubnet(var.vpc_cidr, 8, 21)
   rds_private_cidr_3                = cidrsubnet(var.vpc_cidr, 7, 11) # This will give 22-23
   rds_private_cidr_4                = cidrsubnet(var.vpc_cidr, 7, 12) # This will give 24-25


### PR DESCRIPTION
## Changes proposed in this pull request:

Update all of the `provider` definitions (which there are many of in this repo) to have `use_fips_endpoint = true`, which according to the Terraform documentation should mean that FIPS endpoints are automatically used when making requests to AWS: https://registry.terraform.io/providers/hashicorp/aws/latest/docs#use_fips_endpoint. With this approach, we shouldn't need to manually specify each FIPS endpoint that we want to use but Terraform will transparently take care of using the right endpoints for us

## Security considerations

These changes update our Terraform code to use FIPS endpoints when communicating with AWS in order to comply with FIPS-140 
