### PR TITLE
updating prod domains alb count after being out of space for new certs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -844,7 +844,7 @@ jobs:
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
       TF_VAR_shibboleth_hosts: '["idp.fr.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr.cloud.gov"]'
-      TF_VAR_domains_broker_alb_count: "8"
+      TF_VAR_domains_broker_alb_count: "10"
       TF_VAR_domains_broker_rds_username: ((production_domains_broker_rds_username))
       TF_VAR_domains_broker_rds_password: ((production_domains_broker_rds_password))
       TF_VAR_pages_cert_patterns: '["pages.cloud.gov","pages-staging.cloud.gov","pages-dev.cloud.gov"]'


### PR DESCRIPTION
## Changes proposed in this pull request:
- Increase domain ALB count from 8 to 10 to scale capacity

## security considerations
Having capacity for ALBs allows CG customers to add external domains to the platform
