### PR TITLE
Rollback IP exceptions and fix WAF

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -490,8 +490,6 @@ jobs:
       TF_VAR_waf_regular_expressions: ((development_waf_regular_expressions))
       TF_VAR_s3_gateway_policy_accounts: ((development_s3_gateway_policy_accounts))
       TF_VAR_sns_name: cloud-gov-notifications
-      TF_VAR_usa_gov_load_ip_1: ((usa_gov_load_ip_1))
-      TF_VAR_usa_gov_load_ip_2: ((usa_gov_load_ip_2))
   - *notify-slack
 
 - name: bootstrap-development
@@ -649,8 +647,6 @@ jobs:
       TF_VAR_waf_regular_expressions: ((staging_waf_regular_expressions))
       TF_VAR_s3_gateway_policy_accounts: ((staging_s3_gateway_policy_accounts))
       TF_VAR_sns_name: cloud-gov-notifications
-      TF_VAR_usa_gov_load_ip_1: ((usa_gov_load_ip_1))
-      TF_VAR_usa_gov_load_ip_2: ((usa_gov_load_ip_2))
   - *notify-slack
 
 - name: bootstrap-staging
@@ -807,8 +803,6 @@ jobs:
       TF_VAR_waf_regular_expressions: ((production_waf_regular_expressions))
       TF_VAR_s3_gateway_policy_accounts: ((production_s3_gateway_policy_accounts))
       TF_VAR_sns_name: cloud-gov-notifications
-      TF_VAR_usa_gov_load_ip_1: ((usa_gov_load_ip_1))
-      TF_VAR_usa_gov_load_ip_2: ((usa_gov_load_ip_2))
   - *notify-slack
 
 - name: bootstrap-production

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -54,20 +54,6 @@ resource "aws_lb_listener" "cf_uaa_http" {
   }
 }
 
-resource "aws_waf_ipset" "usa_gov_ipset" {
-  name = "usaGovIPSet"
-
-  ip_set_descriptors {
-    type  = "IPV4"
-    value = var.usa_gov_load_ip_1
-  }
-
-  ip_set_descriptors {
-    type  = "IPV4"
-    value = var.usa_gov_load_ip_2
-  }
-}
-
 // For webacl rules using AWS managed rule sets or custom rules, checkout the AWS Govcloud WAF V2 console
 // Use the console to craft a sample webacl but before you commit you can click the tab/option to show you
 // The rule in json format which will make it easier to translate to TF
@@ -231,35 +217,8 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   }
 
   rule {
-    name     = "AllowUSAGovLoadTestIPs"
-    priority = 4
-
-    action {
-      allow {}
-    }
-
-    statement {
-      ip_set_reference_statement {
-        arn = aws_waf_ipset.usa_gov_ipset.arn
-        ip_set_forwarded_ip_config {
-          # Match configuration from next rule, the rate limit
-          header_name       = "X-Forwarded-For"
-          fallback_behavior = "MATCH"
-          position          = "ANY"
-        }
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.stack_description}-AllowUSAGovLoadTestIPs"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
     name     = "RateLimitByForwardedHeader"
-    priority = 5
+    priority = 4
 
     action {
       block {}
@@ -289,7 +248,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
   rule {
     name     = "CG-RegexPatternSets"
-    priority = 6
+    priority = 5
     action {
       block {}
     }

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -128,11 +128,3 @@ variable "tcp_allow_cidrs_ipv6" {
 variable "waf_regular_expressions" {
   type = list(string)
 }
-
-variable "usa_gov_load_ip_1" {
-  type = string
-}
-
-variable "usa_gov_load_ip_2" {
-  type = string
-}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -36,6 +36,7 @@ provider "aws" {
   endpoints {
     # see https://github.com/hashicorp/terraform-provider-aws/issues/23619#issuecomment-1100198434
     route53resolver = "https://route53resolver.${var.aws_default_region}.amazonaws.com"
+    waf             = "https://waf-regional-fips.${var.aws_default_region}.amazonaws.com"
   }
 
   assume_role {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -275,9 +275,6 @@ module "cf" {
   tcp_allow_cidrs_ipv4    = var.force_restricted_network == "no" ? ["0.0.0.0/0"] : var.restricted_ingress_web_cidrs
   tcp_allow_cidrs_ipv6    = var.force_restricted_network == "no" ? ["::/0"] : var.restricted_ingress_web_ipv6_cidrs
   waf_regular_expressions = var.waf_regular_expressions
-
-  usa_gov_load_ip_1 = var.usa_gov_load_ip_1
-  usa_gov_load_ip_2 = var.usa_gov_load_ip_2
 }
 
 resource "aws_wafv2_web_acl_association" "main_waf_core" {

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -143,11 +143,3 @@ variable "s3_gateway_policy_accounts" {
 variable "sns_name" {
 
 }
-
-variable "usa_gov_load_ip_1" {
-  type = string
-}
-
-variable "usa_gov_load_ip_2" {
-  type = string
-}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Rollback IP exceptions added in 7003165574e6332e9a4e53f67cd1c1db99877400
- Set WAF FIPS endpoint to correct value, instead of value provided by `use_fips_endpoint`.

## security considerations
None.