### PR TITLE
adding cert/key check to provision script

### DIFF
--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -40,3 +40,22 @@ certbot certonly \
 
 out_path=$(ls -d -1 ${config_path}/live/*/)
 cp ${out_path}/*.pem acme
+
+# Before provision exit - check that certificate and key are RSA based and 2048 bit length - if not error out task
+
+CERT_CHECK=$(cat acme/cert.pem | openssl x509 -text -noout | grep "Public-Key")
+KEY_CHECK=$(cat acme/privkey.pem | openssl rsa -text -noout | grep "Private-Key")
+
+if [[ "$CERT_CHECK" == *"2048 bit"* ]]; then
+    echo  "Certificate is 2048 bit and good"
+    else
+    echo "Certificate failed 2048 bit check and is bad/corrupt"
+    exit 1
+fi
+
+if [[ "$KEY_CHECK" == *"RSA Private"* ]]; then
+    echo  "Key is RSA based and good"
+    else
+    echo "Key is NOT RSA based and is bad/corrupt"
+    exit 1
+fi


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add cert/key check to provision cert script to error out of task before upload if generated cert/key are not RSA 2048


## Notes
This change is a extra gate to make sure if `certbot` and/or Let's Encrypt change the default generated certificate type/bit length. `certbot` `2.x` switched default from `RSA` to `EDSCA` which is not widely supported yet in most code bases

## security considerations
Making sure we generate secure and widely accepted certificates to use for the platform
