### PR TITLE
Removing uaa load balancer from list of LBs

### DIFF
--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -204,7 +204,6 @@ output "cf_router_target_groups" {
   value = concat(
     [module.cf.lb_target_https_group],
     [module.cf.apps_lb_target_https_group],
-    [module.cf.uaa_lb_target_group],
     aws_lb_target_group.domains_broker_apps_https.*.name,
     aws_lb_target_group.domains_broker_challenge.*.name,
   )


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove the uaa load balancers for the list of load balancers used for cf-router-network-properties in the ops file as it now has it's own extension called cf-router-main-network-properties
-
-

## security considerations
None
