### PR TITLE
add retention period to cloudwatch log groups

### DIFF
--- a/terraform/modules/bosh_vpc/vpc.tf
+++ b/terraform/modules/bosh_vpc/vpc.tf
@@ -18,6 +18,8 @@ resource "aws_vpc" "main_vpc" {
 # Create CloudWatch log group
 resource "aws_cloudwatch_log_group" "main_vpc_flow_log_cloudwatch_log_group" {
   name = "${var.stack_description}-flow-log-group"
+  # Lowest allowed value that fulfills M-21-31 reqs of storing for 30 months
+  retention_in_days = 1827
 }
 
 # Create IAM role for sending flow logs

--- a/terraform/modules/dns_logging/resolver_logging.tf
+++ b/terraform/modules/dns_logging/resolver_logging.tf
@@ -13,6 +13,8 @@ resource "aws_cloudwatch_log_group" "query_resolver_logs" {
 resource "aws_route53_resolver_query_log_config" "resolver_config" {
   name            = "${var.stack_description}-query-resolver-logs"
   destination_arn = aws_cloudwatch_log_group.query_resolver_logs.arn
+  # Lowest allowed value that fulfills M-21-31 reqs of storing for 30 months
+  retention_in_days = 1827
 
   tags = {
     Environment = var.stack_description

--- a/terraform/modules/dns_logging/resolver_logging.tf
+++ b/terraform/modules/dns_logging/resolver_logging.tf
@@ -13,8 +13,6 @@ resource "aws_cloudwatch_log_group" "query_resolver_logs" {
 resource "aws_route53_resolver_query_log_config" "resolver_config" {
   name            = "${var.stack_description}-query-resolver-logs"
   destination_arn = aws_cloudwatch_log_group.query_resolver_logs.arn
-  # Lowest allowed value that fulfills M-21-31 reqs of storing for 30 months
-  retention_in_days = 1827
 
   tags = {
     Environment = var.stack_description

--- a/terraform/modules/elasticsearch_broker/log_group.tf
+++ b/terraform/modules/elasticsearch_broker/log_group.tf
@@ -1,3 +1,5 @@
 resource "aws_cloudwatch_log_group" "audit_log" {
   name = "${var.stack_description}-elasticsearch_broker_audit_log"
+  # Lowest allowed value that fulfills M-21-31 reqs of storing for 30 months
+  retention_in_days = 1827
 }


### PR DESCRIPTION
Related to https://github.com/cloud-gov/private/issues/732

## Changes proposed in this pull request:

We only need to keep Cloudwatch logs for a minimum of 30 months (~931 days) to fulfill M-21-31 logging requirements. However, in many cases, we have no retention period set for Cloudwatch log groups, so we are keeping logs **forever**, which is a significant waste of money.

This PR adds retention period for the log groups created by this repo which have no period defined.

## security considerations

These retention periods fulfill M-21-31 compliance, so there should be no security impact.
