### PR TITLE
Change to concourse worker role, AWS requires self reference going forward

### DIFF
--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -140,10 +140,10 @@ module "concourse_iaas_worker_role" {
     "Statement": [
       {
         "Action": "sts:AssumeRole",
-  	    "Principal": {
+        "Principal": {
           "AWS":  "arn:${var.partition}:iam::${var.account_id}:role/bosh-passed/tooling-concourse-iaas-worker",
-  	  	  "Service": "ec2.amazonaws.com"
-  	    },
+          "Service": "ec2.amazonaws.com"
+        },
         "Effect": "Allow"
       }
     ]

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -133,8 +133,21 @@ module "concourse_worker_role" {
 }
 
 module "concourse_iaas_worker_role" {
-  source    = "../../modules/iam_role"
-  role_name = "tooling-concourse-iaas-worker"
+  source                 = "../../modules/iam_role"
+  role_name              = "tooling-concourse-iaas-worker"
+  iam_assume_role_policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+  	    "Principal": {
+          "AWS":  "arn:${var.partition}:iam::${var.account_id}:role/bosh-passed/tooling-concourse-iaas-worker",
+  	  	  "Service": "ec2.amazonaws.com"
+  	    },
+        "Effect": "Allow"
+      }
+    ]
+  })
 }
 
 resource "aws_iam_policy_attachment" "blobstore" {

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -141,7 +141,7 @@ module "concourse_iaas_worker_role" {
       {
         "Action": "sts:AssumeRole",
         "Principal": {
-          "AWS":  "arn:${var.partition}:iam::${var.account_id}:role/bosh-passed/tooling-concourse-iaas-worker",
+          "AWS":  "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/bosh-passed/tooling-concourse-iaas-worker",
           "Service": "ec2.amazonaws.com"
         },
         "Effect": "Allow"

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -133,18 +133,18 @@ module "concourse_worker_role" {
 }
 
 module "concourse_iaas_worker_role" {
-  source                 = "../../modules/iam_role"
-  role_name              = "tooling-concourse-iaas-worker"
+  source    = "../../modules/iam_role"
+  role_name = "tooling-concourse-iaas-worker"
   iam_assume_role_policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Action": "sts:AssumeRole",
-        "Principal": {
-          "AWS":  "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/bosh-passed/tooling-concourse-iaas-worker",
-          "Service": "ec2.amazonaws.com"
+        "Action" : "sts:AssumeRole",
+        "Principal" : {
+          "AWS" : "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/bosh-passed/tooling-concourse-iaas-worker",
+          "Service" : "ec2.amazonaws.com"
         },
-        "Effect": "Allow"
+        "Effect" : "Allow"
       }
     ]
   })


### PR DESCRIPTION
## Changes proposed in this pull request:
- For `tooling-concourse-iaas-worker` supply an IAM role policy instead of using the default one to reference itself 
-
-

## security considerations
This is needed as a result of [https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/)
