### PR TITLE
Add permissions for ecr pipeline change

### DIFF
--- a/terraform/modules/iam_role_policy/ecr/policy.json
+++ b/terraform/modules/iam_role_policy/ecr/policy.json
@@ -11,7 +11,8 @@
           "ecr:ListImages",
           "ecr:BatchCheckLayerAvailability",
           "ecr:GetRepositoryPolicy",
-          "ecr:GetDownloadUrlForLayer"
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:PutImageTagMutability"
         ],
         "Resource": [
           "arn:${aws_partition}:ecr:${aws_default_region}:${account_id}:repository/*"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updates the ecr policy to allow PutImageTagMutability actions so that we can change the mutability of our ECR repos

## security considerations
This allows our concourse worker to control turning on or off image tag mutability for our ECR repos.
