### PR TITLE
Cf timeout health check adjustments

### DIFF
--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -21,10 +21,10 @@ resource "aws_lb_target_group" "cf_apps_target_https" {
   vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold   = 2
-    interval            = 7
+    healthy_threshold   = 3
+    interval            = 15
     port                = 81
-    timeout             = 6
+    timeout             = 10
     unhealthy_threshold = 3
     matcher             = 200
   }

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -22,7 +22,7 @@ resource "aws_lb_target_group" "cf_apps_target_https" {
 
   health_check {
     healthy_threshold   = 2
-    interval            = 5
+    interval            = 7
     port                = 81
     timeout             = 6
     unhealthy_threshold = 3

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -24,7 +24,7 @@ resource "aws_lb_target_group" "cf_apps_target_https" {
     healthy_threshold   = 2
     interval            = 5
     port                = 81
-    timeout             = 4
+    timeout             = 6
     unhealthy_threshold = 3
     matcher             = 200
   }

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -24,7 +24,7 @@ resource "aws_lb_target_group" "cf_target_https" {
     healthy_threshold   = 2
     interval            = 5
     port                = 81
-    timeout             = 4
+    timeout             = 6
     unhealthy_threshold = 3
     matcher             = 200
   }

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -21,10 +21,10 @@ resource "aws_lb_target_group" "cf_target_https" {
   vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold   = 2
-    interval            = 7
+    healthy_threshold   = 3
+    interval            = 15
     port                = 81
-    timeout             = 6
+    timeout             = 10
     unhealthy_threshold = 3
     matcher             = 200
   }

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -22,7 +22,7 @@ resource "aws_lb_target_group" "cf_target_https" {
 
   health_check {
     healthy_threshold   = 2
-    interval            = 5
+    interval            = 7
     port                = 81
     timeout             = 6
     unhealthy_threshold = 3

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -21,10 +21,10 @@ resource "aws_lb_target_group" "cf_uaa_target" {
   vpc_id   = var.vpc_id
 
   health_check {
-    healthy_threshold   = 2
-    interval            = 7
+    healthy_threshold   = 3
+    interval            = 15
     port                = 81
-    timeout             = 6
+    timeout             = 10
     unhealthy_threshold = 3
     matcher             = 200
   }

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -22,7 +22,7 @@ resource "aws_lb_target_group" "cf_uaa_target" {
 
   health_check {
     healthy_threshold   = 2
-    interval            = 5
+    interval            = 7
     port                = 81
     timeout             = 6
     unhealthy_threshold = 3

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -24,7 +24,7 @@ resource "aws_lb_target_group" "cf_uaa_target" {
     healthy_threshold   = 2
     interval            = 5
     port                = 81
-    timeout             = 4
+    timeout             = 6
     unhealthy_threshold = 3
     matcher             = 200
   }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -176,7 +176,7 @@ resource "aws_lb_target_group" "domains_broker_apps_https" {
     healthy_threshold   = 2
     unhealthy_threshold = 3
     timeout             = 6
-    interval            = 5
+    interval            = 7
     port                = 81
     matcher             = 200
   }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -173,10 +173,10 @@ resource "aws_lb_target_group" "domains_broker_apps_https" {
   vpc_id   = module.stack.vpc_id
 
   health_check {
-    healthy_threshold   = 2
+    healthy_threshold   = 3
     unhealthy_threshold = 3
-    timeout             = 6
-    interval            = 7
+    timeout             = 10
+    interval            = 15
     port                = 81
     matcher             = 200
   }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -175,7 +175,7 @@ resource "aws_lb_target_group" "domains_broker_apps_https" {
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 3
-    timeout             = 4
+    timeout             = 6
     interval            = 5
     port                = 81
     matcher             = 200


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updating target group health checks for CF based ELBs
- Make healthy and unhealthy counts 3, increase timeout to 10 seconds, increase internal to 15 seconds

## security considerations
By increasing the timeout and interval we give secureproxy on the gorouters more time to process health checks under load and not fail causing DOS failures
