### PR TITLE
Mark AWS secret keys as sensitive

### DIFF
--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -55,7 +55,8 @@ output "cf_rds_username" {
 }
 
 output "cf_rds_password" {
-  value = module.cf_database_96.rds_password
+  value     = module.cf_database_96.rds_password
+  sensitive = true
 }
 
 output "cf_rds_engine" {

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -54,6 +54,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "rds_subnet_group" {

--- a/terraform/modules/concourse/outputs.tf
+++ b/terraform/modules/concourse/outputs.tf
@@ -36,7 +36,8 @@ output "concourse_rds_username" {
 }
 
 output "concourse_rds_password" {
-  value = module.rds_96.rds_password
+  value     = module.rds_96.rds_password
+  sensitive = true
 }
 
 output "concourse_lb_target_group" {

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -46,6 +46,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "rds_subnet_group" {

--- a/terraform/modules/credhub/outputs.tf
+++ b/terraform/modules/credhub/outputs.tf
@@ -45,7 +45,8 @@ output "credhub_rds_username" {
 }
 
 output "credhub_rds_password" {
-  value = module.rds_96.rds_password
+  value     = module.rds_96.rds_password
+  sensitive = true
 }
 
 output "credhub_lb_target_group" {

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -54,6 +54,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "rds_subnet_group" {

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -23,7 +23,8 @@ output "rds_username" {
 }
 
 output "rds_password" {
-  value = aws_db_instance.rds_database.password
+  value     = aws_db_instance.rds_database.password
+  sensitive = true
 }
 
 output "rds_engine" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -32,6 +32,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "rds_subnet_group" {

--- a/terraform/modules/stack/base/outputs.tf
+++ b/terraform/modules/stack/base/outputs.tf
@@ -32,11 +32,11 @@ output "private_cidr_az2" {
   value = module.vpc.private_cidr_az2
 }
 
-output "vpc_endpoint_customer_s3_if1_ip"{
+output "vpc_endpoint_customer_s3_if1_ip" {
   value = module.vpc.vpc_endpoint_customer_s3_if1_ip
 }
 
-output "vpc_endpoint_customer_s3_if2_ip"{
+output "vpc_endpoint_customer_s3_if2_ip" {
   value = module.vpc.vpc_endpoint_customer_s3_if2_ip
 }
 
@@ -169,7 +169,8 @@ output "bosh_rds_username" {
 }
 
 output "bosh_rds_password" {
-  value = module.rds.rds_password
+  value     = module.rds.rds_password
+  sensitive = true
 }
 
 /*
@@ -201,7 +202,8 @@ output "credhub_rds_username" {
 }
 
 output "credhub_rds_password" {
-  value = module.credhub_rds.rds_password
+  value     = module.credhub_rds.rds_password
+  sensitive = true
 }
 
 output "default_key_name" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -84,6 +84,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "restricted_ingress_web_cidrs" {
@@ -156,6 +157,7 @@ variable "credhub_rds_username" {
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_db_engine_version" {
@@ -178,7 +180,7 @@ variable "bosh_default_ssh_public_key" {
 
 }
 
-variable "s3_gateway_policy_accounts"{
+variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }

--- a/terraform/modules/stack/spoke/outputs.tf
+++ b/terraform/modules/stack/spoke/outputs.tf
@@ -32,11 +32,11 @@ output "private_cidr_az2" {
   value = module.base.private_cidr_az2
 }
 
-output "vpc_endpoint_customer_s3_if1_ip"{
+output "vpc_endpoint_customer_s3_if1_ip" {
   value = module.base.vpc_endpoint_customer_s3_if1_ip
 }
 
-output "vpc_endpoint_customer_s3_if2_ip"{
+output "vpc_endpoint_customer_s3_if2_ip" {
   value = module.base.vpc_endpoint_customer_s3_if2_ip
 }
 
@@ -169,7 +169,8 @@ output "bosh_rds_username" {
 }
 
 output "bosh_rds_password" {
-  value = module.base.bosh_rds_password
+  value     = module.base.bosh_rds_password
+  sensitive = true
 }
 
 /*
@@ -193,7 +194,8 @@ output "credhub_rds_username" {
 }
 
 output "credhub_rds_password" {
-  value = module.base.credhub_rds_password
+  value     = module.base.credhub_rds_password
+  sensitive = true
 }
 
 output "default_key_name" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -97,9 +97,11 @@ variable "aws_partition" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "target_vpc_id" {
@@ -161,7 +163,7 @@ variable "bosh_default_ssh_public_key" {
 
 }
 
-variable "s3_gateway_policy_accounts"{
+variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }

--- a/terraform/stacks/cloudfront/stack.tf
+++ b/terraform/stacks/cloudfront/stack.tf
@@ -6,6 +6,7 @@ variable "aws_access_key" {
 }
 
 variable "aws_secret_key" {
+  sensitive = true
 }
 
 variable "aws_region" {
@@ -17,9 +18,9 @@ terraform {
 }
 
 provider "aws" {
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-  region     = var.aws_region
+  access_key        = var.aws_access_key
+  secret_key        = var.aws_secret_key
+  region            = var.aws_region
   use_fips_endpoint = true
 
   endpoints {
@@ -31,7 +32,7 @@ provider "aws" {
   default_tags {
     tags = {
       deployment = "cloudfront-${var.stack_description}"
-      stack = "${var.stack_description}"
+      stack      = "${var.stack_description}"
     }
   }
 }

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -5,6 +5,7 @@ variable "aws_access_key" {
 }
 
 variable "aws_secret_key" {
+  sensitive = true
 }
 
 variable "aws_region" {
@@ -16,9 +17,9 @@ terraform {
 }
 
 provider "aws" {
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-  region     = var.aws_region
+  access_key        = var.aws_access_key
+  secret_key        = var.aws_secret_key
+  region            = var.aws_region
   use_fips_endpoint = true
 
   default_tags {

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -6,15 +6,16 @@ variable "domains_broker_rds_username" {
 }
 
 variable "domains_broker_rds_password" {
+  sensitive = true
 }
 
 /* Broker internal load balancer */
 resource "aws_lb" "domains_broker_internal" {
-  name    = "${var.stack_description}-domains-internal"
-  subnets = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
-  security_groups = [module.stack.bosh_security_group]
-  internal        = true
-  enable_deletion_protection  = true
+  name                       = "${var.stack_description}-domains-internal"
+  subnets                    = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
+  security_groups            = [module.stack.bosh_security_group]
+  internal                   = true
+  enable_deletion_protection = true
   access_logs {
     bucket  = module.log_bucket.elb_bucket_name
     prefix  = var.stack_description
@@ -88,12 +89,12 @@ output "domains_broker_rds_port" {
 resource "aws_lb" "domains_broker" {
   count = var.domains_broker_alb_count
 
-  name    = "${var.stack_description}-domains-${count.index}"
-  subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
-  security_groups = [module.stack.web_traffic_security_group]
-  ip_address_type = "dualstack"
-  idle_timeout    = 3600
-  enable_deletion_protection  = true
+  name                       = "${var.stack_description}-domains-${count.index}"
+  subnets                    = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
+  security_groups            = [module.stack.web_traffic_security_group]
+  ip_address_type            = "dualstack"
+  idle_timeout               = 3600
+  enable_deletion_protection = true
   access_logs {
     bucket  = module.log_bucket.elb_bucket_name
     prefix  = var.stack_description
@@ -359,7 +360,7 @@ output "legacy_domain_certificate_renewer_access_key_id_curr" {
 }
 
 output "legacy_domain_certificate_renewer_secret_access_key_curr" {
-  value = aws_iam_access_key.legacy_domain_certificate_renewer_key_v1.secret
+  value     = aws_iam_access_key.legacy_domain_certificate_renewer_key_v1.secret
   sensitive = true
 }
 

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -17,15 +17,20 @@ variable "rds_db_size" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
+
 variable "rds_instance_type" {
-  default = "db.m4.large"
+  default   = "db.m4.large"
+  sensitive = true
 }
 
 variable "cf_rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "remote_state_bucket" {

--- a/terraform/stacks/regionalmasterbosh/opsuaa.tf
+++ b/terraform/stacks/regionalmasterbosh/opsuaa.tf
@@ -1,4 +1,5 @@
 variable "opsuaa_rds_password" {
+  sensitive = true
 }
 
 module "opsuaa_db" {
@@ -34,7 +35,8 @@ output "opsuaa_rds_username" {
 }
 
 output "opsuaa_rds_password" {
-  value = module.opsuaa_db.rds_password
+  value     = module.opsuaa_db.rds_password
+  sensitive = true
 }
 
 output "opsuaa_rds_engine" {

--- a/terraform/stacks/regionalmasterbosh/variables.tf
+++ b/terraform/stacks/regionalmasterbosh/variables.tf
@@ -10,9 +10,11 @@ variable "vpc_cidr" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "rds_multi_az" {

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -1,4 +1,5 @@
 variable "opsuaa_rds_password" {
+  sensitive = true
 }
 
 module "opsuaa_db" {
@@ -34,7 +35,7 @@ output "opsuaa_rds_username" {
 }
 
 output "opsuaa_rds_password" {
-  value = module.opsuaa_db.rds_password
+  value     = module.opsuaa_db.rds_password
   sensitive = true
 }
 

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -10,9 +10,11 @@ variable "vpc_cidr" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "rds_multi_az" {
@@ -39,18 +41,22 @@ variable "remote_state_bucket" {
 }
 
 variable "concourse_prod_rds_password" {
+  sensitive = true
 }
 
 variable "concourse_staging_rds_password" {
+  sensitive = true
 }
 
 variable "concourse_varz_bucket" {
 }
 
 variable "credhub_prod_rds_password" {
+  sensitive = true
 }
 
 variable "credhub_staging_rds_password" {
+  sensitive = true
 }
 
 variable "wildcard_production_certificate_name_prefix" {
@@ -181,7 +187,7 @@ variable "bosh_default_ssh_public_key" {
 
 }
 
-variable "s3_gateway_policy_accounts"{
+variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

This change adds `sensitive` fields to all password and secret_key variables and outputs. 

Marking [variables](https://developer.hashicorp.com/terraform/language/values/variables#suppressing-values-in-cli-output) and [outputs](https://developer.hashicorp.com/terraform/language/values/outputs#sensitive-suppressing-values-in-cli-output) `sensitive` helps prevent Terraform from printing them to logs. (It is not fool-proof measure: Providers can still print unredacted values to logs.) 

## security considerations

This is a security improvement that makes printing sensitive information less likely.
