### PR TITLE
remove s3 bucket for pgp keys

### DIFF
--- a/terraform/stacks/tooling/buckets.tf
+++ b/terraform/stacks/tooling/buckets.tf
@@ -59,13 +59,6 @@ module "build_artifacts_bucket" {
   versioning    = "true"
 }
 
-module "pgp_keys_bucket" {
-  source        = "../../modules/s3_bucket/encrypted_bucket"
-  bucket        = var.pgp_keys_bucket_name
-  aws_partition = data.aws_partition.current.partition
-  versioning    = "true"
-}
-
 module "container_scanning_bucket" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
   bucket        = var.container_scanning_bucket_name

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -170,10 +170,6 @@ variable "log_bucket_name" {
   default = "cg-elb-logs"
 }
 
-variable "pgp_keys_bucket_name" {
-  default = "cg-pgp-keys"
-}
-
 variable "container_scanning_bucket_name" {
   default = "cg-container-scanning"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

We will no longer need or use this bucket for managing the team's PGP keys, so removing it.

Related to https://github.com/cloud-gov/gpg-keys/pull/3

## security considerations

See https://github.com/cloud-gov/gpg-keys/pull/3 for discussion of security implications
