### PR TITLE
Hard coding versions of certbot, avoid pain

### DIFF
--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -5,7 +5,8 @@ set -eu
 curl -L -o jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
 chmod +x ./jq
 
-pip install certbot certbot-dns-route53
+pip install certbot==2.6.0 
+pip install certbot-dns-route53==2.6.0
 
 #spruce_url=$(curl https://api.github.com/repos/geofffranks/spruce/releases/latest \
 #  | ./jq -r '.assets[] | select(.name == "spruce-linux-amd64") | .browser_download_url')


### PR DESCRIPTION
## Changes proposed in this pull request:
- Hard coded certbot to 2.6.0 to avoid changes to default cert creation options
-
-

## security considerations
Helps to enforce RSA 2048 Letsencrypt certs
