### PR TITLE
Update hashicorp/aws provider to v5

### DIFF
--- a/terraform/modules/bosh_vpc/versions.tf
+++ b/terraform/modules/bosh_vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/cdn_broker/versions.tf
+++ b/terraform/modules/cdn_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/cloud_watch/versions.tf
+++ b/terraform/modules/cloud_watch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -124,7 +124,11 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
         name        = "AWSManagedRulesAnonymousIpList"
         vendor_name = "AWS"
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "HostingProviderIPList"
         }
       }
@@ -150,7 +154,11 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
         name        = "AWSManagedRulesAmazonIpReputationList"
         vendor_name = "AWS"
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "AWSManagedIPReputationList"
         }
       }
@@ -242,51 +250,99 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "CrossSiteScripting_COOKIE"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "CrossSiteScripting_BODY"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "EC2MetaDataSSRF_BODY"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "EC2MetaDataSSRF_QUERYARGUMENTS"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "GenericLFI_BODY"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "GenericRFI_BODY"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "GenericRFI_QUERYARGUMENTS"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "NoUserAgent_HEADER"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "SizeRestrictions_BODY"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "SizeRestrictions_Cookie_HEADER"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "SizeRestrictions_QUERYSTRING"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "SizeRestrictions_URIPATH"
         }
       }

--- a/terraform/modules/cloudfoundry/versions.tf
+++ b/terraform/modules/cloudfoundry/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/cloudfront/versions.tf
+++ b/terraform/modules/cloudfront/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/concourse/versions.tf
+++ b/terraform/modules/concourse/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/credhub/versions.tf
+++ b/terraform/modules/credhub/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/cvd_mirror/versions.tf
+++ b/terraform/modules/cvd_mirror/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/diego/versions.tf
+++ b/terraform/modules/diego/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/dns/versions.tf
+++ b/terraform/modules/dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/elasticache_broker_network/versions.tf
+++ b/terraform/modules/elasticache_broker_network/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/elasticsearch_broker/versions.tf
+++ b/terraform/modules/elasticsearch_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/environment_dns/versions.tf
+++ b/terraform/modules/environment_dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/external_domain_broker/versions.tf
+++ b/terraform/modules/external_domain_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/external_domain_broker_govcloud/versions.tf
+++ b/terraform/modules/external_domain_broker_govcloud/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/external_domain_broker_tests/versions.tf
+++ b/terraform/modules/external_domain_broker_tests/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role/versions.tf
+++ b/terraform/modules/iam_role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/aws_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/blobstore/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/bosh/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
+++ b/terraform/modules/iam_role_policy/bosh_compilation/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
+++ b/terraform/modules/iam_role_policy/cf_blobstore/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/cloudwatch/versions.tf
+++ b/terraform/modules/iam_role_policy/cloudwatch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/compliance_role/versions.tf
+++ b/terraform/modules/iam_role_policy/compliance_role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_iaas_worker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/concourse_worker/versions.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/ecr/versions.tf
+++ b/terraform/modules/iam_role_policy/ecr/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/elasticache_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
+++ b/terraform/modules/iam_role_policy/logsearch_ingestor/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/s3_broker/versions.tf
+++ b/terraform/modules/iam_role_policy/s3_broker/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
+++ b/terraform/modules/iam_role_policy/self_managed_credentials/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/billing_user/versions.tf
+++ b/terraform/modules/iam_user/billing_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/cvd_sync/versions.tf
+++ b/terraform/modules/iam_user/cvd_sync/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/ecr_user/versions.tf
+++ b/terraform/modules/iam_user/ecr_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/federalist_auditor/versions.tf
+++ b/terraform/modules/iam_user/federalist_auditor/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/health_check/versions.tf
+++ b/terraform/modules/iam_user/health_check/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/iam_cert_provision/versions.tf
+++ b/terraform/modules/iam_user/iam_cert_provision/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/lets_encrypt/versions.tf
+++ b/terraform/modules/iam_user/lets_encrypt/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/limit_check_user/versions.tf
+++ b/terraform/modules/iam_user/limit_check_user/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/rds_storage_alert/versions.tf
+++ b/terraform/modules/iam_user/rds_storage_alert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/iam_user/s3_logstash/versions.tf
+++ b/terraform/modules/iam_user/s3_logstash/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/logsearch/versions.tf
+++ b/terraform/modules/logsearch/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/monitoring/versions.tf
+++ b/terraform/modules/monitoring/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/opensearch_domain/versions.tf
+++ b/terraform/modules/opensearch_domain/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -3,7 +3,7 @@ output "rds_identifier" {
 }
 
 output "rds_name" {
-  value = aws_db_instance.rds_database.name
+  value = aws_db_instance.rds_database.db_name
 }
 
 output "rds_url" {

--- a/terraform/modules/rds/versions.tf
+++ b/terraform/modules/rds/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/rds_network/versions.tf
+++ b/terraform/modules/rds_network/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/regionalmaster_dns/versions.tf
+++ b/terraform/modules/regionalmaster_dns/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/shibboleth/versions.tf
+++ b/terraform/modules/shibboleth/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/smtp/versions.tf
+++ b/terraform/modules/smtp/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/stack/base/versions.tf
+++ b/terraform/modules/stack/base/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }

--- a/terraform/modules/vpc_peering/versions.tf
+++ b/terraform/modules/vpc_peering/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "< 5.0.0"
+      version               = "< 6.0.0"
       configuration_aliases = [aws, aws.tooling]
     }
   }

--- a/terraform/modules/vpc_peering_sg/versions.tf
+++ b/terraform/modules/vpc_peering_sg/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "< 5.0.0"
+      version               = "< 6.0.0"
       configuration_aliases = [aws]
     }
   }

--- a/terraform/stacks/main/versions.tf
+++ b/terraform/stacks/main/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.0.0"
+      version = "< 6.0.0"
     }
   }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update hashicorp/aws provider to v5 which should close all the Dependabot alerts/PRs
- Update TF code for compatibility with hashicorp/aws v5

I manually tested these changes by re-flying the pipeline to use this branch and all the `plan-*` jobs were successful.

## security considerations

Staying up to date on the `hashicorp/aws` provider ensures we have the latest security and bug fixes
