### PR TITLE
Enabled S3 access logging for the cg-s3-cloudtrail bucket for s3-audit-logs trail.

### DIFF
--- a/terraform/stacks/tooling/s3-logs.tf
+++ b/terraform/stacks/tooling/s3-logs.tf
@@ -8,8 +8,8 @@ resource "aws_s3_bucket" "cg-s3-cloudtrail-bucket" {
 }
 
 resource "aws_s3_bucket" "cloudtrail_accesslog_bucket" {
-  bucket        = var.cloudtrail_accesslog_bucket
-  acl           = "log-delivery-write"
+  bucket = var.cloudtrail_accesslog_bucket
+  acl    = "log-delivery-write"
 
   logging {
     target_bucket = var.cloudtrail_accesslog_bucket

--- a/terraform/stacks/tooling/s3-logs.tf
+++ b/terraform/stacks/tooling/s3-logs.tf
@@ -1,6 +1,20 @@
 resource "aws_s3_bucket" "cg-s3-cloudtrail-bucket" {
   bucket        = var.cloudtrail_bucket
   force_destroy = true
+  logging {
+    target_bucket = "${aws_s3_bucket.cloudtrail_accesslog_bucket.id}"
+    target_prefix = "log/"
+  }
+}
+
+resource "aws_s3_bucket" "cloudtrail_accesslog_bucket" {
+  bucket        = var.cloudtrail_accesslog_bucket
+  acl           = "log-delivery-write"
+
+  logging {
+    target_bucket = var.cloudtrail_accesslog_bucket
+    target_prefix = "log/"
+  }
 }
 
 resource "aws_s3_bucket_policy" "cloudtrail_bucket_policy" {
@@ -29,6 +43,25 @@ resource "aws_s3_bucket_policy" "cloudtrail_bucket_policy" {
             "Condition": {
                 "StringEquals": {
                     "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        },
+        {
+            "Sid": "S3ServerAccessLogsPolicy",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "logging.s3.amazonaws.com"
+            },
+            "Action": [
+                "s3:PutObject"
+            ],
+            "Resource": "arn:${data.aws_partition.current.partition}:s3:::${var.cloudtrail_accesslog_bucket}/log/*",
+            "Condition": {
+                "ArnLike": {
+                    "aws:SourceArn": "arn:${data.aws_partition.current.partition}:s3:::${var.cloudtrail_bucket}"
+                },
+                "StringEquals": {
+                    "aws:SourceAccount": “${data.aws_caller_identity.current.account_id}"
                 }
             }
         }

--- a/terraform/stacks/tooling/s3-logs.tf
+++ b/terraform/stacks/tooling/s3-logs.tf
@@ -2,7 +2,7 @@ resource "aws_s3_bucket" "cg-s3-cloudtrail-bucket" {
   bucket        = var.cloudtrail_bucket
   force_destroy = true
   logging {
-    target_bucket = "${aws_s3_bucket.cloudtrail_accesslog_bucket.id}"
+    target_bucket = var.cloudtrail_accesslog_bucket
     target_prefix = "log/"
   }
 }

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -162,6 +162,10 @@ variable "cloudtrail_bucket" {
   default = "cg-s3-cloudtrail"
 }
 
+variable "cloudtrail_accesslog_bucket" {
+  default = "cloud-gov-organization-cloudtrail-logs-archive"
+}
+
 variable "log_bucket_name" {
   default = "cg-elb-logs"
 }


### PR DESCRIPTION
	modified:   terraform/stacks/tooling/variables.tf
Enabled S3 access logging for the cg-s3-cloudtrail bucket for s3-audit-logs trail.

## Changes proposed in this pull request:
- Enabled S3 access logging for the cg-s3-cloudtrail bucket for s3-audit-logs trail.
- Added a new bucket to log access logs for the cg-s3-cloudtrail bucket
- Fixed tf format for the target bucket.

## security considerations
This change will allow us to monitor access logging for our trail buckets and resolves an open POAM.