### PR TITLE
update opensearch customer security groups

### DIFF
--- a/terraform/modules/opensearch_domain/opensearch.tf
+++ b/terraform/modules/opensearch_domain/opensearch.tf
@@ -39,6 +39,7 @@ resource "aws_opensearch_domain" "opensearch" {
   }
 
   vpc_options {
-    subnet_ids = var.private_elb_subnets
+    subnet_ids         = var.subnet_ids
+    security_group_ids = [aws_security_group.opensearch_customer.id]
   }
 }

--- a/terraform/modules/opensearch_domain/variables.tf
+++ b/terraform/modules/opensearch_domain/variables.tf
@@ -34,9 +34,22 @@ variable "internal_user_database_enabled" {
 variable "master_user_name" {
   type = string
 }
+
 variable "master_user_password" {
   type = string
 }
-variable "private_elb_subnets" {
-  type = list(string)
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID to use"
+}
+
+variable "allow_incoming_traffic_security_group_ids" {
+  type        = list(string)
+  description = "Specifies AWS Security Group IDs that should be able to send incoming traffic to this domain"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "AWS Subnet IDs to use for Opensearch domain"
 }

--- a/terraform/modules/opensearch_domain/vpc.tf
+++ b/terraform/modules/opensearch_domain/vpc.tf
@@ -1,0 +1,24 @@
+resource "aws_security_group" "opensearch_customer" {
+  name        = "${var.domain_name}-incoming-elasticsearch"
+  description = "Allow access to incoming elasticsearch traffic"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = var.allow_incoming_traffic_security_group_ids
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    security_groups = var.allow_incoming_traffic_security_group_ids
+  }
+
+  tags = {
+    Name = "${var.domain_name} - Incoming Elasticsearch Traffic"
+  }
+}
+

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -306,12 +306,14 @@ module "diego" {
 }
 
 module "opensearch_logs_customer" {
-  count                = var.deploy_opensearch_logs_customer ? 1 : 0
-  source               = "../../modules/opensearch_domain"
-  private_elb_subnets  = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
-  domain_name          = "${var.stack_description}-logs-customer"
-  master_user_name     = var.opensearch_logs_customer_master_username
-  master_user_password = var.opensearch_logs_customer_master_password
+  count                                     = var.deploy_opensearch_logs_customer ? 1 : 0
+  source                                    = "../../modules/opensearch_domain"
+  domain_name                               = "${var.stack_description}-logs-customer"
+  master_user_name                          = var.opensearch_logs_customer_master_username
+  master_user_password                      = var.opensearch_logs_customer_master_password
+  vpc_id                                    = module.stack.vpc_id
+  allow_incoming_traffic_security_group_ids = [module.stack.bosh_security_group]
+  subnet_ids                                = [module.cf.services_subnet_az1, module.cf.services_subnet_az2]
 }
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- update opensearch customer domain to allow incoming traffic from specified security groups

## security considerations

We're going to allow incoming traffic from the BOSH security group, which includes diego cells. The purpose of this change is to allow testing [our authentication proxy](https://github.com/cloud-gov/kibana-cf-auth-proxy/) , which runs as a CF app, for our opensearch logs customer domain. In order for that to work, we need to have the security group on the domain to allow incoming traffic on 443 from the BOSH security group running the diego cell.

The Opensearch domain is still protected by a master username/password so even though traffic from other diego cells and applications could now reach this domain, it should not be able to make any requests.
