### PR TITLE
Removing unneeded bucket and kms key for credhub backups

### DIFF
--- a/terraform/modules/iam_role_policy/concourse_worker/policy.json
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.json
@@ -45,9 +45,7 @@
         "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}",
         "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}/*",
         "arn:${aws_partition}:s3:::${container_scanning_bucket_name}",
-        "arn:${aws_partition}:s3:::${container_scanning_bucket_name}/*",
-        "arn:${aws_partition}:s3:::${tooling_credhub_backups_bucket_name}",
-        "arn:${aws_partition}:s3:::${tooling_credhub_backups_bucket_name}/*"
+        "arn:${aws_partition}:s3:::${container_scanning_bucket_name}/*"
       ]
     },
     {
@@ -70,8 +68,7 @@
         "arn:${aws_partition}:s3:::${varz_bucket}/*-creds.yml",
         "arn:${aws_partition}:s3:::${build_artifacts_bucket}/*",
         "arn:${aws_partition}:s3:::${terraform_state_bucket}/*",
-        "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}/*",
-        "arn:${aws_partition}:s3:::${tooling_credhub_backups_bucket_name}/*"
+        "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}/*"
       ]
     }
   ]

--- a/terraform/modules/iam_role_policy/concourse_worker/policy.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.tf
@@ -16,7 +16,6 @@ data "template_file" "policy" {
     concourse_varz_bucket               = var.concourse_varz_bucket
     pgp_keys_bucket_name                = var.pgp_keys_bucket_name
     container_scanning_bucket_name      = var.container_scanning_bucket_name
-    tooling_credhub_backups_bucket_name = var.tooling_credhub_backups_bucket_name
   }
 }
 

--- a/terraform/modules/iam_role_policy/concourse_worker/policy.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.tf
@@ -2,20 +2,20 @@ data "template_file" "policy" {
   template = file("${path.module}/policy.json")
 
   vars = {
-    aws_partition                       = var.aws_partition
-    varz_bucket                         = var.varz_bucket
-    varz_staging_bucket                 = var.varz_staging_bucket
-    bosh_release_bucket                 = var.bosh_release_bucket
-    build_artifacts_bucket              = var.build_artifacts_bucket
-    terraform_state_bucket              = var.terraform_state_bucket
-    semver_bucket                       = var.semver_bucket
-    buildpack_notify_bucket             = var.buildpack_notify_bucket
-    billing_bucket                      = var.billing_bucket
-    cg_binaries_bucket                  = var.cg_binaries_bucket
-    log_bucket                          = var.log_bucket
-    concourse_varz_bucket               = var.concourse_varz_bucket
-    pgp_keys_bucket_name                = var.pgp_keys_bucket_name
-    container_scanning_bucket_name      = var.container_scanning_bucket_name
+    aws_partition                  = var.aws_partition
+    varz_bucket                    = var.varz_bucket
+    varz_staging_bucket            = var.varz_staging_bucket
+    bosh_release_bucket            = var.bosh_release_bucket
+    build_artifacts_bucket         = var.build_artifacts_bucket
+    terraform_state_bucket         = var.terraform_state_bucket
+    semver_bucket                  = var.semver_bucket
+    buildpack_notify_bucket        = var.buildpack_notify_bucket
+    billing_bucket                 = var.billing_bucket
+    cg_binaries_bucket             = var.cg_binaries_bucket
+    log_bucket                     = var.log_bucket
+    concourse_varz_bucket          = var.concourse_varz_bucket
+    pgp_keys_bucket_name           = var.pgp_keys_bucket_name
+    container_scanning_bucket_name = var.container_scanning_bucket_name
   }
 }
 

--- a/terraform/modules/iam_role_policy/concourse_worker/variables.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/variables.tf
@@ -47,7 +47,3 @@ variable "container_scanning_bucket_name" {
   description = "Name of S3 bucket for container scanning config"
 }
 
-variable "tooling_credhub_backups_bucket_name" {
-  type        = string
-  description = "Name of S3 bucket for Credhub Tooling backups"
-}

--- a/terraform/stacks/tooling/buckets.tf
+++ b/terraform/stacks/tooling/buckets.tf
@@ -73,11 +73,4 @@ module "container_scanning_bucket" {
   versioning    = "true"
 }
 
-module "credhub_backups_bucket" {
-  source                   = "../../modules/s3_bucket/kms_encrypted_bucket"
-  bucket_name              = "${var.stack_description}-credhub-backups"
-  aws_partition            = data.aws_partition.current.partition
-  region                   = data.aws_region.current.name
-  kms_account_id           = data.aws_caller_identity.current.account_id
-  enable_bucket_versioning = true
-}
+

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -60,22 +60,22 @@ module "bosh_compilation_policy" {
 }
 
 module "concourse_worker_policy" {
-  source                              = "../../modules/iam_role_policy/concourse_worker"
-  policy_name                         = "concourse-worker"
-  aws_partition                       = data.aws_partition.current.partition
-  varz_bucket                         = var.varz_bucket
-  varz_staging_bucket                 = var.varz_bucket_stage
-  bosh_release_bucket                 = var.bosh_release_bucket
-  terraform_state_bucket              = var.terraform_state_bucket
-  build_artifacts_bucket              = var.build_artifacts_bucket
-  semver_bucket                       = var.semver_bucket
-  buildpack_notify_bucket             = var.buildpack_notify_bucket
-  billing_bucket                      = var.billing_bucket
-  cg_binaries_bucket                  = var.cg_binaries_bucket
-  log_bucket                          = var.log_bucket_name
-  concourse_varz_bucket               = var.concourse_varz_bucket
-  pgp_keys_bucket_name                = var.pgp_keys_bucket_name
-  container_scanning_bucket_name      = var.container_scanning_bucket_name
+  source                         = "../../modules/iam_role_policy/concourse_worker"
+  policy_name                    = "concourse-worker"
+  aws_partition                  = data.aws_partition.current.partition
+  varz_bucket                    = var.varz_bucket
+  varz_staging_bucket            = var.varz_bucket_stage
+  bosh_release_bucket            = var.bosh_release_bucket
+  terraform_state_bucket         = var.terraform_state_bucket
+  build_artifacts_bucket         = var.build_artifacts_bucket
+  semver_bucket                  = var.semver_bucket
+  buildpack_notify_bucket        = var.buildpack_notify_bucket
+  billing_bucket                 = var.billing_bucket
+  cg_binaries_bucket             = var.cg_binaries_bucket
+  log_bucket                     = var.log_bucket_name
+  concourse_varz_bucket          = var.concourse_varz_bucket
+  pgp_keys_bucket_name           = var.pgp_keys_bucket_name
+  container_scanning_bucket_name = var.container_scanning_bucket_name
 }
 
 module "concourse_iaas_worker_policy" {

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -76,7 +76,6 @@ module "concourse_worker_policy" {
   concourse_varz_bucket               = var.concourse_varz_bucket
   pgp_keys_bucket_name                = var.pgp_keys_bucket_name
   container_scanning_bucket_name      = var.container_scanning_bucket_name
-  tooling_credhub_backups_bucket_name = module.credhub_backups_bucket.bucket_name
 }
 
 module "concourse_iaas_worker_policy" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes bucket and kms key for credhub exports, redundant since these are backed up in RDS
-
-

## security considerations
Removes flagged KMS key
