### PR TITLE
Reserve fix

### DIFF
--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -375,5 +375,5 @@ data "dns_a_record_set" "domains-internal-lb_ips" {
 }
 
 output "domains-internal-ips" {
-  value = join(",", data.dns_a_record_set.domains-internal-lb_ips.addrs)
+  value = data.dns_a_record_set.domains-internal-lb_ips.addrs
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -371,7 +371,7 @@ output "domains_broker_profile" {
 
 
 data "dns_a_record_set" "domains-internal-lb_ips" {
-  host = aws_lb.var.stack_description-domains-internal.dns_name
+  host = aws_lb.domains_broker_internal.dns_name
 }
 
 output "domains-internal-ips" {

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -377,3 +377,13 @@ data "dns_a_record_set" "domains-internal-lb_ips" {
 output "domains-internal-ips" {
   value = data.dns_a_record_set.domains-internal-lb_ips.addrs
 }
+
+output "domains-internal-ip-az1" {
+  services-az1-net  = module.cf.services_cidr_1
+  value = ${ cidrhost(module.cf.services_cidr_1,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}
+}
+
+output "domains-internal-ip-az2" {
+  services-az2-net  = module.cf.services_cidr_2
+  value = ${ cidrhost(module.cf.services_cidr_2,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}
+}

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -380,10 +380,10 @@ output "domains-internal-ips" {
 
 output "domains-internal-ip-az1" {
   services-az1-net  = module.cf.services_cidr_1
-  value = ${ cidrhost(module.cf.services_cidr_1,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}
+  value = "${ cidrhost(module.cf.services_cidr_1,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}"
 }
 
 output "domains-internal-ip-az2" {
   services-az2-net  = module.cf.services_cidr_2
-  value = ${ cidrhost(module.cf.services_cidr_2,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}
+  value = "${ cidrhost(module.cf.services_cidr_2,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -389,5 +389,5 @@ output "domains-internal-ip-az1" {
 }
 
 output "domains-internal-ip-az2" {
-  value = "${ cidrhost(local.services-az2-net,1) == cidrhost("${local.domain-lb-ips[1]}/24",0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
+  value = "${ cidrhost(local.services-az2-net,0) == cidrhost("${local.domain-lb-ips[1]}/24",0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -381,7 +381,7 @@ locals {
 
 output "domains-internal-ip-az1" {
   value = cidrhost(local.services-az1-net, 0) == cidrhost("${local.domain-lb-ips[0]}/24", 0) ? local.domain-lb-ips[0] : local.domain-lb-ips[1]
-
+}
 output "domains-internal-ip-az2" {
   value = cidrhost(local.services-az2-net, 0) == cidrhost("${local.domain-lb-ips[1]}/24", 0) ? local.domain-lb-ips[1] : local.domain-lb-ips[0]
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -385,9 +385,9 @@ locals {
 }
 
 output "domains-internal-ip-az1" {
-  value = "${ cidrhost(local.services-az1-net,0) == cidrhost("${local.domain-lb-ips[0]}/24",0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}"
+  value = "${ cidrhost(local.services-az1-net,0) == cidrhost("${local.domain-lb-ips[0]}/24",0) ? local.domain-lb-ips[0] : local.domain-lb-ips[1]}"
 }
 
 output "domains-internal-ip-az2" {
-  value = "${ cidrhost(local.services-az2-net,0) == cidrhost("${local.domain-lb-ips[1]}/24",0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
+  value = "${ cidrhost(local.services-az2-net,0) == cidrhost("${local.domain-lb-ips[1]}/24",0) ? local.domain-lb-ips[1] : local.domain-lb-ips[0]}"
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -389,5 +389,5 @@ output "domains-internal-ip-az1" {
 }
 
 output "domains-internal-ip-az2" {
-  value = "${ cidrhost(local.services-az1-net,1) == cidrhost("${local.domain-lb-ips[1]}/24",0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
+  value = "${ cidrhost(local.services-az2-net,1) == cidrhost("${local.domain-lb-ips[1]}/24",0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -385,9 +385,9 @@ locals {
 }
 
 output "domains-internal-ip-az1" {
-  value = "${ cidrhost(local.services-az1-net,0) == cidrhost(local.domain-lb-ips[0],0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}"
+  value = "${ cidrhost(local.services-az1-net,0) == cidrhost("${local.domain-lb-ips[0]}/24",0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}"
 }
 
 output "domains-internal-ip-az2" {
-  value = "${ cidrhost(local.services-az1-net,1) == cidrhost(local.domain-lb-ips[1],0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
+  value = "${ cidrhost(local.services-az1-net,1) == cidrhost("${local.domain-lb-ips[1]}/24",0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -368,3 +368,12 @@ output "legacy_domain_certificate_renewer_secret_access_key_curr" {
 output "domains_broker_profile" {
   value = aws_iam_instance_profile.domains_broker.name
 }
+
+
+data "dns_a_record_set"  {
+  host = aws_lb."${var.stack_description}-domains-internal".dns_name
+}
+
+output "${var.stack_description}-domains-internal-ips" {
+  value = join(",", data.dns_a_record_set."${var.stack_description}-domains-internal-lb_ips".addrs)
+}

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -370,7 +370,7 @@ output "domains_broker_profile" {
 }
 
 
-data "dns_a_record_set"  {
+data "dns_a_record_set" "${var.stack_description}-domains-internal-lb_ips" {
   host = aws_lb."${var.stack_description}-domains-internal".dns_name
 }
 

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -374,10 +374,6 @@ data "dns_a_record_set" "domains-internal-lb_ips" {
   host = aws_lb.domains_broker_internal.dns_name
 }
 
-output "domains-internal-ips" {
-  value = data.dns_a_record_set.domains-internal-lb_ips.addrs
-}
-
 locals {
   services-az1-net  = module.cf.services_cidr_1
   services-az2-net  = module.cf.services_cidr_2

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -370,10 +370,10 @@ output "domains_broker_profile" {
 }
 
 
-data "dns_a_record_set" "${var.stack_description}-domains-internal-lb_ips" {
-  host = aws_lb."${var.stack_description}-domains-internal".dns_name
+data "dns_a_record_set" "domains-internal-lb_ips" {
+  host = aws_lb.var.stack_description-domains-internal.dns_name
 }
 
-output "${var.stack_description}-domains-internal-ips" {
-  value = join(",", data.dns_a_record_set."${var.stack_description}-domains-internal-lb_ips".addrs)
+output "domains-internal-ips" {
+  value = join(",", data.dns_a_record_set.domains-internal-lb_ips.addrs)
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -369,21 +369,19 @@ output "domains_broker_profile" {
   value = aws_iam_instance_profile.domains_broker.name
 }
 
-
 data "dns_a_record_set" "domains-internal-lb_ips" {
   host = aws_lb.domains_broker_internal.dns_name
 }
 
 locals {
-  services-az1-net  = module.cf.services_cidr_1
-  services-az2-net  = module.cf.services_cidr_2
-  domain-lb-ips     = data.dns_a_record_set.domains-internal-lb_ips.addrs
+  services-az1-net = module.cf.services_cidr_1
+  services-az2-net = module.cf.services_cidr_2
+  domain-lb-ips    = data.dns_a_record_set.domains-internal-lb_ips.addrs
 }
 
 output "domains-internal-ip-az1" {
-  value = "${ cidrhost(local.services-az1-net,0) == cidrhost("${local.domain-lb-ips[0]}/24",0) ? local.domain-lb-ips[0] : local.domain-lb-ips[1]}"
-}
+  value = cidrhost(local.services-az1-net, 0) == cidrhost("${local.domain-lb-ips[0]}/24", 0) ? local.domain-lb-ips[0] : local.domain-lb-ips[1]
 
 output "domains-internal-ip-az2" {
-  value = "${ cidrhost(local.services-az2-net,0) == cidrhost("${local.domain-lb-ips[1]}/24",0) ? local.domain-lb-ips[1] : local.domain-lb-ips[0]}"
+  value = cidrhost(local.services-az2-net, 0) == cidrhost("${local.domain-lb-ips[1]}/24", 0) ? local.domain-lb-ips[1] : local.domain-lb-ips[0]
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -381,12 +381,13 @@ output "domains-internal-ips" {
 locals {
   services-az1-net  = module.cf.services_cidr_1
   services-az2-net  = module.cf.services_cidr_2
+  domain-lb-ips     = data.dns_a_record_set.domains-internal-lb_ips.addrs
 }
 
 output "domains-internal-ip-az1" {
-  value = "${ cidrhost(local.services-az1-net,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}"
+  value = "${ cidrhost(local.services-az1-net,0) == cidrhost(local.domain-lb-ips[0],0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}"
 }
 
 output "domains-internal-ip-az2" {
-  value = "${ cidrhost(local.services-az1-net,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
+  value = "${ cidrhost(local.services-az1-net,1) == cidrhost(local.domain-lb-ips[1],0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
 }

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -378,12 +378,15 @@ output "domains-internal-ips" {
   value = data.dns_a_record_set.domains-internal-lb_ips.addrs
 }
 
-output "domains-internal-ip-az1" {
+locals {
   services-az1-net  = module.cf.services_cidr_1
-  value = "${ cidrhost(module.cf.services_cidr_1,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}"
+  services-az2-net  = module.cf.services_cidr_2
+}
+
+output "domains-internal-ip-az1" {
+  value = "${ cidrhost(local.services-az1-net,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az1" : "slot0_is_not_in_az1"}"
 }
 
 output "domains-internal-ip-az2" {
-  services-az2-net  = module.cf.services_cidr_2
-  value = "${ cidrhost(module.cf.services_cidr_2,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
+  value = "${ cidrhost(local.services-az1-net,0) == cidrhost(domains-internal-ips[0],0) ? "slot0_is_in_az2" : "slot0_is_not_in_az2"}"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add in logic to extract and output internal domain broker lb IPs to be used in bosh cloud-config in reserve range

## Notes
When you create an internal lb, AWS randomly picks IPs from each subnet you supply - you can't specify which IP to use so this code gets that IP and adds it to the reserved range in BOSH's cloud-config so BOSH does not try to use it in VM assignment.

## security considerations
n/a

