### PR TITLE
add names for all security group resources

### DIFF
--- a/terraform/modules/bosh_vpc/sg_bosh.tf
+++ b/terraform/modules/bosh_vpc/sg_bosh.tf
@@ -10,6 +10,7 @@
 
 # this security group is applied to all the vms in this stack, including the bosh director
 resource "aws_security_group" "bosh" {
+  name = "${var.stack_description}-bosh"
   description = "BOSH security group"
   vpc_id      = aws_vpc.main_vpc.id
 

--- a/terraform/modules/bosh_vpc/sg_bosh.tf
+++ b/terraform/modules/bosh_vpc/sg_bosh.tf
@@ -10,7 +10,7 @@
 
 # this security group is applied to all the vms in this stack, including the bosh director
 resource "aws_security_group" "bosh" {
-  name = "${var.stack_description}-bosh"
+  name        = "${var.stack_description}-bosh"
   description = "BOSH security group"
   vpc_id      = aws_vpc.main_vpc.id
 

--- a/terraform/modules/bosh_vpc/sg_local_vpc_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_local_vpc_traffic.tf
@@ -7,7 +7,7 @@
  */
 
 resource "aws_security_group" "local_vpc_traffic" {
-  name = "${var.stack_description}-local-vpc-traffic"
+  name        = "${var.stack_description}-local-vpc-traffic"
   description = "Enable access to all VPC CIDR block ips"
   vpc_id      = aws_vpc.main_vpc.id
 

--- a/terraform/modules/bosh_vpc/sg_local_vpc_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_local_vpc_traffic.tf
@@ -7,6 +7,7 @@
  */
 
 resource "aws_security_group" "local_vpc_traffic" {
+  name = "${var.stack_description}-local-vpc-traffic"
   description = "Enable access to all VPC CIDR block ips"
   vpc_id      = aws_vpc.main_vpc.id
 

--- a/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
@@ -7,6 +7,7 @@
  */
 
 resource "aws_security_group" "restricted_web_traffic" {
+  name = "${var.stack_description}-restricted-incoming-web"
   description = "Restricted web type traffic"
   vpc_id      = aws_vpc.main_vpc.id
 

--- a/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
@@ -7,7 +7,7 @@
  */
 
 resource "aws_security_group" "restricted_web_traffic" {
-  name = "${var.stack_description}-restricted-incoming-web"
+  name        = "${var.stack_description}-restricted-incoming-web"
   description = "Restricted web type traffic"
   vpc_id      = aws_vpc.main_vpc.id
 

--- a/terraform/modules/bosh_vpc/sg_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_web_traffic.tf
@@ -7,7 +7,7 @@
  */
 
 resource "aws_security_group" "web_traffic" {
-  name = "${var.stack_description}-allow-incoming-web"
+  name        = "${var.stack_description}-allow-incoming-web"
   description = "Allow access to incoming web type traffic"
   vpc_id      = aws_vpc.main_vpc.id
 

--- a/terraform/modules/bosh_vpc/sg_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_web_traffic.tf
@@ -7,6 +7,7 @@
  */
 
 resource "aws_security_group" "web_traffic" {
+  name = "${var.stack_description}-allow-incoming-web"
   description = "Allow access to incoming web type traffic"
   vpc_id      = aws_vpc.main_vpc.id
 

--- a/terraform/modules/cloudfoundry/nlb.tf
+++ b/terraform/modules/cloudfoundry/nlb.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "nlb_traffic" {
-  name = "${var.stack_description}-allow-incoming-tcp"
+  name        = "${var.stack_description}-allow-incoming-tcp"
   count       = var.tcp_lb_count > 0 ? 1 : 0
   description = "Allow traffic in to NLB"
   vpc_id      = var.vpc_id

--- a/terraform/modules/cloudfoundry/nlb.tf
+++ b/terraform/modules/cloudfoundry/nlb.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "nlb_traffic" {
+  name = "${var.stack_description}-allow-incoming-tcp"
   count       = var.tcp_lb_count > 0 ? 1 : 0
   description = "Allow traffic in to NLB"
   vpc_id      = var.vpc_id

--- a/terraform/modules/concourse/sg_concourse.tf
+++ b/terraform/modules/concourse/sg_concourse.tf
@@ -5,6 +5,7 @@
  */
 
 resource "aws_security_group" "concourse" {
+  name = "${var.stack_description}-allow-incoming-concourse"
   description = "Allow access to incoming concourse traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/concourse/sg_concourse.tf
+++ b/terraform/modules/concourse/sg_concourse.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_security_group" "concourse" {
-  name = "${var.stack_description}-allow-incoming-concourse"
+  name        = "${var.stack_description}-allow-incoming-concourse"
   description = "Allow access to incoming concourse traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/credhub/security-groups.tf
+++ b/terraform/modules/credhub/security-groups.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_security_group" "credhub" {
-  name = "${var.stack_description}-allow-incoming-credhub"
+  name        = "${var.stack_description}-allow-incoming-credhub"
   description = "Allow access to incoming credhub traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/credhub/security-groups.tf
+++ b/terraform/modules/credhub/security-groups.tf
@@ -5,6 +5,7 @@
  */
 
 resource "aws_security_group" "credhub" {
+  name = "${var.stack_description}-allow-incoming-credhub"
   description = "Allow access to incoming credhub traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/dns/sg.tf
+++ b/terraform/modules/dns/sg.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "dns_axfr" {
+  name = "${var.stack_description}-dns-axfr"
   description = "Allow access from public DNS for AXFR"
   vpc_id      = var.vpc_id
 
@@ -22,6 +23,7 @@ resource "aws_security_group" "dns_axfr" {
 }
 
 resource "aws_security_group" "dns_public" {
+  name = "${var.stack_description}-incoming-dns"
   description = "Allow access to incoming DNS traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/dns/sg.tf
+++ b/terraform/modules/dns/sg.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "dns_axfr" {
-  name = "${var.stack_description}-dns-axfr"
+  name        = "${var.stack_description}-dns-axfr"
   description = "Allow access from public DNS for AXFR"
   vpc_id      = var.vpc_id
 
@@ -23,7 +23,7 @@ resource "aws_security_group" "dns_axfr" {
 }
 
 resource "aws_security_group" "dns_public" {
-  name = "${var.stack_description}-incoming-dns"
+  name        = "${var.stack_description}-incoming-dns"
   description = "Allow access to incoming DNS traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/elasticache_broker_network/sg_redis.tf
+++ b/terraform/modules/elasticache_broker_network/sg_redis.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "elasticache_redis" {
+  name = "${var.stack_description}-incoming-redis"
   description = "Allow access to incoming redis traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/elasticache_broker_network/sg_redis.tf
+++ b/terraform/modules/elasticache_broker_network/sg_redis.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "elasticache_redis" {
-  name = "${var.stack_description}-incoming-redis"
+  name        = "${var.stack_description}-incoming-redis"
   description = "Allow access to incoming redis traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/monitoring/sg_monitoring.tf
+++ b/terraform/modules/monitoring/sg_monitoring.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_security_group" "monitoring" {
-  name = "${var.stack_description}-incoming-monitoring"
+  name        = "${var.stack_description}-incoming-monitoring"
   description = "Allow access to incoming monitoring traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/monitoring/sg_monitoring.tf
+++ b/terraform/modules/monitoring/sg_monitoring.tf
@@ -5,6 +5,7 @@
  */
 
 resource "aws_security_group" "monitoring" {
+  name = "${var.stack_description}-incoming-monitoring"
   description = "Allow access to incoming monitoring traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/rds_network/sg_mssql.tf
+++ b/terraform/modules/rds_network/sg_mssql.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_security_group" "rds_mssql" {
-  name = "${var.stack_description}-incoming-db-mssql"
+  name        = "${var.stack_description}-incoming-db-mssql"
   description = "Allow access to incoming mssql traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/rds_network/sg_mssql.tf
+++ b/terraform/modules/rds_network/sg_mssql.tf
@@ -5,6 +5,7 @@
  */
 
 resource "aws_security_group" "rds_mssql" {
+  name = "${var.stack_description}-incoming-db-mssql"
   description = "Allow access to incoming mssql traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/rds_network/sg_mysql.tf
+++ b/terraform/modules/rds_network/sg_mysql.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_security_group" "rds_mysql" {
-  name = "${var.stack_description}-incoming-db-mysql"
+  name        = "${var.stack_description}-incoming-db-mysql"
   description = "Allow access to incoming mysql traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/rds_network/sg_mysql.tf
+++ b/terraform/modules/rds_network/sg_mysql.tf
@@ -5,6 +5,7 @@
  */
 
 resource "aws_security_group" "rds_mysql" {
+  name = "${var.stack_description}-incoming-db-mysql"
   description = "Allow access to incoming mysql traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/rds_network/sg_oracle.tf
+++ b/terraform/modules/rds_network/sg_oracle.tf
@@ -5,6 +5,7 @@
  */
 
 resource "aws_security_group" "rds_oracle" {
+  name = "${var.stack_description}-incoming-db-oracle"
   description = "Allow access to incoming Oracle traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/rds_network/sg_oracle.tf
+++ b/terraform/modules/rds_network/sg_oracle.tf
@@ -5,7 +5,7 @@
  */
 
 resource "aws_security_group" "rds_oracle" {
-  name = "${var.stack_description}-incoming-db-oracle"
+  name        = "${var.stack_description}-incoming-db-oracle"
   description = "Allow access to incoming Oracle traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/rds_network/sg_postgres.tf
+++ b/terraform/modules/rds_network/sg_postgres.tf
@@ -11,7 +11,7 @@ data "aws_prefix_list" "s3" {
 }
 
 resource "aws_security_group" "rds_postgres" {
-  name = "${var.stack_description}-incoming-db-postgresql"
+  name        = "${var.stack_description}-incoming-db-postgresql"
   description = "Allow access to incoming postgresql traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/rds_network/sg_postgres.tf
+++ b/terraform/modules/rds_network/sg_postgres.tf
@@ -11,6 +11,7 @@ data "aws_prefix_list" "s3" {
 }
 
 resource "aws_security_group" "rds_postgres" {
+  name = "${var.stack_description}-incoming-db-postgresql"
   description = "Allow access to incoming postgresql traffic"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/smtp/sg.tf
+++ b/terraform/modules/smtp/sg.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "smtp" {
-  name = "${var.stack_description}-smtp"
+  name        = "${var.stack_description}-smtp"
   description = "Allow access to smtp service from all our internal hosts, and outbound access to 587 too"
   vpc_id      = var.vpc_id
 

--- a/terraform/modules/smtp/sg.tf
+++ b/terraform/modules/smtp/sg.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "smtp" {
+  name = "${var.stack_description}-smtp"
   description = "Allow access to smtp service from all our internal hosts, and outbound access to 587 too"
   vpc_id      = var.vpc_id
 

--- a/terraform/stacks/bootstrap/bootstrap.tf
+++ b/terraform/stacks/bootstrap/bootstrap.tf
@@ -24,7 +24,7 @@ resource "aws_default_subnet" "default_az1" {
 }
 
 resource "aws_security_group" "bootstrap" {
-  name = "${var.stack_description}-bootstrap"
+  name = "bootstrap-sg"
   ingress {
     from_port   = 22
     to_port     = 22

--- a/terraform/stacks/bootstrap/bootstrap.tf
+++ b/terraform/stacks/bootstrap/bootstrap.tf
@@ -24,6 +24,7 @@ resource "aws_default_subnet" "default_az1" {
 }
 
 resource "aws_security_group" "bootstrap" {
+  name = "${var.stack_description}-bootstrap"
   ingress {
     from_port   = 22
     to_port     = 22

--- a/terraform/stacks/regionalmasterbosh/sg_elb_uaa.tf
+++ b/terraform/stacks/regionalmasterbosh/sg_elb_uaa.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "bosh_uaa_traffic" {
-  name = "${var.stack_description}-incoming-bosh-uaa"
+  name        = "${var.stack_description}-incoming-bosh-uaa"
   description = "Allow access to incoming BOSH UAA traffic for operations"
   vpc_id      = module.stack.vpc_id
 

--- a/terraform/stacks/regionalmasterbosh/sg_elb_uaa.tf
+++ b/terraform/stacks/regionalmasterbosh/sg_elb_uaa.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "bosh_uaa_traffic" {
+  name = "${var.stack_description}-incoming-bosh-uaa"
   description = "Allow access to incoming BOSH UAA traffic for operations"
   vpc_id      = module.stack.vpc_id
 

--- a/terraform/stacks/regionalmasterbosh/sg_nessus.tf
+++ b/terraform/stacks/regionalmasterbosh/sg_nessus.tf
@@ -7,7 +7,7 @@
  */
 
 resource "aws_security_group" "nessus_traffic" {
-  name = "${var.stack_description}-incoming-nessus"
+  name        = "${var.stack_description}-incoming-nessus"
   description = "Allow access to incoming nessus traffic"
   vpc_id      = module.stack.vpc_id
 

--- a/terraform/stacks/regionalmasterbosh/sg_nessus.tf
+++ b/terraform/stacks/regionalmasterbosh/sg_nessus.tf
@@ -7,6 +7,7 @@
  */
 
 resource "aws_security_group" "nessus_traffic" {
+  name = "${var.stack_description}-incoming-nessus"
   description = "Allow access to incoming nessus traffic"
   vpc_id      = module.stack.vpc_id
 

--- a/terraform/stacks/tooling/sg_elb_uaa.tf
+++ b/terraform/stacks/tooling/sg_elb_uaa.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "bosh_uaa_traffic" {
-  name = "${var.stack_description}-incoming-bosh-uaa"
+  name        = "${var.stack_description}-incoming-bosh-uaa"
   description = "Allow access to incoming BOSH UAA traffic for operations"
   vpc_id      = module.stack.vpc_id
 

--- a/terraform/stacks/tooling/sg_elb_uaa.tf
+++ b/terraform/stacks/tooling/sg_elb_uaa.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "bosh_uaa_traffic" {
+  name = "${var.stack_description}-incoming-bosh-uaa"
   description = "Allow access to incoming BOSH UAA traffic for operations"
   vpc_id      = module.stack.vpc_id
 

--- a/terraform/stacks/tooling/sg_nessus.tf
+++ b/terraform/stacks/tooling/sg_nessus.tf
@@ -7,7 +7,7 @@
  */
 
 resource "aws_security_group" "nessus_traffic" {
-  name = "${var.stack_description}-incoming-nessus"
+  name        = "${var.stack_description}-incoming-nessus"
   description = "Allow access to incoming nessus traffic"
   vpc_id      = module.stack.vpc_id
 

--- a/terraform/stacks/tooling/sg_nessus.tf
+++ b/terraform/stacks/tooling/sg_nessus.tf
@@ -7,6 +7,7 @@
  */
 
 resource "aws_security_group" "nessus_traffic" {
+  name = "${var.stack_description}-incoming-nessus"
   description = "Allow access to incoming nessus traffic"
   vpc_id      = module.stack.vpc_id
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- add names for all security group resources so that they have better names in AWS than `terraform-*` and their purpose is clear from their naming

## security considerations

Improving security by making the intended use of our security groups more obvious
