### PR TITLE
Force 2048 key size

### DIFF
--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -33,7 +33,9 @@ certbot certonly \
   --dns-route53 \
   --config-dir "${config_path}" \
   --email "${EMAIL}" \
-  --domain "${DOMAIN}"
+  --domain "${DOMAIN}" \
+  --rsa-key-size 2048 \
+  --key-type rsa 
 
 out_path=$(ls -d -1 ${config_path}/live/*/)
 cp ${out_path}/*.pem acme


### PR DESCRIPTION
## Changes proposed in this pull request:
- Should be a fix to force 2048 RSA for the newer version of certbot
-
-

## security considerations
Same cert length and type as what used to be the default
