### PR TITLE
remove permissive KMS key policy

### DIFF
--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
@@ -2,24 +2,6 @@ data "aws_iam_policy_document" "kms_key_policy" {
   source_policy_documents = var.source_kms_key_policy_documents
 
   statement {
-    sid    = "Enable IAM User Permissions"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:${var.aws_partition}:iam::${var.kms_account_id}:root"]
-    }
-
-    actions = [
-      "kms:*"
-    ]
-
-    resources = [
-      "*"
-    ]
-  }
-
-  statement {
     sid    = "Allow access for Key Administrators"
     effect = "Allow"
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove permissive KMS key policy

## security considerations

This improves security by removing an overly permissive statement in the KMS key policies. [This policy did come from the "default key policy" specified in the AWS documentation](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam), however it may not be necessary for our purposes
