### PR TITLE
Remove default ACL from KMS encrypted buckets

### DIFF
--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
@@ -30,12 +30,12 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sse_kms_config" {
 }
 
 resource "aws_s3_bucket_acl" "kms_encrypted_bucket_acl" {
-  count = var.acl != null ? 1 : 0
+  count  = var.acl != "" ? 1 : 0
   bucket = aws_s3_bucket.kms_encrypted_bucket.id
   acl    = var.acl
 }
 
-resource "aws_s3_bucket_ownership_controls" "kms_encrypted_bucket_acl_ownership" {
+resource "aws_s3_bucket_ownership_controls" "kms_encrypted_bucket_ownership" {
   bucket = aws_s3_bucket.kms_encrypted_bucket.id
   rule {
     object_ownership = var.object_ownership

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
@@ -35,7 +35,8 @@ resource "aws_s3_bucket_acl" "kms_encrypted_bucket_acl" {
   acl    = var.acl
 }
 
-resource "aws_s3_bucket_ownership_controls" "kms_encrypted_bucket_ownership" {
+resource "aws_s3_bucket_ownership_controls" "kms_encrypted_bucket_acl_ownership" {
+  count  = var.acl != "" && var.object_ownership != "" ? 1 : 0
   bucket = aws_s3_bucket.kms_encrypted_bucket.id
   rule {
     object_ownership = var.object_ownership

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
@@ -29,11 +29,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sse_kms_config" {
   }
 }
 
-resource "aws_s3_bucket_acl" "kms_encrypted_bucket_acl" {
-  bucket = aws_s3_bucket.kms_encrypted_bucket.id
-  acl    = var.acl
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "kms_encrypted_bucket_lifecycle" {
   bucket = aws_s3_bucket.kms_encrypted_bucket.id
   count  = length(var.lifecycle_rules) > 0 ? 1 : 0

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/bucket.tf
@@ -29,6 +29,19 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sse_kms_config" {
   }
 }
 
+resource "aws_s3_bucket_acl" "kms_encrypted_bucket_acl" {
+  count = var.acl != null ? 1 : 0
+  bucket = aws_s3_bucket.kms_encrypted_bucket.id
+  acl    = var.acl
+}
+
+resource "aws_s3_bucket_ownership_controls" "kms_encrypted_bucket_acl_ownership" {
+  bucket = aws_s3_bucket.kms_encrypted_bucket.id
+  rule {
+    object_ownership = var.object_ownership
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "kms_encrypted_bucket_lifecycle" {
   bucket = aws_s3_bucket.kms_encrypted_bucket.id
   count  = length(var.lifecycle_rules) > 0 ? 1 : 0

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -1,6 +1,7 @@
 variable "acl" {
   type        = string
   description = "ACL to apply to objects"
+  default     = ""
 }
 
 variable "aws_partition" {
@@ -106,6 +107,7 @@ variable "restrict_public_buckets" {
 }
 
 variable "object_ownership" {
-  type = string
-  default = "BucketOwnerPreferred"
+  type        = string
+  default     = "BucketOwnerPreferred"
+  description = "Object ownership strategy to use for S3 bucket"
 }

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -108,6 +108,6 @@ variable "restrict_public_buckets" {
 
 variable "object_ownership" {
   type        = string
-  default     = "BucketOwnerPreferred"
+  default     = ""
   description = "Object ownership strategy to use for S3 bucket"
 }

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -1,3 +1,8 @@
+variable "acl" {
+  type        = string
+  description = "ACL to apply to objects"
+}
+
 variable "aws_partition" {
   type        = string
   description = "Name of AWS partition (e.g. aws)"
@@ -98,4 +103,9 @@ variable "restrict_public_buckets" {
   type        = bool
   description = "Whether Amazon S3 should restrict public bucket policies for this bucket"
   default     = false
+}
+
+variable "object_ownership" {
+  type = string
+  default = "BucketOwnerPreferred"
 }

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -1,9 +1,3 @@
-variable "acl" {
-  type        = string
-  description = "ACL to apply to objects"
-  default     = "private"
-}
-
 variable "aws_partition" {
   type        = string
   description = "Name of AWS partition (e.g. aws)"


### PR DESCRIPTION
## Changes proposed in this pull request:

AWS is now creating buckets with ACLs disabled by default: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

While this code was creating a "private" ACL for any newly created KMS-ecnrypted buckets, the effect of that is that the bucket and object owner get "full control" of the object and no one else has access rights: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl

But a "private" ACL isn't necessary for all cases. Most of the time, we may prefer to use the new AWS default where the bucket owner only has sole access to the bucket and objects, in which case setting an ACL isn't necessary.

So this PR :

- Removes the default "private" ACL and makes an ACL optional
- Makes setting the object ownership possible in case we do want to use ACLs for a bucket

## security considerations

None
