### PR TITLE
Changing versions accepted from from >=4.4.0 to < 5.0.0

### DIFF
--- a/terraform/modules/cdn_broker/versions.tf
+++ b/terraform/modules/cdn_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/cloud_watch/versions.tf
+++ b/terraform/modules/cloud_watch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/cloudfoundry/versions.tf
+++ b/terraform/modules/cloudfoundry/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/cloudfront/versions.tf
+++ b/terraform/modules/cloudfront/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/concourse/versions.tf
+++ b/terraform/modules/concourse/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/credhub/versions.tf
+++ b/terraform/modules/credhub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/cvd_mirror/versions.tf
+++ b/terraform/modules/cvd_mirror/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/diego/versions.tf
+++ b/terraform/modules/diego/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/dns/versions.tf
+++ b/terraform/modules/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/elasticache_broker_network/versions.tf
+++ b/terraform/modules/elasticache_broker_network/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/elasticsearch_broker/versions.tf
+++ b/terraform/modules/elasticsearch_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/environment_dns/versions.tf
+++ b/terraform/modules/environment_dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/external_domain_broker/versions.tf
+++ b/terraform/modules/external_domain_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/external_domain_broker_govcloud/versions.tf
+++ b/terraform/modules/external_domain_broker_govcloud/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/external_domain_broker_tests/versions.tf
+++ b/terraform/modules/external_domain_broker_tests/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role/versions.tf
+++ b/terraform/modules/iam_role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/aws_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/blobstore/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/bosh/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/cloudwatch/versions.tf
+++ b/terraform/modules/iam_role_policy/cloudwatch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/compliance_role/versions.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/concourse_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/ecr/versions.tf
+++ b/terraform/modules/iam_role_policy/ecr/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
+++ b/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/s3_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/billing_user/versions.tf
+++ b/terraform/modules/iam_user/billing_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/cvd_sync/versions.tf
+++ b/terraform/modules/iam_user/cvd_sync/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/ecr_user/versions.tf
+++ b/terraform/modules/iam_user/ecr_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/federalist_auditor/versions.tf
+++ b/terraform/modules/iam_user/federalist_auditor/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/health_check/versions.tf
+++ b/terraform/modules/iam_user/health_check/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/iam_cert_provision/versions.tf
+++ b/terraform/modules/iam_user/iam_cert_provision/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/lets_encrypt/versions.tf
+++ b/terraform/modules/iam_user/lets_encrypt/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/limit_check_user/versions.tf
+++ b/terraform/modules/iam_user/limit_check_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/rds_storage_alert/versions.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/s3_logstash/versions.tf
+++ b/terraform/modules/iam_user/s3_logstash/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/logsearch/versions.tf
+++ b/terraform/modules/logsearch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/monitoring/versions.tf
+++ b/terraform/modules/monitoring/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/rds/versions.tf
+++ b/terraform/modules/rds/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/rds_network/versions.tf
+++ b/terraform/modules/rds_network/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/regionalmaster_dns/versions.tf
+++ b/terraform/modules/regionalmaster_dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/shibboleth/versions.tf
+++ b/terraform/modules/shibboleth/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/smtp/versions.tf
+++ b/terraform/modules/smtp/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/stack/base/versions.tf
+++ b/terraform/modules/stack/base/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }

--- a/terraform/modules/vpc_peering/versions.tf
+++ b/terraform/modules/vpc_peering/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">=4.4.0"
+      version               = "< 5.0.0"
       configuration_aliases = [aws, aws.tooling]
     }
   }

--- a/terraform/modules/vpc_peering_sg/versions.tf
+++ b/terraform/modules/vpc_peering_sg/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">=4.4.0"
+      version               = "< 5.0.0"
       configuration_aliases = [aws]
     }
   }

--- a/terraform/stacks/main/versions.tf
+++ b/terraform/stacks/main/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.4.0"
+      version = "< 5.0.0"
     }
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- switch possible versions to <5.0.0 for version
-
-

## security considerations
Many Improvements, this major release of terraform from 4 to 5 include retiring of old instances, edits to multiple providers and changes to tags. More shown [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade)
