### PR TITLE
rename outputs for elasticsearch broker AZs for clarity

### DIFF
--- a/terraform/modules/elasticsearch_broker/outputs.tf
+++ b/terraform/modules/elasticsearch_broker/outputs.tf
@@ -1,16 +1,16 @@
-output "elasticsearch_subnet_az1" {
+output "elasticsearch_subnet1_az1" {
   value = aws_subnet.az1_elasticsearch.id
 }
 
-output "elasticsearch_subnet_az2" {
+output "elasticsearch_subnet2_az2" {
   value = aws_subnet.az2_elasticsearch.id
 }
 
-output "elasticsearch_subnet_az3" {
+output "elasticsearch_subnet3_az1" {
   value = aws_subnet.az3_elasticsearch.id
 }
 
-output "elasticsearch_subnet_az4" {
+output "elasticsearch_subnet4_az2" {
   value = aws_subnet.az4_elasticsearch.id
 }
 

--- a/terraform/modules/elasticsearch_broker/subnets.tf
+++ b/terraform/modules/elasticsearch_broker/subnets.tf
@@ -4,7 +4,7 @@ resource "aws_subnet" "az1_elasticsearch" {
   availability_zone = var.az1
 
   tags = {
-    Name = "${var.stack_description} (elasticsearch Broker AZ1)"
+    Name = "${var.stack_description} (elasticsearch Broker 1 - AZ1)"
   }
 }
 
@@ -14,28 +14,31 @@ resource "aws_subnet" "az2_elasticsearch" {
   availability_zone = var.az2
 
   tags = {
-    Name = "${var.stack_description} (elasticsearch Broker AZ2)"
+    Name = "${var.stack_description} (elasticsearch Broker 2 - AZ2)"
   }
 }
 
-
+# This is actually AZ 1, not a third AZ. We can't rename the resource without
+# destroying the subnet though.
 resource "aws_subnet" "az3_elasticsearch" {
   vpc_id            = var.vpc_id
   cidr_block        = var.elasticsearch_private_cidr_3
   availability_zone = var.az1
 
   tags = {
-    Name = "${var.stack_description} (elasticsearch Broker AZ3)"
+    Name = "${var.stack_description} (elasticsearch Broker 3 - AZ1)"
   }
 }
 
+# This is actually AZ 2, not a fourth AZ. We can't rename the resource without
+# destroying the subnet though.
 resource "aws_subnet" "az4_elasticsearch" {
   vpc_id            = var.vpc_id
   cidr_block        = var.elasticsearch_private_cidr_4
   availability_zone = var.az2
 
   tags = {
-    Name = "${var.stack_description} (elasticsearch Broker AZ4)"
+    Name = "${var.stack_description} (elasticsearch Broker 4 - AZ2)"
   }
 }
 

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -327,20 +327,20 @@ output "elasticsearch_log_group_audit" {
   value = module.elasticsearch_broker.elasticsearch_log_group_audit
 }
 
-output "elasticsearch_subnet_az1" {
-  value = module.elasticsearch_broker.elasticsearch_subnet_az1
+output "elasticsearch_subnet1_az1" {
+  value = module.elasticsearch_broker.elasticsearch_subnet1_az1
 }
 
-output "elasticsearch_subnet_az2" {
-  value = module.elasticsearch_broker.elasticsearch_subnet_az2
+output "elasticsearch_subnet2_az2" {
+  value = module.elasticsearch_broker.elasticsearch_subnet2_az2
 }
 
-output "elasticsearch_subnet_az3" {
-  value = module.elasticsearch_broker.elasticsearch_subnet_az3
+output "elasticsearch_subnet3_az1" {
+  value = module.elasticsearch_broker.elasticsearch_subnet3_az1
 }
 
-output "elasticsearch_subnet_az4" {
-  value = module.elasticsearch_broker.elasticsearch_subnet_az4
+output "elasticsearch_subnet4_az2" {
+  value = module.elasticsearch_broker.elasticsearch_subnet4_az2
 }
 
 output "elasticsearch_subnet_cidr_az1" {


### PR DESCRIPTION
## Changes proposed in this pull request:

The Terraform output names and resource tags for our Elasticsearch broker subnets imply that there are 4 possible AZs - but in reality the subnets are only distributed across 2 AZs. So this PR updates the resource tags and tag output names to match reality. We can't rename the resources themselves without destroying them, which would be disruptive to customer resources.

## security considerations

None, just renaming resources and outputs
