### PR TITLE
WAF - log all traffic to CloudWatch/Set Retention/Define CloudWatch Log Groups for WAF

### DIFF
--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -382,6 +382,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
 resource "aws_cloudwatch_log_group" "cf_uaa_waf_core" {
   name = "aws-waf-logs-${var.stack_description}"
+  arn = aws_waf_cloudwatch.arn
   retention_in_days = 180
   tags = {
     Environment = "${var.stack_description}"
@@ -391,7 +392,7 @@ resource "aws_cloudwatch_log_group" "cf_uaa_waf_core" {
 // create default logging ruleset which is log all and associate to the correct cloudwatch log group
 
 resource "aws_wafv2_web_acl_logging_configuration" "cf_uaa_waf_core" {
-  log_destination_configs = aws_cloudwatch_log_group.cf_uaa-waf_core.arn
+  log_destination_configs = aws_waf_cloudwatch.arn
   resource_arn            = aws_wafv2_web_acl.cf_uaa_waf_core.arn
 }
 

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -391,7 +391,7 @@ resource "aws_cloudwatch_log_group" "cf_uaa_waf_core_cloudwatch_log_group" {
 // create default logging ruleset which is log all and associate to the correct cloudwatch log group
 
 resource "aws_wafv2_web_acl_logging_configuration" "cf_uaa_waf_core" {
-  log_destination_configs = [aws_cloudwatch_log_group.cf_uaa_waf_core_cloudwatch_log_group]
+  log_destination_configs = [aws_cloudwatch_log_group.cf_uaa_waf_core_cloudwatch_log_group.arn]
   resource_arn            = aws_wafv2_web_acl.cf_uaa_waf_core.arn
 }
 

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -382,7 +382,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
 resource "aws_cloudwatch_log_group" "cf_uaa_waf_core" {
   name = "aws-waf-logs-${var.stack_description}"
-  arn = aws_cloudwatch.cf_uaa.arn
+  arn = aws_cloudwatch.cf_uaa_waf_core.arn
   retention_in_days = 180
   tags = {
     Environment = "${var.stack_description}"
@@ -392,7 +392,7 @@ resource "aws_cloudwatch_log_group" "cf_uaa_waf_core" {
 // create default logging ruleset which is log all and associate to the correct cloudwatch log group
 
 resource "aws_wafv2_web_acl_logging_configuration" "cf_uaa_waf_core" {
-  log_destination_configs = aws_cloudwatch.cf_uaa.arn
+  log_destination_configs = aws_cloudwatch.cf_uaa_waf_core.arn
   resource_arn            = aws_wafv2_web_acl.cf_uaa_waf_core.arn
 }
 

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -378,6 +378,23 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   }
 }
 
+// create the cloudwatch log group to log traffic and set cloudwatch retention to 6 months
+
+resource "aws_cloudwatch_log_group" "cf_uaa_waf_core" {
+  name = "aws-waf-logs-${var.stack_description}"
+  retention_in_days = 180
+  tags = {
+    Environment = "${var.stack_description}"
+  }
+}
+
+// create default logging ruleset which is log all and associate to the correct cloudwatch log group
+
+resource "aws_wafv2_web_acl_logging_configuration" "cf_uaa_waf_core" {
+  log_destination_configs = aws_cloudwatch_log_group.cf_uaa-waf_core.arn
+  resource_arn            = aws_wafv2_web_acl.cf_uaa_waf_core.arn
+}
+
 resource "aws_wafv2_web_acl_association" "cf_uaa_waf_core" {
   resource_arn = aws_lb.cf_uaa.arn
   web_acl_arn  = aws_wafv2_web_acl.cf_uaa_waf_core.arn

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -382,7 +382,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
 resource "aws_cloudwatch_log_group" "cf_uaa_waf_core" {
   name = "aws-waf-logs-${var.stack_description}"
-  arn = aws_waf_cloudwatch.arn
+  arn = aws_cloudwatch.cf_uaa.arn
   retention_in_days = 180
   tags = {
     Environment = "${var.stack_description}"
@@ -392,7 +392,7 @@ resource "aws_cloudwatch_log_group" "cf_uaa_waf_core" {
 // create default logging ruleset which is log all and associate to the correct cloudwatch log group
 
 resource "aws_wafv2_web_acl_logging_configuration" "cf_uaa_waf_core" {
-  log_destination_configs = aws_waf_cloudwatch.arn
+  log_destination_configs = aws_cloudwatch.cf_uaa.arn
   resource_arn            = aws_wafv2_web_acl.cf_uaa_waf_core.arn
 }
 

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -380,9 +380,8 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
 // create the cloudwatch log group to log traffic and set cloudwatch retention to 6 months
 
-resource "aws_cloudwatch_log_group" "cf_uaa_waf_core" {
+resource "aws_cloudwatch_log_group" "cf_uaa_waf_core_cloudwatch_log_group" {
   name = "aws-waf-logs-${var.stack_description}"
-  arn = aws_cloudwatch.cf_uaa_waf_core.arn
   retention_in_days = 180
   tags = {
     Environment = "${var.stack_description}"
@@ -392,7 +391,7 @@ resource "aws_cloudwatch_log_group" "cf_uaa_waf_core" {
 // create default logging ruleset which is log all and associate to the correct cloudwatch log group
 
 resource "aws_wafv2_web_acl_logging_configuration" "cf_uaa_waf_core" {
-  log_destination_configs = aws_cloudwatch.cf_uaa_waf_core.arn
+  log_destination_configs = [aws_cloudwatch_log_group.cf_uaa_waf_core_cloudwatch_log_group]
   resource_arn            = aws_wafv2_web_acl.cf_uaa_waf_core.arn
 }
 

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -386,7 +386,6 @@ resource "aws_cloudwatch_log_group" "cf_uaa_waf_core_cloudwatch_log_group" {
   }
 }
 
-
 resource "aws_wafv2_web_acl_logging_configuration" "cf_uaa_waf_core" {
   log_destination_configs = [aws_cloudwatch_log_group.cf_uaa_waf_core_cloudwatch_log_group.arn]
   resource_arn            = aws_wafv2_web_acl.cf_uaa_waf_core.arn

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -378,8 +378,6 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   }
 }
 
-// create the cloudwatch log group to log traffic and set cloudwatch retention to 6 months
-
 resource "aws_cloudwatch_log_group" "cf_uaa_waf_core_cloudwatch_log_group" {
   name = "aws-waf-logs-${var.stack_description}"
   retention_in_days = 180
@@ -388,7 +386,6 @@ resource "aws_cloudwatch_log_group" "cf_uaa_waf_core_cloudwatch_log_group" {
   }
 }
 
-// create default logging ruleset which is log all and associate to the correct cloudwatch log group
 
 resource "aws_wafv2_web_acl_logging_configuration" "cf_uaa_waf_core" {
   log_destination_configs = [aws_cloudwatch_log_group.cf_uaa_waf_core_cloudwatch_log_group.arn]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Log all WAF traffic instead of block - managed in TF
- Manage CloudWatch Log Groups for WAF in TF now
- Set 6 month retention policy on WAF CloudWatch log groups

## security considerations
Logging all traffic passing through WAF to CloudWatch helps operators review items in a concise and timely manner
