### PR TITLE
Fail CI if PR includes unformatted HCL

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -50,7 +50,40 @@ jobs:
     params:
       path: pull-request
       status: pending
+      context: format-terraform
+  - put: pull-request
+    params:
+      path: pull-request
+      status: pending
       context: validate-terraform
+  - task: format-terraform
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          aws_access_key_id: ((ecr_aws_key))
+          aws_secret_access_key: ((ecr_aws_secret))
+          repository: harden-concourse-task
+          aws_region: us-gov-west-1
+          tag: ((harden-concourse-task-tag))
+      inputs:
+      - name: pull-request
+      params:
+      run:
+        path: pull-request/ci/scripts/terraform_fmt.sh
+    on_success:
+      put: pull-request
+      params:
+        path: pull-request
+        status: success
+        context: format-terraform
+    on_failure:
+      put: pull-request
+      params:
+        path: pull-request
+        status: failure
+        context: format-terraform
   - task: validate-terraform
     config:
       platform: linux

--- a/ci/scripts/terraform_fmt.sh
+++ b/ci/scripts/terraform_fmt.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+terraform fmt -recursive
+git diff-index --quiet HEAD -- # exit 1 if dirty, 0 otherwise

--- a/terraform/modules/admin/admin_elb_main.tf
+++ b/terraform/modules/admin/admin_elb_main.tf
@@ -5,7 +5,7 @@ resource "aws_lb" "admin" {
   ip_address_type = "dualstack"
   idle_timeout    = 3600
 
-  enable_deletion_protection  = true
+  enable_deletion_protection = true
 
   access_logs {
     bucket  = var.log_bucket_name

--- a/terraform/modules/admin/versions.tf
+++ b/terraform/modules/admin/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/bosh_vpc/endpoint_s3.tf
+++ b/terraform/modules/bosh_vpc/endpoint_s3.tf
@@ -1,9 +1,9 @@
 resource "aws_vpc_endpoint" "private-s3" {
-  vpc_id          = aws_vpc.main_vpc.id
-  service_name    = "com.amazonaws.${var.aws_default_region}.s3"
+  vpc_id            = aws_vpc.main_vpc.id
+  service_name      = "com.amazonaws.${var.aws_default_region}.s3"
   vpc_endpoint_type = "Gateway"
-  route_table_ids = [aws_route_table.az1_private_route_table.id, aws_route_table.az2_private_route_table.id]
-  policy          = <<EOF
+  route_table_ids   = [aws_route_table.az1_private_route_table.id, aws_route_table.az2_private_route_table.id]
+  policy            = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -37,24 +37,24 @@ EOF
 }
 
 resource "aws_vpc_endpoint" "customer_s3" {
-  vpc_id              = aws_vpc.main_vpc.id
-  service_name        = "com.amazonaws.${var.aws_default_region}.s3"
-  vpc_endpoint_type   = "Interface"
-  security_group_ids  = [aws_security_group.bosh.id]
-  subnet_ids          = [aws_subnet.az1_public.id, aws_subnet.az2_public.id]
+  vpc_id             = aws_vpc.main_vpc.id
+  service_name       = "com.amazonaws.${var.aws_default_region}.s3"
+  vpc_endpoint_type  = "Interface"
+  security_group_ids = [aws_security_group.bosh.id]
+  subnet_ids         = [aws_subnet.az1_public.id, aws_subnet.az2_public.id]
 }
 
-data "aws_network_interface" "vpce_customer_s3_if1"{
+data "aws_network_interface" "vpce_customer_s3_if1" {
   id = local.network_interface_ids[0]
 }
 
-data "aws_network_interface" "vpce_customer_s3_if2"{
-  id = local.network_interface_ids[1] 
+data "aws_network_interface" "vpce_customer_s3_if2" {
+  id = local.network_interface_ids[1]
 }
 
 data "aws_caller_identity" "current" {}
 
 locals {
   network_interface_ids = tolist(aws_vpc_endpoint.customer_s3.network_interface_ids)
-  policy_account_list = concat(var.s3_gateway_policy_accounts, [data.aws_caller_identity.current.account_id])
+  policy_account_list   = concat(var.s3_gateway_policy_accounts, [data.aws_caller_identity.current.account_id])
 }

--- a/terraform/modules/bosh_vpc/outputs.tf
+++ b/terraform/modules/bosh_vpc/outputs.tf
@@ -92,6 +92,6 @@ output "vpc_endpoint_customer_s3_if2_ip" {
 }
 
 /* DNS for the S3 Private Endpoint */
-output "vpc_endpoint_customer_s3_dns"{
+output "vpc_endpoint_customer_s3_dns" {
   value = aws_vpc_endpoint.customer_s3.dns_entry
 }

--- a/terraform/modules/bosh_vpc/sg_bosh.tf
+++ b/terraform/modules/bosh_vpc/sg_bosh.tf
@@ -146,12 +146,12 @@ resource "aws_security_group_rule" "bosh_credhub" {
 }
 
 resource "aws_security_group_rule" "node_exporter" {
-  type                     = "ingress"
-  from_port                = 9100
-  to_port                  = 9100
-  protocol                 = "tcp"
-  cidr_blocks              = var.monitoring_security_group_cidrs
-  security_group_id        = aws_security_group.bosh.id
+  type              = "ingress"
+  from_port         = 9100
+  to_port           = 9100
+  protocol          = "tcp"
+  cidr_blocks       = var.monitoring_security_group_cidrs
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "platform_kibana" {
@@ -164,39 +164,39 @@ resource "aws_security_group_rule" "platform_kibana" {
 }
 
 resource "aws_security_group_rule" "monitoring_elasticsearch_exporter" {
-  type                     = "ingress"
-  from_port                = 9114
-  to_port                  = 9114
-  protocol                 = "tcp"
-  cidr_blocks              = var.monitoring_security_group_cidrs
-  security_group_id        = aws_security_group.bosh.id
+  type              = "ingress"
+  from_port         = 9114
+  to_port           = 9114
+  protocol          = "tcp"
+  cidr_blocks       = var.monitoring_security_group_cidrs
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "concourse_logsearch" {
-  type                     = "ingress"
-  from_port                = 9200
-  to_port                  = 9200
-  protocol                 = "tcp"
-  cidr_blocks              = var.concourse_security_group_cidrs
-  security_group_id        = aws_security_group.bosh.id
+  type              = "ingress"
+  from_port         = 9200
+  to_port           = 9200
+  protocol          = "tcp"
+  cidr_blocks       = var.concourse_security_group_cidrs
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "concourse_secureproxy" {
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  cidr_blocks              = var.concourse_security_group_cidrs
-  security_group_id        = aws_security_group.bosh.id
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = var.concourse_security_group_cidrs
+  security_group_id = aws_security_group.bosh.id
 }
 
 resource "aws_security_group_rule" "concourse_secureproxy_https" {
-  type                     = "ingress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  cidr_blocks              = var.concourse_security_group_cidrs
-  security_group_id        = aws_security_group.bosh.id
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = var.concourse_security_group_cidrs
+  security_group_id = aws_security_group.bosh.id
 }
 
 

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -61,7 +61,7 @@ variable "bosh_default_ssh_public_key" {
 
 }
 
-variable "s3_gateway_policy_accounts"{
+variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }

--- a/terraform/modules/bosh_vpc/versions.tf
+++ b/terraform/modules/bosh_vpc/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/cdn_broker/versions.tf
+++ b/terraform/modules/cdn_broker/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/cloud_watch/alarms.tf
+++ b/terraform/modules/cloud_watch/alarms.tf
@@ -1,36 +1,36 @@
 resource "aws_cloudwatch_metric_alarm" "lb_4XX_anomaly_detection" {
-    alarm_name = "${var.stack_description} CF Load Balancer High 4XX Response Rate"
-    comparison_operator = "GreaterThanUpperThreshold"
-    evaluation_periods = 5
-    datapoints_to_alarm = 3
-    threshold_metric_id = "ad1"
-    alarm_description = "Alerts when the targets are returning a higher than normal rate of 4XX responses"
-    insufficient_data_actions = []
-    actions_enabled = true
-    ok_actions = []
-    alarm_actions = [var.sns_arn]
-    treat_missing_data = "missing"
+  alarm_name                = "${var.stack_description} CF Load Balancer High 4XX Response Rate"
+  comparison_operator       = "GreaterThanUpperThreshold"
+  evaluation_periods        = 5
+  datapoints_to_alarm       = 3
+  threshold_metric_id       = "ad1"
+  alarm_description         = "Alerts when the targets are returning a higher than normal rate of 4XX responses"
+  insufficient_data_actions = []
+  actions_enabled           = true
+  ok_actions                = []
+  alarm_actions             = [var.sns_arn]
+  treat_missing_data        = "missing"
 
-    metric_query {
-        id = "ad1"
-        expression = "ANOMALY_DETECTION_BAND(m1, 20)"
-        label = "HTTPCode_Target_4XX_Count (expected)"
-        return_data = "true"
+  metric_query {
+    id          = "ad1"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 20)"
+    label       = "HTTPCode_Target_4XX_Count (expected)"
+    return_data = "true"
+  }
+
+  metric_query {
+    id          = "m1"
+    return_data = "true"
+    metric {
+      metric_name = "HTTPCode_Target_4XX_Count"
+      namespace   = "AWS/ApplicationELB"
+      period      = "60"
+      stat        = "Sum"
+
+      dimensions = {
+        LoadBalancer = var.load_balancer_dns
+      }
     }
-
-    metric_query {
-        id = "m1"
-        return_data = "true"
-        metric {
-            metric_name = "HTTPCode_Target_4XX_Count"
-            namespace = "AWS/ApplicationELB"
-            period = "60"
-            stat = "Sum"
-
-            dimensions = {
-              LoadBalancer = var.load_balancer_dns
-            }
-        }
-    }
+  }
 
 }

--- a/terraform/modules/cloud_watch/variables.tf
+++ b/terraform/modules/cloud_watch/variables.tf
@@ -7,5 +7,5 @@ variable "sns_arn" {
 }
 
 variable "load_balancer_dns" {
-    
+
 }

--- a/terraform/modules/cloud_watch/versions.tf
+++ b/terraform/modules/cloud_watch/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -1,18 +1,18 @@
 module "cf_database_96" {
   source = "../rds"
 
-  stack_description                 = var.stack_description
-  rds_instance_type                 = var.rds_instance_type
-  rds_db_size                       = var.rds_db_size
-  rds_db_engine                     = var.rds_db_engine
-  rds_db_engine_version             = var.rds_db_engine_version
-  rds_db_name                       = var.rds_db_name
-  rds_username                      = var.rds_username
-  rds_password                      = var.rds_password
-  rds_subnet_group                  = var.rds_subnet_group
-  rds_security_groups               = var.rds_security_groups
-  rds_parameter_group_family        = var.rds_parameter_group_family
-  rds_allow_major_version_upgrade   = var.rds_allow_major_version_upgrade
-  rds_apply_immediately             = var.rds_apply_immediately
+  stack_description               = var.stack_description
+  rds_instance_type               = var.rds_instance_type
+  rds_db_size                     = var.rds_db_size
+  rds_db_engine                   = var.rds_db_engine
+  rds_db_engine_version           = var.rds_db_engine_version
+  rds_db_name                     = var.rds_db_name
+  rds_username                    = var.rds_username
+  rds_password                    = var.rds_password
+  rds_subnet_group                = var.rds_subnet_group
+  rds_security_groups             = var.rds_security_groups
+  rds_parameter_group_family      = var.rds_parameter_group_family
+  rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  rds_apply_immediately           = var.rds_apply_immediately
 }
 

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -5,7 +5,7 @@ resource "aws_lb" "cf_apps" {
   ip_address_type = "dualstack"
   idle_timeout    = 3600
 
-  enable_deletion_protection  = true
+  enable_deletion_protection = true
 
   access_logs {
     bucket  = var.log_bucket_name

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -5,7 +5,7 @@ resource "aws_lb" "cf" {
   ip_address_type = "dualstack"
   idle_timeout    = 3600
 
-  enable_deletion_protection  = true
+  enable_deletion_protection = true
 
   access_logs {
     bucket  = var.log_bucket_name

--- a/terraform/modules/cloudfoundry/nlb.tf
+++ b/terraform/modules/cloudfoundry/nlb.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "nlb_traffic" {
-  count = var.tcp_lb_count > 0 ? 1 : 0
+  count       = var.tcp_lb_count > 0 ? 1 : 0
   description = "Allow traffic in to NLB"
   vpc_id      = var.vpc_id
 
@@ -17,12 +17,12 @@ resource "aws_security_group" "nlb_traffic" {
 }
 
 resource "aws_lb" "cf_apps_tcp" {
-  count              = var.tcp_lb_count
-  name               = "${var.stack_description}-cf-tcp-${count.index}"
-  load_balancer_type = "network"
-  subnets            = var.elb_subnets
-  ip_address_type    = "dualstack"
-  enable_deletion_protection  = true
+  count                      = var.tcp_lb_count
+  name                       = "${var.stack_description}-cf-tcp-${count.index}"
+  load_balancer_type         = "network"
+  subnets                    = var.elb_subnets
+  ip_address_type            = "dualstack"
+  enable_deletion_protection = true
 }
 
 resource "aws_lb_target_group" "cf_apps_target_tcp" {
@@ -36,7 +36,7 @@ resource "aws_lb_target_group" "cf_apps_target_tcp" {
 
 resource "aws_lb_listener" "cf_apps_tcp" {
   count             = var.tcp_lb_count * var.listeners_per_tcp_lb
-  load_balancer_arn = aws_lb.cf_apps_tcp[floor(count.index/var.listeners_per_tcp_lb)].arn
+  load_balancer_arn = aws_lb.cf_apps_tcp[floor(count.index / var.listeners_per_tcp_lb)].arn
   protocol          = "TCP"
   port              = var.tcp_first_port + count.index
 

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -55,7 +55,8 @@ output "cf_rds_username" {
 }
 
 output "cf_rds_password" {
-  value = module.cf_database_96.rds_password
+  value     = module.cf_database_96.rds_password
+  sensitive = true
 }
 
 output "cf_rds_engine" {

--- a/terraform/modules/cloudfoundry/service_subnets.tf
+++ b/terraform/modules/cloudfoundry/service_subnets.tf
@@ -17,7 +17,7 @@ resource "aws_subnet" "az1_services" {
   availability_zone = var.az1
 
   tags = {
-    Name              = "${var.stack_description} (Services AZ1)"
+    Name = "${var.stack_description} (Services AZ1)"
   }
 }
 
@@ -27,7 +27,7 @@ resource "aws_subnet" "az2_services" {
   availability_zone = var.az2
 
   tags = {
-    Name              = "${var.stack_description} (Services AZ2)"
+    Name = "${var.stack_description} (Services AZ2)"
   }
 }
 

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -54,6 +54,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "rds_subnet_group" {

--- a/terraform/modules/cloudfoundry/versions.tf
+++ b/terraform/modules/cloudfoundry/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/cloudfront/versions.tf
+++ b/terraform/modules/cloudfront/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/concourse/outputs.tf
+++ b/terraform/modules/concourse/outputs.tf
@@ -36,7 +36,8 @@ output "concourse_rds_username" {
 }
 
 output "concourse_rds_password" {
-  value = module.rds_96.rds_password
+  value     = module.rds_96.rds_password
+  sensitive = true
 }
 
 output "concourse_lb_target_group" {

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -46,6 +46,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "rds_subnet_group" {

--- a/terraform/modules/concourse/versions.tf
+++ b/terraform/modules/concourse/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/credhub/outputs.tf
+++ b/terraform/modules/credhub/outputs.tf
@@ -45,7 +45,8 @@ output "credhub_rds_username" {
 }
 
 output "credhub_rds_password" {
-  value = module.rds_96.rds_password
+  value     = module.rds_96.rds_password
+  sensitive = true
 }
 
 output "credhub_lb_target_group" {

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -54,6 +54,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "rds_subnet_group" {

--- a/terraform/modules/credhub/versions.tf
+++ b/terraform/modules/credhub/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/cvd_mirror/public_encrypted_bucket.tf
+++ b/terraform/modules/cvd_mirror/public_encrypted_bucket.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "public_encrypted_
   bucket = aws_s3_bucket.cvd_bucket.id
   rule {
     apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/terraform/modules/cvd_mirror/versions.tf
+++ b/terraform/modules/cvd_mirror/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/diego/diego_elb_main.tf
+++ b/terraform/modules/diego/diego_elb_main.tf
@@ -39,7 +39,7 @@ resource "aws_elb" "diego_elb_main" {
     instance_port     = 2222
     instance_protocol = "TCP"
   }
-  
+
   health_check {
     healthy_threshold   = 10
     interval            = 30

--- a/terraform/modules/diego/versions.tf
+++ b/terraform/modules/diego/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/dns/versions.tf
+++ b/terraform/modules/dns/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/dns_logging/variables.tf
+++ b/terraform/modules/dns_logging/variables.tf
@@ -1,11 +1,11 @@
 variable "stack_description" {
-    type = string
+  type = string
 }
 
 variable "aws_partition" {
-    type = string
+  type = string
 }
 
 variable "vpc_id" {
-    type = string
+  type = string
 }

--- a/terraform/modules/elasticache_broker_network/elb.tf
+++ b/terraform/modules/elasticache_broker_network/elb.tf
@@ -3,7 +3,7 @@ resource "aws_elb" "elasticache_elb" {
   subnets         = var.elb_subnets
   security_groups = var.elb_security_groups
   internal        = true
-  
+
   listener {
     lb_port           = 80
     lb_protocol       = "HTTP"

--- a/terraform/modules/elasticache_broker_network/versions.tf
+++ b/terraform/modules/elasticache_broker_network/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/elasticsearch_broker/versions.tf
+++ b/terraform/modules/elasticsearch_broker/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/environment_dns/versions.tf
+++ b/terraform/modules/environment_dns/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/external_domain_broker/versions.tf
+++ b/terraform/modules/external_domain_broker/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/external_domain_broker_govcloud/resources.tf
+++ b/terraform/modules/external_domain_broker_govcloud/resources.tf
@@ -6,8 +6,8 @@ data "template_file" "policy" {
   template = file("${path.module}/policy.json")
 
   vars = {
-    account_id      = var.account_id
-    stack           = var.stack_description
+    account_id = var.account_id
+    stack      = var.stack_description
   }
 }
 

--- a/terraform/modules/external_domain_broker_govcloud/versions.tf
+++ b/terraform/modules/external_domain_broker_govcloud/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/external_domain_broker_tests/versions.tf
+++ b/terraform/modules/external_domain_broker_tests/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role/versions.tf
+++ b/terraform/modules/iam_role/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/aws_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/blobstore/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/bosh/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/cloudwatch/versions.tf
+++ b/terraform/modules/iam_role_policy/cloudwatch/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/compliance_role/versions.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/concourse_worker/variables.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/variables.tf
@@ -38,16 +38,16 @@ variable "concourse_varz_bucket" {
 }
 
 variable "pgp_keys_bucket_name" {
-    type = string
-    description = "Name of S3 bucket for PGP keys"
+  type        = string
+  description = "Name of S3 bucket for PGP keys"
 }
 
 variable "container_scanning_bucket_name" {
-    type = string
-    description = "Name of S3 bucket for container scanning config"
+  type        = string
+  description = "Name of S3 bucket for container scanning config"
 }
 
 variable "tooling_credhub_backups_bucket_name" {
-    type = string
-    description = "Name of S3 bucket for Credhub Tooling backups"
+  type        = string
+  description = "Name of S3 bucket for Credhub Tooling backups"
 }

--- a/terraform/modules/iam_role_policy/concourse_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/ecr/versions.tf
+++ b/terraform/modules/iam_role_policy/ecr/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
+++ b/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/s3_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/billing_user/versions.tf
+++ b/terraform/modules/iam_user/billing_user/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/cvd_sync/versions.tf
+++ b/terraform/modules/iam_user/cvd_sync/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/ecr_user/versions.tf
+++ b/terraform/modules/iam_user/ecr_user/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/federalist_auditor/versions.tf
+++ b/terraform/modules/iam_user/federalist_auditor/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/health_check/versions.tf
+++ b/terraform/modules/iam_user/health_check/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/iam_cert_provision/versions.tf
+++ b/terraform/modules/iam_user/iam_cert_provision/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/lets_encrypt/versions.tf
+++ b/terraform/modules/iam_user/lets_encrypt/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/limit_check_user/versions.tf
+++ b/terraform/modules/iam_user/limit_check_user/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/rds_storage_alert/versions.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/iam_user/s3_logstash/versions.tf
+++ b/terraform/modules/iam_user/s3_logstash/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/log_bucket/log_bucket.tf
+++ b/terraform/modules/log_bucket/log_bucket.tf
@@ -32,15 +32,15 @@ resource "aws_s3_bucket" "log_bucket" {
 }
 
 resource "aws_s3_bucket_acl" "log_bucket_acl" {
-  bucket        = aws_s3_bucket.log_bucket.id
-  acl           = var.log_bucket_acl
+  bucket = aws_s3_bucket.log_bucket.id
+  acl    = var.log_bucket_acl
 }
 resource "aws_s3_bucket_lifecycle_configuration" "log_bucket_lifecycle" {
   bucket = aws_s3_bucket.log_bucket.id
   rule {
     id = "all"
     filter {
-      prefix  = ""
+      prefix = ""
     }
     status = "Enabled"
     transition {

--- a/terraform/modules/logsearch/versions.tf
+++ b/terraform/modules/logsearch/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/monitoring/versions.tf
+++ b/terraform/modules/monitoring/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -17,7 +17,7 @@ resource "aws_db_instance" "rds_database" {
 
   auto_minor_version_upgrade = true
 
-  db_name              = var.rds_db_name
+  db_name           = var.rds_db_name
   allocated_storage = var.rds_db_size
   storage_type      = var.rds_db_storage_type
   iops              = var.rds_db_iops

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -23,7 +23,8 @@ output "rds_username" {
 }
 
 output "rds_password" {
-  value = aws_db_instance.rds_database.password
+  value     = aws_db_instance.rds_database.password
+  sensitive = true
 }
 
 output "rds_engine" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -32,6 +32,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "rds_subnet_group" {

--- a/terraform/modules/rds/versions.tf
+++ b/terraform/modules/rds/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/rds_network/sg_postgres.tf
+++ b/terraform/modules/rds_network/sg_postgres.tf
@@ -43,20 +43,20 @@ resource "aws_security_group_rule" "egress_default" {
 
 # allows pg rds to get to s3 for import and export
 resource "aws_security_group_rule" "egress_s3" {
-  type                     = "egress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  prefix_list_ids          = [data.aws_prefix_list.s3.id]
-  security_group_id        = aws_security_group.rds_postgres.id
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  prefix_list_ids   = [data.aws_prefix_list.s3.id]
+  security_group_id = aws_security_group.rds_postgres.id
 }
 
 resource "aws_security_group_rule" "ingress_tooling" {
 
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  cidr_blocks              = var.allowed_cidrs
-  security_group_id        = aws_security_group.rds_postgres.id
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = var.allowed_cidrs
+  security_group_id = aws_security_group.rds_postgres.id
 }

--- a/terraform/modules/rds_network/versions.tf
+++ b/terraform/modules/rds_network/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/regionalmaster_dns/versions.tf
+++ b/terraform/modules/regionalmaster_dns/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "encrypted_bucket_
 }
 
 resource "aws_s3_bucket_versioning" "encrypted_bucket_versioning" {
-  count = var.versioning ? 1 : 0
+  count  = var.versioning ? 1 : 0
   bucket = aws_s3_bucket.encrypted_bucket.id
   versioning_configuration {
     status = "Enabled"
@@ -30,7 +30,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
   rule {
     id = "rule0"
     filter {
-      prefix  = ""
+      prefix = ""
     }
     #if expiration_days is 0 then the rule is disabled
     status = var.expiration_days == 0 ? "Disabled" : "Enabled"

--- a/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
@@ -36,7 +36,7 @@ resource "aws_s3_bucket_acl" "kms_encrypted_bucket_acl" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "kms_encrypted_bucket_lifecycle" {
   bucket = aws_s3_bucket.kms_encrypted_bucket.id
-  count = length(var.lifecycle_rules) > 0 ? 1 : 0
+  count  = length(var.lifecycle_rules) > 0 ? 1 : 0
 
   dynamic "rule" {
     for_each = var.lifecycle_rules

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/iam.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/iam.tf
@@ -1,8 +1,8 @@
 data "aws_iam_policy_document" "kms_encrypted_bucket_policy" {
   source_policy_documents = var.source_bucket_policy_documents
-  
+
   statement {
-    sid = "DenyIncorrectEncryptionHeader"
+    sid    = "DenyIncorrectEncryptionHeader"
     effect = "Deny"
 
     principals {
@@ -19,14 +19,14 @@ data "aws_iam_policy_document" "kms_encrypted_bucket_policy" {
     ]
 
     condition {
-      test = "StringNotEquals"
+      test     = "StringNotEquals"
       variable = "s3:x-amz-server-side-encryption"
-      values = ["aws:kms"]
+      values   = ["aws:kms"]
     }
   }
 
   statement {
-    sid = "DenyUnEncryptedObjectUploads"
+    sid    = "DenyUnEncryptedObjectUploads"
     effect = "Deny"
 
     principals {
@@ -43,9 +43,9 @@ data "aws_iam_policy_document" "kms_encrypted_bucket_policy" {
     ]
 
     condition {
-      test = "Null"
+      test     = "Null"
       variable = "s3:x-amz-server-side-encryption"
-      values = [true]
+      values   = [true]
     }
   }
 
@@ -54,11 +54,11 @@ data "aws_iam_policy_document" "kms_encrypted_bucket_policy" {
     iterator = account
 
     content {
-      sid = "AllowExternalAccountAccess_${account.value}"
+      sid    = "AllowExternalAccountAccess_${account.value}"
       effect = "Allow"
 
       principals {
-        type = "AWS"
+        type        = "AWS"
         identifiers = ["arn:${var.aws_partition}:iam::${account.value}:root"]
       }
 

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
@@ -2,7 +2,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   source_policy_documents = var.source_kms_key_policy_documents
 
   statement {
-    sid = "Enable IAM User Permissions"
+    sid    = "Enable IAM User Permissions"
     effect = "Allow"
 
     principals {
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   }
 
   statement {
-    sid = "Allow access for Key Administrators"
+    sid    = "Allow access for Key Administrators"
     effect = "Allow"
 
     principals {
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
   }
 
   statement {
-    sid = "AllowKeyUse"
+    sid    = "AllowKeyUse"
     effect = "Allow"
 
     principals {
@@ -72,15 +72,15 @@ data "aws_iam_policy_document" "kms_key_policy" {
     ]
 
     condition {
-      test = "StringEquals"
+      test     = "StringEquals"
       variable = "kms:ViaService"
-      values = ["s3.${var.region}.amazonaws.com"]
+      values   = ["s3.${var.region}.amazonaws.com"]
     }
 
     condition {
-      test = "StringEquals"
+      test     = "StringEquals"
       variable = "kms:CallerAccount"
-      values = [var.kms_account_id]
+      values   = [var.kms_account_id]
     }
   }
 
@@ -89,11 +89,11 @@ data "aws_iam_policy_document" "kms_key_policy" {
     iterator = account
 
     content {
-      sid = "AllowExternalKMSKeyAccess_${account.value}"
+      sid    = "AllowExternalKMSKeyAccess_${account.value}"
       effect = "Allow"
 
       principals {
-        type = "AWS"
+        type        = "AWS"
         identifiers = ["arn:${var.aws_partition}:iam::${account.value}:root"]
       }
 

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -1,31 +1,31 @@
 variable "acl" {
-  type = string
+  type        = string
   description = "ACL to apply to objects"
-  default = "private"
+  default     = "private"
 }
 
 variable "aws_partition" {
-  type = string
+  type        = string
   description = "Name of AWS partition (e.g. aws)"
 }
 
 variable "bucket_name" {
-  type = string
+  type        = string
   description = "Name of S3 bucket"
 }
 
 variable "enable_bucket_versioning" {
-  type = bool
+  type        = bool
   description = "true to enable versioning of objects stored in bucket"
 }
 
 variable "kms_account_id" {
-  type = string
+  type        = string
   description = "Account ID making requests to KMS key"
 }
 
 variable "kms_admin_roles" {
-  type = list(string)
+  type    = list(string)
   default = ["Administrator"]
 }
 
@@ -61,25 +61,25 @@ variable "lifecycle_rules" {
 }
 
 variable "allowed_external_account_ids" {
-  type = list(string)
+  type    = list(string)
   default = []
 }
 
 variable "region" {
-  type = string
+  type        = string
   description = "AWS region (e.g. us-gov-west-1)"
 }
 
 variable "source_bucket_policy_documents" {
   description = "IAM policy documents to include in the S3 bucket policy"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 
 variable "source_kms_key_policy_documents" {
   description = "IAM policy documents to include in the KMS key policy"
-  type = list(string)
-  default = []
+  type        = list(string)
+  default     = []
 }
 
 variable "block_public_acls" {

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -14,7 +14,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "log_encrypted_buc
 }
 
 resource "aws_s3_bucket_versioning" "log_encrypted_bucket_versioning" {
-  count = var.versioning ? 1 : 0
+  count  = var.versioning ? 1 : 0
   bucket = aws_s3_bucket.log_encrypted_bucket.id
   versioning_configuration {
     status = "Enabled"
@@ -30,7 +30,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
   rule {
     id = "log-rule"
     filter {
-      prefix  = ""
+      prefix = ""
     }
     #if expiration_days is 0 then the rule is disabled
     status = var.expiration_days == 0 ? "Disabled" : "Enabled"
@@ -51,7 +51,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
 }
 
 resource "aws_s3_bucket_policy" "log_encrypted_bucket_policy" {
-  count = var.include_require_encrypted_put_bucket_policy ? 1 : 0
+  count  = var.include_require_encrypted_put_bucket_policy ? 1 : 0
   bucket = aws_s3_bucket.log_encrypted_bucket.id
   policy = <<EOF
 {

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
@@ -22,7 +22,7 @@ variable "expiration_days" {
 
 variable "include_require_encrypted_put_bucket_policy" {
   description = "True to include bucket policy to required encrypted PUTs"
-  type = bool
-  default = true
+  type        = bool
+  default     = true
 }
 

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/public_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/public_encrypted_bucket.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "public_encrypted_bucket" {
   force_destroy = var.force_destroy
 }
 resource "aws_s3_bucket_versioning" "public_encrypted_bucket_versioning" {
-  count = var.versioning ? 1 : 0
+  count  = var.versioning ? 1 : 0
   bucket = aws_s3_bucket.public_encrypted_bucket.id
   versioning_configuration {
     status = "Enabled"
@@ -13,7 +13,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "public_encrypted_
   bucket = aws_s3_bucket.public_encrypted_bucket.id
   rule {
     apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/shibboleth/versions.tf
+++ b/terraform/modules/shibboleth/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/smtp/versions.tf
+++ b/terraform/modules/smtp/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -1,22 +1,22 @@
 module "vpc" {
   source = "../../bosh_vpc"
 
-  stack_description                      = var.stack_description
-  vpc_cidr                               = var.vpc_cidr
-  az1                                    = var.az1
-  az2                                    = var.az2
-  aws_default_region                     = var.aws_default_region
-  private_cidr_1                         = var.private_cidr_1
-  private_cidr_2                         = var.private_cidr_2
-  public_cidr_1                          = var.public_cidr_1
-  public_cidr_2                          = var.public_cidr_2
-  restricted_ingress_web_cidrs           = var.restricted_ingress_web_cidrs
-  restricted_ingress_web_ipv6_cidrs      = var.restricted_ingress_web_ipv6_cidrs
-  nat_gateway_instance_type              = var.nat_gateway_instance_type
-  monitoring_security_group_cidrs        = var.target_monitoring_security_group_cidrs
-  concourse_security_group_cidrs         = var.target_concourse_security_group_cidrs
-  bosh_default_ssh_public_key            = var.bosh_default_ssh_public_key
-  s3_gateway_policy_accounts             = var.s3_gateway_policy_accounts
+  stack_description                 = var.stack_description
+  vpc_cidr                          = var.vpc_cidr
+  az1                               = var.az1
+  az2                               = var.az2
+  aws_default_region                = var.aws_default_region
+  private_cidr_1                    = var.private_cidr_1
+  private_cidr_2                    = var.private_cidr_2
+  public_cidr_1                     = var.public_cidr_1
+  public_cidr_2                     = var.public_cidr_2
+  restricted_ingress_web_cidrs      = var.restricted_ingress_web_cidrs
+  restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
+  nat_gateway_instance_type         = var.nat_gateway_instance_type
+  monitoring_security_group_cidrs   = var.target_monitoring_security_group_cidrs
+  concourse_security_group_cidrs    = var.target_concourse_security_group_cidrs
+  bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
+  s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
 }
 
 module "rds_network" {

--- a/terraform/modules/stack/base/outputs.tf
+++ b/terraform/modules/stack/base/outputs.tf
@@ -32,11 +32,11 @@ output "private_cidr_az2" {
   value = module.vpc.private_cidr_az2
 }
 
-output "vpc_endpoint_customer_s3_if1_ip"{
+output "vpc_endpoint_customer_s3_if1_ip" {
   value = module.vpc.vpc_endpoint_customer_s3_if1_ip
 }
 
-output "vpc_endpoint_customer_s3_if2_ip"{
+output "vpc_endpoint_customer_s3_if2_ip" {
   value = module.vpc.vpc_endpoint_customer_s3_if2_ip
 }
 
@@ -169,7 +169,8 @@ output "bosh_rds_username" {
 }
 
 output "bosh_rds_password" {
-  value = module.rds.rds_password
+  value     = module.rds.rds_password
+  sensitive = true
 }
 
 /*
@@ -201,7 +202,8 @@ output "credhub_rds_username" {
 }
 
 output "credhub_rds_password" {
-  value = module.credhub_rds.rds_password
+  value     = module.credhub_rds.rds_password
+  sensitive = true
 }
 
 output "default_key_name" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -84,6 +84,7 @@ variable "rds_username" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "restricted_ingress_web_cidrs" {
@@ -156,6 +157,7 @@ variable "credhub_rds_username" {
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_db_engine_version" {
@@ -178,7 +180,7 @@ variable "bosh_default_ssh_public_key" {
 
 }
 
-variable "s3_gateway_policy_accounts"{
+variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }

--- a/terraform/modules/stack/base/versions.tf
+++ b/terraform/modules/stack/base/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/modules/stack/spoke/outputs.tf
+++ b/terraform/modules/stack/spoke/outputs.tf
@@ -32,11 +32,11 @@ output "private_cidr_az2" {
   value = module.base.private_cidr_az2
 }
 
-output "vpc_endpoint_customer_s3_if1_ip"{
+output "vpc_endpoint_customer_s3_if1_ip" {
   value = module.base.vpc_endpoint_customer_s3_if1_ip
 }
 
-output "vpc_endpoint_customer_s3_if2_ip"{
+output "vpc_endpoint_customer_s3_if2_ip" {
   value = module.base.vpc_endpoint_customer_s3_if2_ip
 }
 
@@ -169,7 +169,8 @@ output "bosh_rds_username" {
 }
 
 output "bosh_rds_password" {
-  value = module.base.bosh_rds_password
+  value     = module.base.bosh_rds_password
+  sensitive = true
 }
 
 /*
@@ -193,7 +194,8 @@ output "credhub_rds_username" {
 }
 
 output "credhub_rds_password" {
-  value = module.base.credhub_rds_password
+  value     = module.base.credhub_rds_password
+  sensitive = true
 }
 
 output "default_key_name" {

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -29,14 +29,14 @@ module "base" {
   restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
   bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
   s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
-  
+
   rds_security_groups = [
     module.base.bosh_security_group,
   ]
-  rds_security_groups_count         = 1
+  rds_security_groups_count = 1
 
-  rds_allowed_cidrs = var.target_concourse_security_group_cidrs
-  rds_allowed_cidrs_count         = 1
+  rds_allowed_cidrs       = var.target_concourse_security_group_cidrs
+  rds_allowed_cidrs_count = 1
 
 
   target_monitoring_security_group_cidrs = var.parent_monitoring_security_group_cidrs
@@ -50,7 +50,7 @@ module "vpc_peering" {
   source = "../../vpc_peering"
 
   providers = {
-    aws = aws
+    aws         = aws
     aws.tooling = aws.tooling
   }
   target_vpc_account_id  = var.target_account_id
@@ -68,7 +68,7 @@ module "vpc_peering_parentbosh" {
   source = "../../vpc_peering"
 
   providers = {
-    aws = aws
+    aws         = aws
     aws.tooling = aws.parent
   }
   target_vpc_account_id  = var.parent_account_id
@@ -82,16 +82,16 @@ module "vpc_peering_parentbosh" {
   source_az2_route_table = module.base.private_route_table_az2
 }
 
- module "vpc_security_source_to_parent" {
+module "vpc_security_source_to_parent" {
   # and bosh -> monitoring stack
-   providers = {
-     aws = aws.parent
-   }
-   source = "../../vpc_peering_sg"
- 
-   target_bosh_security_group = var.parent_bosh_security_group
-   source_vpc_cidr            = module.base.vpc_cidr
- }
+  providers = {
+    aws = aws.parent
+  }
+  source = "../../vpc_peering_sg"
+
+  target_bosh_security_group = var.parent_bosh_security_group
+  source_vpc_cidr            = module.base.vpc_cidr
+}
 
 module "vpc_security_parent_to_source" {
   # toolingbosh -> envbosh

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -97,9 +97,11 @@ variable "aws_partition" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "target_vpc_id" {
@@ -161,7 +163,7 @@ variable "bosh_default_ssh_public_key" {
 
 }
 
-variable "s3_gateway_policy_accounts"{
+variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }

--- a/terraform/modules/stack/spoke/versions.tf
+++ b/terraform/modules/stack/spoke/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      version = ">=3.37.0"
+      source                = "hashicorp/aws"
+      version               = ">=3.37.0"
       configuration_aliases = [aws, aws.parent, aws.tooling]
     }
   }

--- a/terraform/modules/vpc_peering/network.tf
+++ b/terraform/modules/vpc_peering/network.tf
@@ -42,7 +42,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
 
 # Add peering connection to target_az1_route_table with source_vpc_cidr
 resource "aws_route" "target_az1_to_source_cidr" {
-  provider = aws.tooling
+  provider                  = aws.tooling
   route_table_id            = var.target_az1_route_table
   destination_cidr_block    = var.source_vpc_cidr
   vpc_peering_connection_id = aws_vpc_peering_connection.peering.id
@@ -50,7 +50,7 @@ resource "aws_route" "target_az1_to_source_cidr" {
 
 # Add peering connection to target_az2_route_table with source_vpc_cidr
 resource "aws_route" "target_az2_to_source_cidr" {
-  provider = aws.tooling
+  provider                  = aws.tooling
   route_table_id            = var.target_az2_route_table
   destination_cidr_block    = var.source_vpc_cidr
   vpc_peering_connection_id = aws_vpc_peering_connection.peering.id

--- a/terraform/modules/vpc_peering/versions.tf
+++ b/terraform/modules/vpc_peering/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      version = ">=4.4.0"
+      source                = "hashicorp/aws"
+      version               = ">=4.4.0"
       configuration_aliases = [aws, aws.tooling]
     }
   }

--- a/terraform/modules/vpc_peering_sg/versions.tf
+++ b/terraform/modules/vpc_peering_sg/versions.tf
@@ -1,10 +1,10 @@
 
 terraform {
   required_version = ">= 0.15"
-    required_providers {
-  aws = {
-      source = "hashicorp/aws"
-      version = ">=4.4.0"
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">=4.4.0"
       configuration_aliases = [aws]
     }
   }

--- a/terraform/stacks/cloudfront/stack.tf
+++ b/terraform/stacks/cloudfront/stack.tf
@@ -6,6 +6,7 @@ variable "aws_access_key" {
 }
 
 variable "aws_secret_key" {
+  sensitive = true
 }
 
 variable "aws_region" {
@@ -17,9 +18,9 @@ terraform {
 }
 
 provider "aws" {
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-  region     = var.aws_region
+  access_key        = var.aws_access_key
+  secret_key        = var.aws_secret_key
+  region            = var.aws_region
   use_fips_endpoint = true
 
   endpoints {
@@ -31,7 +32,7 @@ provider "aws" {
   default_tags {
     tags = {
       deployment = "cloudfront-${var.stack_description}"
-      stack = "${var.stack_description}"
+      stack      = "${var.stack_description}"
     }
   }
 }

--- a/terraform/stacks/dns/dev.tf
+++ b/terraform/stacks/dns/dev.tf
@@ -1,6 +1,6 @@
 
 resource "aws_route53_zone" "dev_zone" {
-    name = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
+  name = "dev.us-gov-west-1.aws-us-gov.cloud.gov"
 }
 
 resource "aws_route53_record" "dev_ns" {

--- a/terraform/stacks/dns/pages.tf
+++ b/terraform/stacks/dns/pages.tf
@@ -60,51 +60,51 @@ resource "aws_route53_record" "cloud_gov_star_sites_pages_cloud_gov_aaaa" {
 ## Templates ##
 
 resource "aws_route53_record" "cloud_gov_uswds-11ty_pages_cloud_gov" {
-    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-    name    = "uswds-11ty.pages.cloud.gov."
-    type    = "CNAME"
-    ttl     = 60
-    records = ["uswds-11ty.pages.cloud.gov.external-domains-production.cloud.gov."]
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "uswds-11ty.pages.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["uswds-11ty.pages.cloud.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "cloud_gov__acme-challenge_uswds-11ty_pages_cloud_gov" {
-    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-    name    = "_acme-challenge.uswds-11ty.pages.cloud.gov."
-    type    = "CNAME"
-    ttl     = 60
-    records = ["_acme-challenge.uswds-11ty.pages.cloud.gov.external-domains-production.cloud.gov."]
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "_acme-challenge.uswds-11ty.pages.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["_acme-challenge.uswds-11ty.pages.cloud.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "cloud_gov_uswds-gatsby_pages_cloud_gov" {
-    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-    name    = "uswds-gatsby.pages.cloud.gov."
-    type    = "CNAME"
-    ttl     = 60
-    records = ["uswds-gatsby.pages.cloud.gov.external-domains-production.cloud.gov."]
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "uswds-gatsby.pages.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["uswds-gatsby.pages.cloud.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "cloud_gov__acme-challenge_uswds-gatsby_pages_cloud_gov" {
-    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-    name    = "_acme-challenge.uswds-gatsby.pages.cloud.gov."
-    type    = "CNAME"
-    ttl     = 60
-    records = ["_acme-challenge.uswds-gatsby.pages.cloud.gov.external-domains-production.cloud.gov."]
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "_acme-challenge.uswds-gatsby.pages.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["_acme-challenge.uswds-gatsby.pages.cloud.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "cloud_gov_uswds-jekyll_pages_cloud_gov" {
-    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-    name    = "uswds-jekyll.pages.cloud.gov."
-    type    = "CNAME"
-    ttl     = 60
-    records = ["uswds-jekyll.pages.cloud.gov.external-domains-production.cloud.gov."]
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "uswds-jekyll.pages.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["uswds-jekyll.pages.cloud.gov.external-domains-production.cloud.gov."]
 }
 
 resource "aws_route53_record" "cloud_gov__acme-challenge_uswds-jekyll_pages_cloud_gov" {
-    zone_id = aws_route53_zone.cloud_gov_zone.zone_id
-    name    = "_acme-challenge.uswds-jekyll.pages.cloud.gov."
-    type    = "CNAME"
-    ttl     = 60
-    records = ["_acme-challenge.uswds-jekyll.pages.cloud.gov.external-domains-production.cloud.gov."]
+  zone_id = aws_route53_zone.cloud_gov_zone.zone_id
+  name    = "_acme-challenge.uswds-jekyll.pages.cloud.gov."
+  type    = "CNAME"
+  ttl     = 60
+  records = ["_acme-challenge.uswds-jekyll.pages.cloud.gov.external-domains-production.cloud.gov."]
 }
 
 ## End Production ##

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -5,6 +5,7 @@ variable "aws_access_key" {
 }
 
 variable "aws_secret_key" {
+  sensitive = true
 }
 
 variable "aws_region" {
@@ -16,9 +17,9 @@ terraform {
 }
 
 provider "aws" {
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-  region     = var.aws_region
+  access_key        = var.aws_access_key
+  secret_key        = var.aws_secret_key
+  region            = var.aws_region
   use_fips_endpoint = true
 
   default_tags {

--- a/terraform/stacks/dns/staging.tf
+++ b/terraform/stacks/dns/staging.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_zone" "staging_zone" {
-    name = "fr-stage.cloud.gov"
+  name = "fr-stage.cloud.gov"
 }
 
 resource "aws_route53_record" "staging_ns" {

--- a/terraform/stacks/dns/validators.tf
+++ b/terraform/stacks/dns/validators.tf
@@ -48,7 +48,7 @@ resource "aws_route53_record" "cloud_gov_gsuite_dkim_txt" {
   ttl     = 5
 
   records = [
-     "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjaTlZow4cEXZt/gUvZaVPrlsxzo4grF136MoAXLE5gz314FqsdXsHtCJzVHK+8zA4GajtZ8FLDUTqf+E+fJ9xaWUTfOxhtOccOOMKxTUuXcq+V3+mMad1MFOUxMSNfYtJmvWvpVlo+\"\"TGk70sZSRhhyUcMGqQobdPlAdv67iQsQZLj1I12EbPqByT+lZI57p8C1dVEYHxdzmPEFcaeIX97OPUNEOszDez5glQabg+UJPidgs/h+w+fTs8B2Jf6GN/Q/qLmjZSnGU3xbCqy4jWpNNvISu8jFmqXedwEG/xXv1Yk8oL361J5Oz/Y2mC/dlvbXLJWe8dBOLaKC0vesIMXQIDAQAB",
+    "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjaTlZow4cEXZt/gUvZaVPrlsxzo4grF136MoAXLE5gz314FqsdXsHtCJzVHK+8zA4GajtZ8FLDUTqf+E+fJ9xaWUTfOxhtOccOOMKxTUuXcq+V3+mMad1MFOUxMSNfYtJmvWvpVlo+\"\"TGk70sZSRhhyUcMGqQobdPlAdv67iQsQZLj1I12EbPqByT+lZI57p8C1dVEYHxdzmPEFcaeIX97OPUNEOszDez5glQabg+UJPidgs/h+w+fTs8B2Jf6GN/Q/qLmjZSnGU3xbCqy4jWpNNvISu8jFmqXedwEG/xXv1Yk8oL361J5Oz/Y2mC/dlvbXLJWe8dBOLaKC0vesIMXQIDAQAB",
   ]
 }
 

--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -8,7 +8,7 @@ output "health_check_user_access_key_id_prev" {
 }
 
 output "health_check_user_secret_access_key_prev" {
-  value = module.health_check_user.secret_access_key_prev
+  value     = module.health_check_user.secret_access_key_prev
   sensitive = true
 }
 
@@ -17,7 +17,7 @@ output "health_check_user_access_key_id_curr" {
 }
 
 output "health_check_user_secret_access_key_curr" {
-  value = module.health_check_user.secret_access_key_curr
+  value     = module.health_check_user.secret_access_key_curr
   sensitive = true
 }
 
@@ -31,7 +31,7 @@ output "external_domain_broker_access_key_id_prev" {
 }
 
 output "external_domain_broker_secret_access_key_prev" {
-  value = module.external_domain_broker.secret_access_key_prev
+  value     = module.external_domain_broker.secret_access_key_prev
   sensitive = true
 }
 
@@ -40,7 +40,7 @@ output "external_domain_broker_access_key_id_curr" {
 }
 
 output "external_domain_broker_secret_access_key_curr" {
-  value = module.external_domain_broker.secret_access_key_curr
+  value     = module.external_domain_broker.secret_access_key_curr
   sensitive = true
 }
 
@@ -54,7 +54,7 @@ output "external_domain_broker_tests_access_key_id_prev" {
 }
 
 output "external_domain_broker_tests_secret_access_key_prev" {
-  value = module.external_domain_broker_tests.secret_access_key_prev
+  value     = module.external_domain_broker_tests.secret_access_key_prev
   sensitive = true
 }
 
@@ -63,7 +63,7 @@ output "external_domain_broker_tests_access_key_id_curr" {
 }
 
 output "external_domain_broker_tests_secret_access_key_curr" {
-  value = module.external_domain_broker_tests.secret_access_key_curr
+  value     = module.external_domain_broker_tests.secret_access_key_curr
   sensitive = true
 }
 
@@ -77,7 +77,7 @@ output "cdn_broker_access_key_id_prev" {
 }
 
 output "cdn_broker_secret_access_key_prev" {
-  value = module.cdn_broker.secret_access_key_prev
+  value     = module.cdn_broker.secret_access_key_prev
   sensitive = true
 }
 
@@ -86,7 +86,7 @@ output "cdn_broker_access_key_id_curr" {
 }
 
 output "cdn_broker_secret_access_key_curr" {
-  value = module.cdn_broker.secret_access_key_curr
+  value     = module.cdn_broker.secret_access_key_curr
   sensitive = true
 }
 
@@ -100,7 +100,7 @@ output "limit_check_access_key_id_prev" {
 }
 
 output "limit_check_secret_access_key_prev" {
-  value = module.limit_check_user.secret_access_key_prev
+  value     = module.limit_check_user.secret_access_key_prev
   sensitive = true
 }
 
@@ -109,7 +109,7 @@ output "limit_check_access_key_id_curr" {
 }
 
 output "limit_check_secret_access_key_curr" {
-  value = module.limit_check_user.secret_access_key_curr
+  value     = module.limit_check_user.secret_access_key_curr
   sensitive = true
 }
 
@@ -123,7 +123,7 @@ output "lets_encrypt_access_key_id_prev" {
 }
 
 output "lets_encrypt_secret_access_key_prev" {
-  value = module.lets_encrypt_user.secret_access_key_prev
+  value     = module.lets_encrypt_user.secret_access_key_prev
   sensitive = true
 }
 
@@ -132,6 +132,6 @@ output "lets_encrypt_access_key_id_curr" {
 }
 
 output "lets_encrypt_secret_access_key_curr" {
-  value = module.lets_encrypt_user.secret_access_key_curr
+  value     = module.lets_encrypt_user.secret_access_key_curr
   sensitive = true
 }

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -10,7 +10,7 @@ provider "aws" {
   default_tags {
     tags = {
       deployment = "external-${var.stack_description}"
-      stack = "${var.stack_description}"
+      stack      = "${var.stack_description}"
     }
   }
 }
@@ -23,7 +23,7 @@ provider "aws" {
   default_tags {
     tags = {
       deployment = "external-${var.stack_description}"
-      stack = "${var.stack_description}"
+      stack      = "${var.stack_description}"
     }
   }
 }
@@ -42,7 +42,7 @@ module "external_domain_broker" {
   aws_partition     = data.aws_partition.current.partition
 
   providers = {
-    aws = aws.fips
+    aws          = aws.fips
     aws.standard = aws.standard
   }
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -6,15 +6,16 @@ variable "domains_broker_rds_username" {
 }
 
 variable "domains_broker_rds_password" {
+  sensitive = true
 }
 
 /* Broker internal load balancer */
 resource "aws_lb" "domains_broker_internal" {
-  name    = "${var.stack_description}-domains-internal"
-  subnets = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
-  security_groups = [module.stack.bosh_security_group]
-  internal        = true
-  enable_deletion_protection  = true
+  name                       = "${var.stack_description}-domains-internal"
+  subnets                    = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
+  security_groups            = [module.stack.bosh_security_group]
+  internal                   = true
+  enable_deletion_protection = true
   access_logs {
     bucket  = module.log_bucket.elb_bucket_name
     prefix  = var.stack_description
@@ -88,12 +89,12 @@ output "domains_broker_rds_port" {
 resource "aws_lb" "domains_broker" {
   count = var.domains_broker_alb_count
 
-  name    = "${var.stack_description}-domains-${count.index}"
-  subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
-  security_groups = [module.stack.web_traffic_security_group]
-  ip_address_type = "dualstack"
-  idle_timeout    = 3600
-  enable_deletion_protection  = true
+  name                       = "${var.stack_description}-domains-${count.index}"
+  subnets                    = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
+  security_groups            = [module.stack.web_traffic_security_group]
+  ip_address_type            = "dualstack"
+  idle_timeout               = 3600
+  enable_deletion_protection = true
   access_logs {
     bucket  = module.log_bucket.elb_bucket_name
     prefix  = var.stack_description
@@ -359,7 +360,7 @@ output "legacy_domain_certificate_renewer_access_key_id_curr" {
 }
 
 output "legacy_domain_certificate_renewer_secret_access_key_curr" {
-  value = aws_iam_access_key.legacy_domain_certificate_renewer_key_v1.secret
+  value     = aws_iam_access_key.legacy_domain_certificate_renewer_key_v1.secret
   sensitive = true
 }
 

--- a/terraform/stacks/main/iam.tf
+++ b/terraform/stacks/main/iam.tf
@@ -2,7 +2,7 @@ resource "aws_iam_user" "s3_broker_user" {
   name = "s3-broker-${var.stack_description}"
 }
 resource "aws_iam_access_key" "s3_broker_user_key_v1" {
-  user    = aws_iam_user.s3_broker_user.name
+  user = aws_iam_user.s3_broker_user.name
 }
 
 module "blobstore_policy" {
@@ -153,7 +153,7 @@ resource "aws_iam_policy_attachment" "bosh" {
     module.bosh_role.role_name,
   ]
   users = [
-     aws_iam_user.parent_bosh_user.name
+    aws_iam_user.parent_bosh_user.name
   ]
 }
 
@@ -225,5 +225,5 @@ resource "aws_iam_user" "parent_bosh_user" {
 
 
 resource "aws_iam_access_key" "parent_bosh_user_key_v1" {
-  user    = aws_iam_user.parent_bosh_user.name
+  user = aws_iam_user.parent_bosh_user.name
 }

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -357,11 +357,11 @@ output "s3_gateway_endpoint_cidr_2" {
 }
 
 /* s3 private gateway endpoint ips for public egress */
-output "vpc_endpoint_customer_s3_if1_ip"{
+output "vpc_endpoint_customer_s3_if1_ip" {
   value = module.stack.vpc_endpoint_customer_s3_if1_ip
 }
 
-output "vpc_endpoint_customer_s3_if2_ip"{
+output "vpc_endpoint_customer_s3_if2_ip" {
   value = module.stack.vpc_endpoint_customer_s3_if2_ip
 }
 
@@ -417,7 +417,7 @@ output "cf_rds_username" {
 }
 
 output "cf_rds_password" {
-  value = module.cf.cf_rds_password
+  value     = module.cf.cf_rds_password
   sensitive = true
 }
 
@@ -443,7 +443,7 @@ output "credhub_rds_username" {
 }
 
 output "credhub_rds_password" {
-  value = module.stack.credhub_rds_password
+  value     = module.stack.credhub_rds_password
   sensitive = true
 }
 
@@ -490,7 +490,7 @@ output "platform_logs_bucket_access_key_id_curr" {
 }
 
 output "platform_logs_bucket_secret_access_key_curr" {
-  value = module.logsearch.platform_logs_bucket_secret_access_key_curr
+  value     = module.logsearch.platform_logs_bucket_secret_access_key_curr
   sensitive = true
 }
 output "platform_logs_bucket_name" {
@@ -558,7 +558,7 @@ output "external_domain_broker_gov_access_key_id_curr" {
 }
 
 output "external_domain_broker_gov_secret_access_key_curr" {
-  value = module.external_domain_broker_govcloud.secret_access_key_curr
+  value     = module.external_domain_broker_govcloud.secret_access_key_curr
   sensitive = true
 }
 
@@ -567,7 +567,7 @@ output "external_domain_broker_gov_access_key_id_prev" {
 }
 
 output "external_domain_broker_gov_secret_access_key_prev" {
-  value = module.external_domain_broker_govcloud.secret_access_key_prev
+  value     = module.external_domain_broker_govcloud.secret_access_key_prev
   sensitive = true
 }
 
@@ -620,7 +620,7 @@ output "s3_broker_user_access_key_id_curr" {
 }
 
 output "s3_broker_user_secret_access_key_curr" {
-  value = aws_iam_access_key.s3_broker_user_key_v1.secret
+  value     = aws_iam_access_key.s3_broker_user_key_v1.secret
   sensitive = true
 }
 
@@ -637,7 +637,7 @@ output "parent_bosh_user_access_key_id_curr" {
 }
 
 output "parent_bosh_user_secret_access_key_curr" {
-  value = aws_iam_access_key.parent_bosh_user_key_v1.secret
+  value     = aws_iam_access_key.parent_bosh_user_key_v1.secret
   sensitive = true
 }
 

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -17,15 +17,20 @@ variable "rds_db_size" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
+
 variable "rds_instance_type" {
-  default = "db.m4.large"
+  default   = "db.m4.large"
+  sensitive = true
 }
 
 variable "cf_rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "remote_state_bucket" {

--- a/terraform/stacks/main/versions.tf
+++ b/terraform/stacks/main/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.15"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">=4.4.0"
     }
   }

--- a/terraform/stacks/managedaccount/iam.tf
+++ b/terraform/stacks/managedaccount/iam.tf
@@ -3,15 +3,15 @@ provider "aws" {
   default_tags {
     tags = {
       deployment = "managed-account-${var.environment_name}"
-      stack = "${var.environment_name}"
+      stack      = "${var.environment_name}"
     }
   }
 }
 
 resource "aws_iam_role" "tfrole" {
-  name               = "${var.environment_name}-tooling-concourse-worker"
-  path               = "/terraform/"
-  description        = "policy to allow terraform to run from tooling"
+  name        = "${var.environment_name}-tooling-concourse-worker"
+  path        = "/terraform/"
+  description = "policy to allow terraform to run from tooling"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -29,18 +29,18 @@ resource "aws_iam_role" "tfrole" {
 }
 
 resource "aws_iam_policy" "tfpolicy" {
-  name  = "${var.environment_name}-tooling-terraform-policy"
+  name = "${var.environment_name}-tooling-terraform-policy"
   policy = jsonencode({
-  Version = "2012-10-17"
-  Statement = [
-    {
-      Action = [
-        "*",
-      ]
-      Effect   = "Allow"
-      Resource = "*"
-    },
-  ]
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
   })
 
 }
@@ -51,9 +51,9 @@ resource "aws_iam_role_policy_attachment" "tfrolepolicy" {
 }
 
 resource "aws_iam_role" "certuploadrole" {
-  name               = "${var.environment_name}-tooling-cert-uploader"
-  path               = "/terraform/"
-  description        = "policy to allow terraform to run from tooling"
+  name        = "${var.environment_name}-tooling-cert-uploader"
+  path        = "/terraform/"
+  description = "policy to allow terraform to run from tooling"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -69,7 +69,7 @@ resource "aws_iam_role" "certuploadrole" {
   })
 
 }
-data "aws_partition" "current"{
+data "aws_partition" "current" {
 
 }
 
@@ -77,20 +77,20 @@ data "aws_caller_identity" "current" {
 
 }
 resource "aws_iam_policy" "certuploadpolicy" {
-  name  = "${var.environment_name}-tooling-cert-uploader-policy"
+  name = "${var.environment_name}-tooling-cert-uploader-policy"
   policy = jsonencode({
-  Version = "2012-10-17"
-  Statement = [
-    {
-      Action = [
-        "iam:ListServerCertificates",
-        "iam:UploadServerCertificate",
-        "iam:DeleteServerCertificate"
-      ]
-      Effect   = "Allow"
-      Resource = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/lets-encrypt/*"
-    },
-  ]
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "iam:ListServerCertificates",
+          "iam:UploadServerCertificate",
+          "iam:DeleteServerCertificate"
+        ]
+        Effect   = "Allow"
+        Resource = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/lets-encrypt/*"
+      },
+    ]
   })
 
 }

--- a/terraform/stacks/managedaccount/outputs.tf
+++ b/terraform/stacks/managedaccount/outputs.tf
@@ -1,7 +1,7 @@
 output "tf_role_arn" {
-    value = aws_iam_role.tfrole.arn
+  value = aws_iam_role.tfrole.arn
 }
 
 output "cert_role_arn" {
-    value = aws_iam_role.certuploadrole.arn
+  value = aws_iam_role.certuploadrole.arn
 }

--- a/terraform/stacks/regionalmasterbosh/elb_uaa.tf
+++ b/terraform/stacks/regionalmasterbosh/elb_uaa.tf
@@ -1,10 +1,10 @@
 resource "aws_lb" "opsuaa" {
-  name    = "${var.stack_description}-opsuaa"
-  subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
-  security_groups = [module.stack.restricted_web_traffic_security_group]
-  ip_address_type = "dualstack"
-  idle_timeout    = 3600
-  enable_deletion_protection  = true
+  name                       = "${var.stack_description}-opsuaa"
+  subnets                    = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
+  security_groups            = [module.stack.restricted_web_traffic_security_group]
+  ip_address_type            = "dualstack"
+  idle_timeout               = 3600
+  enable_deletion_protection = true
   access_logs {
     bucket  = var.log_bucket_name
     prefix  = var.stack_description

--- a/terraform/stacks/regionalmasterbosh/iam.tf
+++ b/terraform/stacks/regionalmasterbosh/iam.tf
@@ -6,7 +6,7 @@ resource "aws_iam_user" "bosh_blobstore_user" {
 }
 
 resource "aws_iam_access_key" "bosh_blobstore_user_key_v1" {
-  user    = aws_iam_user.bosh_blobstore_user.name
+  user = aws_iam_user.bosh_blobstore_user.name
 }
 module "s3_logstash" {
   source        = "../../modules/iam_user/s3_logstash"

--- a/terraform/stacks/regionalmasterbosh/opsuaa.tf
+++ b/terraform/stacks/regionalmasterbosh/opsuaa.tf
@@ -1,4 +1,5 @@
 variable "opsuaa_rds_password" {
+  sensitive = true
 }
 
 module "opsuaa_db" {
@@ -34,7 +35,8 @@ output "opsuaa_rds_username" {
 }
 
 output "opsuaa_rds_password" {
-  value = module.opsuaa_db.rds_password
+  value     = module.opsuaa_db.rds_password
+  sensitive = true
 }
 
 output "opsuaa_rds_engine" {

--- a/terraform/stacks/regionalmasterbosh/outputs.tf
+++ b/terraform/stacks/regionalmasterbosh/outputs.tf
@@ -232,7 +232,7 @@ output "bosh_rds_username" {
 }
 
 output "bosh_rds_password" {
-  value = module.stack.bosh_rds_password
+  value     = module.stack.bosh_rds_password
   sensitive = true
 }
 
@@ -268,7 +268,7 @@ output "production_doomsday_lb_target_group" {
 
 output "monitoring_security_groups" {
   value = {
-    production  = module.monitoring_production.monitoring_security_group
+    production = module.monitoring_production.monitoring_security_group
   }
 }
 
@@ -282,7 +282,7 @@ output "s3_logstash_access_key_id_prev" {
 }
 
 output "s3_logstash_secret_access_key_prev" {
-  value = module.s3_logstash.secret_access_key_prev
+  value     = module.s3_logstash.secret_access_key_prev
   sensitive = true
 }
 
@@ -291,7 +291,7 @@ output "s3_logstash_access_key_id_curr" {
 }
 
 output "s3_logstash_secret_access_key_curr" {
-  value = module.s3_logstash.secret_access_key_curr
+  value     = module.s3_logstash.secret_access_key_curr
   sensitive = true
 }
 
@@ -305,7 +305,7 @@ output "rds_storage_alert_access_key_id" {
 }
 
 output "rds_storage_alert_secret_access_key" {
-  value = module.rds_storage_alert.secret_access_key
+  value     = module.rds_storage_alert.secret_access_key
   sensitive = true
 }
 
@@ -319,7 +319,7 @@ output "iam_cert_provision_access_key_id_prev" {
 }
 
 output "iam_cert_provision_secret_access_key_prev" {
-  value = module.iam_cert_provision_user.secret_access_key_prev
+  value     = module.iam_cert_provision_user.secret_access_key_prev
   sensitive = true
 }
 
@@ -328,7 +328,7 @@ output "iam_cert_provision_access_key_id_curr" {
 }
 
 output "iam_cert_provision_secret_access_key_curr" {
-  value = module.iam_cert_provision_user.secret_access_key_curr
+  value     = module.iam_cert_provision_user.secret_access_key_curr
   sensitive = true
 }
 
@@ -422,7 +422,7 @@ output "credhub_rds_username" {
 }
 
 output "credhub_rds_password" {
-  value = module.stack.credhub_rds_password
+  value     = module.stack.credhub_rds_password
   sensitive = true
 }
 
@@ -443,6 +443,6 @@ output "bosh_blobstore_user_access_key_id_curr" {
 }
 
 output "bosh_blobstore_user_secret_access_key_curr" {
-  value = aws_iam_access_key.bosh_blobstore_user_key_v1.secret
+  value     = aws_iam_access_key.bosh_blobstore_user_key_v1.secret
   sensitive = true
 }

--- a/terraform/stacks/regionalmasterbosh/s3-logs.tf
+++ b/terraform/stacks/regionalmasterbosh/s3-logs.tf
@@ -40,10 +40,10 @@ POLICY
 }
 
 resource "aws_cloudtrail" "cg-s3-cloudtrail-trail" {
-  name           = "s3-audit-logs"
-  s3_bucket_name = aws_s3_bucket.cg-s3-cloudtrail-bucket.id
+  name                       = "s3-audit-logs"
+  s3_bucket_name             = aws_s3_bucket.cg-s3-cloudtrail-bucket.id
   enable_log_file_validation = true
-  
+
   event_selector {
     read_write_type           = "All"
     include_management_events = true

--- a/terraform/stacks/regionalmasterbosh/stack.tf
+++ b/terraform/stacks/regionalmasterbosh/stack.tf
@@ -4,7 +4,7 @@ terraform {
 }
 
 provider "aws" {
-  alias = "tooling"
+  alias             = "tooling"
   use_fips_endpoint = true
 
   default_tags {
@@ -16,14 +16,14 @@ provider "aws" {
 
 provider "aws" {
   use_fips_endpoint = true
-  region = var.aws_default_region
+  region            = var.aws_default_region
   assume_role {
     role_arn = var.assume_arn
   }
   default_tags {
     tags = {
       deployment = "regional-master-bosh-${var.stack_description}"
-      stack = "${var.stack_description}"
+      stack      = "${var.stack_description}"
     }
   }
 }
@@ -72,8 +72,8 @@ resource "aws_lb" "main" {
     prefix  = var.stack_description
     enabled = true
   }
- 
-  enable_deletion_protection  = true
+
+  enable_deletion_protection = true
 }
 
 resource "aws_lb_listener" "main" {
@@ -133,7 +133,7 @@ module "stack" {
     data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr,
     data.terraform_remote_state.target_vpc.outputs.staging_concourse_subnet_cidr,
   ]
-  rds_allowed_cidrs                 = [
+  rds_allowed_cidrs = [
     data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr,
     data.terraform_remote_state.target_vpc.outputs.staging_concourse_subnet_cidr,
   ]
@@ -177,7 +177,7 @@ module "concourse_vpc_peering" {
   source = "../../modules/vpc_peering"
 
   providers = {
-    aws = aws
+    aws         = aws
     aws.tooling = aws.tooling
   }
   target_vpc_account_id  = data.aws_caller_identity.tooling.account_id

--- a/terraform/stacks/regionalmasterbosh/variables.tf
+++ b/terraform/stacks/regionalmasterbosh/variables.tf
@@ -10,9 +10,11 @@ variable "vpc_cidr" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "rds_multi_az" {

--- a/terraform/stacks/tooling/cvd_mirror.tf
+++ b/terraform/stacks/tooling/cvd_mirror.tf
@@ -12,10 +12,10 @@ module "cvd_database_bucket" {
   versioning    = "false"
 }
 
-module cvd_sync_user {
-  source = "../../modules/iam_user/cvd_sync"
-  username = "clamav_mirror_sync"
+module "cvd_sync_user" {
+  source              = "../../modules/iam_user/cvd_sync"
+  username            = "clamav_mirror_sync"
   cvd_database_bucket = "cg-clamav-mirror"
   cvd_metadata_bucket = "cg-clamav-meta"
-  aws_partition = data.aws_partition.current.partition
+  aws_partition       = data.aws_partition.current.partition
 }

--- a/terraform/stacks/tooling/elb_uaa.tf
+++ b/terraform/stacks/tooling/elb_uaa.tf
@@ -1,10 +1,10 @@
 resource "aws_lb" "opsuaa" {
-  name    = "${var.stack_description}-opsuaa"
-  subnets = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
-  security_groups = [module.stack.restricted_web_traffic_security_group]
-  ip_address_type = "dualstack"
-  idle_timeout    = 3600
-  enable_deletion_protection  = true
+  name                       = "${var.stack_description}-opsuaa"
+  subnets                    = [module.stack.public_subnet_az1, module.stack.public_subnet_az2]
+  security_groups            = [module.stack.restricted_web_traffic_security_group]
+  ip_address_type            = "dualstack"
+  idle_timeout               = 3600
+  enable_deletion_protection = true
   access_logs {
     bucket  = var.log_bucket_name
     prefix  = var.stack_description

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -89,8 +89,8 @@ module "cloudwatch_policy" {
   policy_name = "${var.stack_description}-cloudwatch"
 }
 module "ecr_policy" {
-  source      = "../../modules/iam_role_policy/ecr"
-  policy_name = "ecr"
+  source             = "../../modules/iam_role_policy/ecr"
+  policy_name        = "ecr"
   aws_partition      = data.aws_partition.current.partition
   aws_default_region = var.aws_default_region
   account_id         = data.aws_caller_identity.current.account_id
@@ -210,6 +210,6 @@ resource "aws_iam_policy_attachment" "ecr" {
 }
 
 module "ecr_user" {
-  source         = "../../modules/iam_user/ecr_user"
-  username       = "cg-ecr"
+  source   = "../../modules/iam_user/ecr_user"
+  username = "cg-ecr"
 }

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -1,4 +1,5 @@
 variable "opsuaa_rds_password" {
+  sensitive = true
 }
 
 module "opsuaa_db" {
@@ -34,7 +35,7 @@ output "opsuaa_rds_username" {
 }
 
 output "opsuaa_rds_password" {
-  value = module.opsuaa_db.rds_password
+  value     = module.opsuaa_db.rds_password
   sensitive = true
 }
 

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -257,7 +257,7 @@ output "bosh_rds_username" {
 }
 
 output "bosh_rds_password" {
-  value = module.stack.bosh_rds_password
+  value     = module.stack.bosh_rds_password
   sensitive = true
 }
 
@@ -279,7 +279,7 @@ output "credhub_rds_username" {
 }
 
 output "credhub_rds_password" {
-  value = module.stack.credhub_rds_password
+  value     = module.stack.credhub_rds_password
   sensitive = true
 }
 
@@ -338,7 +338,7 @@ output "production_concourse_rds_username" {
 }
 
 output "production_concourse_rds_password" {
-  value = module.concourse_production.concourse_rds_password
+  value     = module.concourse_production.concourse_rds_password
   sensitive = true
 }
 
@@ -392,7 +392,7 @@ output "staging_concourse_rds_username" {
 }
 
 output "staging_concourse_rds_password" {
-  value = module.concourse_staging.concourse_rds_password
+  value     = module.concourse_staging.concourse_rds_password
   sensitive = true
 }
 
@@ -462,7 +462,7 @@ output "production_credhub_rds_username" {
 }
 
 output "production_credhub_rds_password" {
-  value = module.credhub_production.credhub_rds_password
+  value     = module.credhub_production.credhub_rds_password
   sensitive = true
 }
 
@@ -534,7 +534,7 @@ output "staging_credhub_rds_username" {
 }
 
 output "staging_credhub_rds_password" {
-  value = module.credhub_staging.credhub_rds_password
+  value     = module.credhub_staging.credhub_rds_password
   sensitive = true
 }
 
@@ -602,7 +602,7 @@ output "billing_access_key_id_prev" {
 }
 
 output "billing_secret_access_key_prev" {
-  value = module.billing_user.secret_access_key_prev
+  value     = module.billing_user.secret_access_key_prev
   sensitive = true
 }
 
@@ -611,7 +611,7 @@ output "billing_access_key_id_curr" {
 }
 
 output "billing_secret_access_key_curr" {
-  value = module.billing_user.secret_access_key_curr
+  value     = module.billing_user.secret_access_key_curr
   sensitive = true
 }
 
@@ -625,7 +625,7 @@ output "federalist_auditor_access_key_id_prev" {
 }
 
 output "federalist_auditor_secret_access_key_prev" {
-  value = module.federalist_auditor_user.secret_access_key_prev
+  value     = module.federalist_auditor_user.secret_access_key_prev
   sensitive = true
 }
 
@@ -634,7 +634,7 @@ output "federalist_auditor_access_key_id_curr" {
 }
 
 output "federalist_auditor_secret_access_key_curr" {
-  value = module.federalist_auditor_user.secret_access_key_curr
+  value     = module.federalist_auditor_user.secret_access_key_curr
   sensitive = true
 }
 
@@ -648,7 +648,7 @@ output "s3_logstash_access_key_id_prev" {
 }
 
 output "s3_logstash_secret_access_key_prev" {
-  value = module.s3_logstash.secret_access_key_prev
+  value     = module.s3_logstash.secret_access_key_prev
   sensitive = true
 }
 
@@ -657,7 +657,7 @@ output "s3_logstash_access_key_id_curr" {
 }
 
 output "s3_logstash_secret_access_key_curr" {
-  value = module.s3_logstash.secret_access_key_curr
+  value     = module.s3_logstash.secret_access_key_curr
   sensitive = true
 }
 
@@ -671,7 +671,7 @@ output "rds_storage_alert_access_key_id" {
 }
 
 output "rds_storage_alert_secret_access_key" {
-  value = module.rds_storage_alert.secret_access_key
+  value     = module.rds_storage_alert.secret_access_key
   sensitive = true
 }
 
@@ -685,7 +685,7 @@ output "iam_cert_provision_access_key_id_prev" {
 }
 
 output "iam_cert_provision_secret_access_key_prev" {
-  value = module.iam_cert_provision_user.secret_access_key_prev
+  value     = module.iam_cert_provision_user.secret_access_key_prev
   sensitive = true
 }
 
@@ -694,7 +694,7 @@ output "iam_cert_provision_access_key_id_curr" {
 }
 
 output "iam_cert_provision_secret_access_key_curr" {
-  value = module.iam_cert_provision_user.secret_access_key_curr
+  value     = module.iam_cert_provision_user.secret_access_key_curr
   sensitive = true
 }
 
@@ -708,7 +708,7 @@ output "ecr_access_key_id_prev" {
 }
 
 output "ecr_secret_access_key_prev" {
-  value = module.ecr_user.secret_access_key_prev
+  value     = module.ecr_user.secret_access_key_prev
   sensitive = true
 }
 
@@ -717,7 +717,7 @@ output "ecr_access_key_id_curr" {
 }
 
 output "ecr_secret_access_key_curr" {
-  value = module.ecr_user.secret_access_key_curr
+  value     = module.ecr_user.secret_access_key_curr
   sensitive = true
 }
 
@@ -832,7 +832,7 @@ output "cvd_sync_access_key_id_prev" {
 }
 
 output "cvd_sync_secret_access_key_prev" {
-  value = module.cvd_sync_user.secret_access_key_prev
+  value     = module.cvd_sync_user.secret_access_key_prev
   sensitive = true
 }
 
@@ -841,7 +841,7 @@ output "cvd_sync_access_key_id_curr" {
 }
 
 output "cvd_sync_secret_access_key_curr" {
-  value = module.cvd_sync_user.secret_access_key_curr
+  value     = module.cvd_sync_user.secret_access_key_curr
   sensitive = true
 }
 

--- a/terraform/stacks/tooling/s3-logs.tf
+++ b/terraform/stacks/tooling/s3-logs.tf
@@ -39,10 +39,10 @@ POLICY
 }
 
 resource "aws_cloudtrail" "cg-s3-cloudtrail-trail" {
-  name           = "s3-audit-logs"
-  s3_bucket_name = aws_s3_bucket.cg-s3-cloudtrail-bucket.id
+  name                       = "s3-audit-logs"
+  s3_bucket_name             = aws_s3_bucket.cg-s3-cloudtrail-bucket.id
   enable_log_file_validation = true
-  
+
   event_selector {
     read_write_type           = "All"
     include_management_events = true

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -8,7 +8,7 @@ provider "aws" {
   default_tags {
     tags = {
       deployment = "tooling"
-      stack = "tooling"
+      stack      = "tooling"
     }
   }
 }
@@ -46,7 +46,7 @@ resource "aws_lb" "main" {
     prefix  = var.stack_description
     enabled = true
   }
-  enable_deletion_protection  = true
+  enable_deletion_protection = true
 }
 
 resource "aws_lb_listener" "main" {
@@ -89,8 +89,8 @@ module "stack" {
   restricted_ingress_web_ipv6_cidrs      = var.restricted_ingress_web_ipv6_cidrs
   rds_private_cidr_1                     = cidrsubnet(var.vpc_cidr, 8, 20)
   rds_private_cidr_2                     = cidrsubnet(var.vpc_cidr, 8, 21)
-  rds_private_cidr_3                = cidrsubnet(var.vpc_cidr, 7, 11) # This will give 22-23
-  rds_private_cidr_4                = cidrsubnet(var.vpc_cidr, 7, 12) # This will give 24-25
+  rds_private_cidr_3                     = cidrsubnet(var.vpc_cidr, 7, 11) # This will give 22-23
+  rds_private_cidr_4                     = cidrsubnet(var.vpc_cidr, 7, 12) # This will give 24-25
   rds_password                           = var.rds_password
   credhub_rds_password                   = var.credhub_rds_password
   rds_multi_az                           = var.rds_multi_az
@@ -101,7 +101,7 @@ module "stack" {
   rds_allow_major_version_upgrade        = var.rds_allow_major_version_upgrade
   rds_apply_immediately                  = var.rds_apply_immediately
   bosh_default_ssh_public_key            = var.bosh_default_ssh_public_key
-  target_concourse_security_group_cidrs  = [cidrsubnet(var.vpc_cidr, 8, 30),cidrsubnet(var.vpc_cidr, 8, 31),cidrsubnet(var.vpc_cidr, 8, 1)]
+  target_concourse_security_group_cidrs  = [cidrsubnet(var.vpc_cidr, 8, 30), cidrsubnet(var.vpc_cidr, 8, 31), cidrsubnet(var.vpc_cidr, 8, 1)]
   target_monitoring_security_group_cidrs = [cidrsubnet(var.vpc_cidr, 8, 32)]
   s3_gateway_policy_accounts             = var.s3_gateway_policy_accounts
 }

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -10,9 +10,11 @@ variable "vpc_cidr" {
 }
 
 variable "rds_password" {
+  sensitive = true
 }
 
 variable "credhub_rds_password" {
+  sensitive = true
 }
 
 variable "rds_multi_az" {
@@ -39,18 +41,22 @@ variable "remote_state_bucket" {
 }
 
 variable "concourse_prod_rds_password" {
+  sensitive = true
 }
 
 variable "concourse_staging_rds_password" {
+  sensitive = true
 }
 
 variable "concourse_varz_bucket" {
 }
 
 variable "credhub_prod_rds_password" {
+  sensitive = true
 }
 
 variable "credhub_staging_rds_password" {
+  sensitive = true
 }
 
 variable "wildcard_production_certificate_name_prefix" {
@@ -181,7 +187,7 @@ variable "bosh_default_ssh_public_key" {
 
 }
 
-variable "s3_gateway_policy_accounts"{
+variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

Terraform includes a built-in formatting tool, `terraform fmt`. This change runs the formatter on PR code and fails if it results in a dirty git index, i.e. if it results in any files being changed. Developers should configure their editors to automatically format on save using `terraform fmt`. (Editors running the [Terraform Language Server](https://github.com/hashicorp/terraform-ls) surface this as a setting.)

## security considerations
None.
