### PR TITLE
Accidentally marked non-sensitive field as sensitive

### DIFF
--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -21,8 +21,7 @@ variable "rds_password" {
 }
 
 variable "rds_instance_type" {
-  default   = "db.m4.large"
-  sensitive = true
+  default = "db.m4.large"
 }
 
 variable "cf_rds_password" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- See title

## security considerations
None, field was not actually sensitive
