### PR TITLE
updating python image used for cert provision

### DIFF
--- a/ci/provision-certificate.yml
+++ b/ci/provision-certificate.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: python
-    tag: "3.6-buster"
+    tag: "3.7-buster"
 
 inputs:
 - name: cg-provision-repo


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updating image used for certbot provision to update some internal libraries to resolve some x509 errors

## security considerations
But keeping up to date on images we run the latest code bases and lessen impact of CVEs
