### PR TITLE
remove references to PGP keys bucket

### DIFF
--- a/terraform/modules/iam_role_policy/concourse_worker/policy.json
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.json
@@ -42,8 +42,6 @@
         "arn:${aws_partition}:s3:::${build_artifacts_bucket}/*",
         "arn:${aws_partition}:s3:::${concourse_varz_bucket}",
         "arn:${aws_partition}:s3:::${concourse_varz_bucket}/*",
-        "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}",
-        "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}/*",
         "arn:${aws_partition}:s3:::${container_scanning_bucket_name}",
         "arn:${aws_partition}:s3:::${container_scanning_bucket_name}/*",
         "arn:${aws_partition}:s3:::${github_backups_bucket_name}",
@@ -70,7 +68,6 @@
         "arn:${aws_partition}:s3:::${varz_bucket}/*-creds.yml",
         "arn:${aws_partition}:s3:::${build_artifacts_bucket}/*",
         "arn:${aws_partition}:s3:::${terraform_state_bucket}/*",
-        "arn:${aws_partition}:s3:::${pgp_keys_bucket_name}/*",
         "arn:${aws_partition}:s3:::${github_backups_bucket_name}/*"
       ]
     }

--- a/terraform/modules/iam_role_policy/concourse_worker/policy.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.tf
@@ -14,7 +14,6 @@ data "template_file" "policy" {
     cg_binaries_bucket             = var.cg_binaries_bucket
     log_bucket                     = var.log_bucket
     concourse_varz_bucket          = var.concourse_varz_bucket
-    pgp_keys_bucket_name           = var.pgp_keys_bucket_name
     container_scanning_bucket_name = var.container_scanning_bucket_name
     github_backups_bucket_name     = var.github_backups_bucket_name
   }

--- a/terraform/modules/iam_role_policy/concourse_worker/variables.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/variables.tf
@@ -37,11 +37,6 @@ variable "build_artifacts_bucket" {
 variable "concourse_varz_bucket" {
 }
 
-variable "pgp_keys_bucket_name" {
-  type        = string
-  description = "Name of S3 bucket for PGP keys"
-}
-
 variable "container_scanning_bucket_name" {
   type        = string
   description = "Name of S3 bucket for container scanning config"

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -74,7 +74,6 @@ module "concourse_worker_policy" {
   cg_binaries_bucket             = var.cg_binaries_bucket
   log_bucket                     = var.log_bucket_name
   concourse_varz_bucket          = var.concourse_varz_bucket
-  pgp_keys_bucket_name           = var.pgp_keys_bucket_name
   container_scanning_bucket_name = var.container_scanning_bucket_name
   github_backups_bucket_name     = var.github_backups_bucket_name
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

We will no longer need or use this bucket for managing the team's PGP keys, so removing the IAM policies that give access to it.

Related to https://github.com/cloud-gov/gpg-keys/pull/3

## security considerations

See https://github.com/cloud-gov/gpg-keys/pull/3 for discussion of security implications
