### PR TITLE
Add Domain Broker RDS Encryption

### DIFF
--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -69,7 +69,7 @@ resource "aws_db_instance" "domains_broker" {
   vpc_security_group_ids      = [module.stack.rds_postgres_security_group]
   allow_major_version_upgrade = true
   backup_retention_period     = 14
-  #storage_encrypted           = true
+  storage_encrypted           = true
 }
 
 output "domains_broker_rds_username" {

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -58,7 +58,7 @@ resource "aws_db_instance" "domains_broker" {
   db_name                     = "domains_broker"
   storage_type                = "gp2"
   allocated_storage           = 10
-  instance_class              = "db.t2.micro"
+  instance_class              = "db.t2.small"
   username                    = var.domains_broker_rds_username
   password                    = var.domains_broker_rds_password
   engine                      = "postgres"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Up instance to t2.small - lowest level instance that supports encryption at test
- Turn on RDS DB encryption at rest

## security considerations
Encryption is a good thing 

# NOTE
I will not merge this until after I run through prod for the 1st pass of the [last pr](https://github.com/cloud-gov/cg-provision/pull/1473) in prod - that will take place on 6/29.  Then this can get merged and run one at a time in stage and then prod with the backup and restore steps between the two PRs.