### PR TITLE
update log encrypted bucket module 

### DIFF
--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
@@ -2,6 +2,34 @@ data "aws_iam_policy_document" "kms_key_policy" {
   source_policy_documents = var.source_kms_key_policy_documents
 
   statement {
+    sid    = "Deployment Permissions"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.deployment_arn]
+    }
+
+    actions = [
+      "kms:DescribeKey",
+      "kms:GetKeyPolicy",
+      "kms:GetKeyRotationStatus",
+      "kms:ListResourceTags",
+      "kms:PutKeyPolicy"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:CallerAccount"
+      values   = [var.kms_account_id]
+    }
+  }
+
+  statement {
     sid    = "Allow access for Key Administrators"
     effect = "Allow"
 

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
@@ -2,12 +2,12 @@ data "aws_iam_policy_document" "kms_key_policy" {
   source_policy_documents = var.source_kms_key_policy_documents
 
   statement {
-    sid    = "Deployment Permissions"
+    sid    = "Deployer Permissions"
     effect = "Allow"
 
     principals {
       type        = "AWS"
-      identifiers = [var.deployment_arn]
+      identifiers = [var.deployer_arn]
     }
 
     actions = [

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/kms.tf
@@ -2,20 +2,27 @@ data "aws_iam_policy_document" "kms_key_policy" {
   source_policy_documents = var.source_kms_key_policy_documents
 
   statement {
-    sid    = "Deployer Permissions"
+    sid    = "Enable IAM User Permissions"
     effect = "Allow"
 
     principals {
       type        = "AWS"
-      identifiers = [var.deployer_arn]
+      identifiers = ["arn:${var.aws_partition}:iam::${var.kms_account_id}:root"]
     }
 
     actions = [
-      "kms:DescribeKey",
-      "kms:GetKeyPolicy",
-      "kms:GetKeyRotationStatus",
-      "kms:ListResourceTags",
-      "kms:PutKeyPolicy"
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion"
     ]
 
     resources = [

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -111,3 +111,8 @@ variable "object_ownership" {
   default     = ""
   description = "Object ownership strategy to use for S3 bucket"
 }
+
+variable "deployment_arn" {
+  type = string
+  default = ""
+}

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -113,6 +113,6 @@ variable "object_ownership" {
 }
 
 variable "deployer_arn" {
-  type    = string
+  type        = string
   description = "ARN of IAM resource that needs permissions to manage the KMS key"
 }

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -111,8 +111,3 @@ variable "object_ownership" {
   default     = ""
   description = "Object ownership strategy to use for S3 bucket"
 }
-
-variable "deployer_arn" {
-  type        = string
-  description = "ARN of IAM resource that needs permissions to manage the KMS key"
-}

--- a/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/kms_encrypted_bucket/variables.tf
@@ -112,7 +112,7 @@ variable "object_ownership" {
   description = "Object ownership strategy to use for S3 bucket"
 }
 
-variable "deployment_arn" {
-  type = string
-  default = ""
+variable "deployer_arn" {
+  type    = string
+  description = "ARN of IAM resource that needs permissions to manage the KMS key"
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -66,3 +66,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
     }
   }
 }
+
+resource "aws_s3_bucket_logging" "log_encrypted_bucket_access_logging" {
+  count = var.access_logging_target_bucket != "" ? 1 : 0
+  bucket = aws_s3_bucket.log_encrypted_bucket.id
+  target_bucket = var.access_logging_target_bucket
+  target_prefix = var.access_logging_target_bucket_prefix
+}

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -68,7 +68,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
 }
 
 resource "aws_s3_bucket_logging" "log_encrypted_bucket_access_logging" {
-  count         = var.access_logging_target_bucket != "" && var.access_logging_target_bucket_prefix != "" ? 1 : 0
+  count         = var.access_logging_target_bucket != "" ? 1 : 0
   bucket        = aws_s3_bucket.log_encrypted_bucket.id
   target_bucket = var.access_logging_target_bucket
   target_prefix = var.access_logging_target_bucket_prefix

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -3,6 +3,14 @@ resource "aws_s3_bucket" "log_encrypted_bucket" {
   force_destroy = var.force_destroy
 }
 
+resource "aws_s3_bucket_public_access_block" "log_encrypted_bucket_block_public" {
+  bucket = aws_s3_bucket.log_encrypted_bucket.id
+
+  block_public_acls       = var.block_public_acls
+  block_public_policy     = var.block_public_policy
+  ignore_public_acls      = var.ignore_public_acls
+  restrict_public_buckets = var.restrict_public_buckets
+}
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "log_encrypted_bucket_sse_config" {
   bucket = aws_s3_bucket.log_encrypted_bucket.id
@@ -10,6 +18,14 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "log_encrypted_buc
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "log_encrypted_bucket_acl_ownership" {
+  count  = var.acl != "" && var.object_ownership != "" ? 1 : 0
+  bucket = aws_s3_bucket.log_encrypted_bucket.id
+  rule {
+    object_ownership = var.object_ownership
   }
 }
 
@@ -21,6 +37,7 @@ resource "aws_s3_bucket_versioning" "log_encrypted_bucket_versioning" {
   }
 }
 resource "aws_s3_bucket_acl" "log_encrypted_bucket_acl" {
+  count = var.acl != "" ? 1 : 0
   bucket = aws_s3_bucket.log_encrypted_bucket.id
   acl    = var.acl
 }
@@ -48,29 +65,4 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
       days = var.expiration_days == 0 ? 30 : var.expiration_days
     }
   }
-}
-
-resource "aws_s3_bucket_policy" "log_encrypted_bucket_policy" {
-  count  = var.include_require_encrypted_put_bucket_policy ? 1 : 0
-  bucket = aws_s3_bucket.log_encrypted_bucket.id
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Sid": "DenyUnencryptedPut",
-        "Effect": "Deny",
-        "Principal": {
-            "AWS": "*"
-        },
-        "Action": "s3:PutObject",
-        "Resource": "arn:${var.aws_partition}:s3:::${var.bucket}/*",
-        "Condition": {
-            "StringNotEquals": {
-                "s3:x-amz-server-side-encryption": "AES256"
-            }
-        }
-    }]
-}
-EOF
-
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -68,8 +68,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
 }
 
 resource "aws_s3_bucket_logging" "log_encrypted_bucket_access_logging" {
-  count = var.access_logging_target_bucket != "" && var.access_logging_target_bucket_prefix != "" ? 1 : 0
-  bucket = aws_s3_bucket.log_encrypted_bucket.id
+  count         = var.access_logging_target_bucket != "" && var.access_logging_target_bucket_prefix != "" ? 1 : 0
+  bucket        = aws_s3_bucket.log_encrypted_bucket.id
   target_bucket = var.access_logging_target_bucket
   target_prefix = var.access_logging_target_bucket_prefix
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -37,7 +37,7 @@ resource "aws_s3_bucket_versioning" "log_encrypted_bucket_versioning" {
   }
 }
 resource "aws_s3_bucket_acl" "log_encrypted_bucket_acl" {
-  count = var.acl != "" ? 1 : 0
+  count  = var.acl != "" ? 1 : 0
   bucket = aws_s3_bucket.log_encrypted_bucket.id
   acl    = var.acl
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -68,7 +68,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
 }
 
 resource "aws_s3_bucket_logging" "log_encrypted_bucket_access_logging" {
-  count = var.access_logging_target_bucket != "" ? 1 : 0
+  count = var.access_logging_target_bucket != "" && var.access_logging_target_bucket_prefix != "" ? 1 : 0
   bucket = aws_s3_bucket.log_encrypted_bucket.id
   target_bucket = var.access_logging_target_bucket
   target_prefix = var.access_logging_target_bucket_prefix

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/outputs.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/outputs.tf
@@ -1,5 +1,5 @@
 output "bucket_name" {
-  value = aws_s3_bucket.log_encrypted_bucket.bucket
+  value = aws_s3_bucket.log_encrypted_bucket.id
 }
 
 output "bucket_arn" {

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
@@ -1,5 +1,5 @@
 data "aws_iam_policy_document" "log_encrypted_bucket_deny_unencrypted_policy" {
-  count                   = var.include_require_encrypted_put_bucket_policy ? 1 : 0
+  count = var.include_require_encrypted_put_bucket_policy ? 1 : 0
 
   statement {
     sid    = "DenyUnencryptedPut"

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
@@ -1,6 +1,5 @@
 data "aws_iam_policy_document" "log_encrypted_bucket_deny_unencrypted_policy" {
   count                   = var.include_require_encrypted_put_bucket_policy ? 1 : 0
-  source_policy_documents = var.source_bucket_policy_documents
 
   statement {
     sid    = "DenyUnencryptedPut"

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "log_encrypted_bucket_deny_unencrypted_policy" {
+  count  = var.include_require_encrypted_put_bucket_policy ? 1 : 0
+  source_policy_documents = var.source_bucket_policy_documents
+
+  statement {
+    sid    = "DenyUnencryptedPut"
+    effect = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:${var.aws_partition}:s3:::${aws_s3_bucket.log_encrypted_bucket.id}/*"
+    ]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["AES:256"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "log_encrypted_bucket_policy" {
+  count  = var.include_require_encrypted_put_bucket_policy || length(var.source_bucket_policy_documents) > 0 ? 1 : 0
+  source_policy_documents = concat(
+    var.source_bucket_policy_documents,
+    var.include_require_encrypted_put_bucket_policy ? [data.aws_iam_policy_document.log_encrypted_bucket_deny_unencrypted_policy.json] : []
+  )
+}
+
+resource "aws_s3_bucket_policy" "log_encrypted_bucket_policy" {
+  count  = var.include_require_encrypted_put_bucket_policy || length(var.source_bucket_policy_documents) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.log_encrypted_bucket.id
+  policy = data.aws_iam_policy_document.log_encrypted_bucket_policy.json
+}

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
@@ -1,5 +1,5 @@
 data "aws_iam_policy_document" "log_encrypted_bucket_deny_unencrypted_policy" {
-  count  = var.include_require_encrypted_put_bucket_policy ? 1 : 0
+  count                   = var.include_require_encrypted_put_bucket_policy ? 1 : 0
   source_policy_documents = var.source_bucket_policy_documents
 
   statement {
@@ -28,10 +28,10 @@ data "aws_iam_policy_document" "log_encrypted_bucket_deny_unencrypted_policy" {
 }
 
 data "aws_iam_policy_document" "log_encrypted_bucket_policy" {
-  count  = var.include_require_encrypted_put_bucket_policy || length(var.source_bucket_policy_documents) > 0 ? 1 : 0
+  count = var.include_require_encrypted_put_bucket_policy || length(var.source_bucket_policy_documents) > 0 ? 1 : 0
   source_policy_documents = concat(
     var.source_bucket_policy_documents,
-    var.include_require_encrypted_put_bucket_policy ? [data.aws_iam_policy_document.log_encrypted_bucket_deny_unencrypted_policy.json] : []
+    var.include_require_encrypted_put_bucket_policy ? [data.aws_iam_policy_document.log_encrypted_bucket_deny_unencrypted_policy[0].json] : []
   )
 }
 

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/policy.tf
@@ -38,5 +38,5 @@ data "aws_iam_policy_document" "log_encrypted_bucket_policy" {
 resource "aws_s3_bucket_policy" "log_encrypted_bucket_policy" {
   count  = var.include_require_encrypted_put_bucket_policy || length(var.source_bucket_policy_documents) > 0 ? 1 : 0
   bucket = aws_s3_bucket.log_encrypted_bucket.id
-  policy = data.aws_iam_policy_document.log_encrypted_bucket_policy.json
+  policy = data.aws_iam_policy_document.log_encrypted_bucket_policy[0].json
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
@@ -2,7 +2,7 @@ variable "bucket" {
 }
 
 variable "acl" {
-  default = "private"
+  default = ""
 }
 
 variable "versioning" {
@@ -24,5 +24,41 @@ variable "include_require_encrypted_put_bucket_policy" {
   description = "True to include bucket policy to required encrypted PUTs"
   type        = bool
   default     = true
+}
+
+variable "source_bucket_policy_documents" {
+  description = "IAM policy documents to include in the S3 bucket policy"
+  type        = list(string)
+  default     = []
+}
+
+variable "block_public_acls" {
+  description = "Whether Amazon S3 should block public ACLs for this bucket"
+  type        = bool
+  default     = true
+}
+
+variable "block_public_policy" {
+  description = "Whether Amazon S3 should block public bucket policies for this bucket"
+  type        = bool
+  default     = true
+}
+
+variable "ignore_public_acls" {
+  description = "Whether Amazon S3 should ignore public ACLs for this bucket."
+  type        = bool
+  default     = true
+}
+
+variable "restrict_public_buckets" {
+  type        = bool
+  description = "Whether Amazon S3 should restrict public bucket policies for this bucket"
+  default     = true
+}
+
+variable "object_ownership" {
+  type        = string
+  default     = ""
+  description = "Object ownership strategy to use for S3 bucket"
 }
 

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
@@ -58,7 +58,7 @@ variable "restrict_public_buckets" {
 
 variable "object_ownership" {
   type        = string
-  default     = ""
+  default     = "BucketOwnerPreferred"
   description = "Object ownership strategy to use for S3 bucket"
 }
 

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
@@ -62,3 +62,14 @@ variable "object_ownership" {
   description = "Object ownership strategy to use for S3 bucket"
 }
 
+variable "access_logging_target_bucket" {
+  type = string
+  default = ""
+  description = "Target S3 bucket name to use for access logging of bucket created by this module"
+}
+
+variable "access_logging_target_bucket_prefix" {
+  type = string
+  default = null
+  description = "Prefix to use when writing access logs of bucket created by this module. Requires access_logging_target_bucket to be set."
+}

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
@@ -70,6 +70,6 @@ variable "access_logging_target_bucket" {
 
 variable "access_logging_target_bucket_prefix" {
   type = string
-  default = null
+  default = ""
   description = "Prefix to use when writing access logs of bucket created by this module. Requires access_logging_target_bucket to be set."
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/variables.tf
@@ -63,13 +63,13 @@ variable "object_ownership" {
 }
 
 variable "access_logging_target_bucket" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Target S3 bucket name to use for access logging of bucket created by this module"
 }
 
 variable "access_logging_target_bucket_prefix" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Prefix to use when writing access logs of bucket created by this module. Requires access_logging_target_bucket to be set."
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

update log encrypted bucket module to support:

- blocking public access
- setting object ownership
- passing in custom policy documents to apply to bucket policy

## security considerations

These changes:

- ensure that we can block public bucket access entirely
- allow us to use object ownership `BucketOwnerEnforced` and ignore ACLs entirely as per AWS recommendation
