### PR TITLE
Move ECR terraform

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -959,6 +959,40 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
+- name: plan-ecr
+  plan:
+  - in_parallel:
+    - get: pipeline-tasks
+    - get: cg-provision-repo
+      trigger: true
+    - get: plan-timer
+      trigger: true
+  - task: plan-update-ecr
+    file: pipeline-tasks/terraform-apply.yml
+    input_mapping: {terraform-templates: cg-provision-repo}
+    params: &tf-ecr
+      TERRAFORM_ACTION: plan
+      TEMPLATE_SUBDIR: terraform/stacks/ecr
+      STACK_NAME: ecr
+      S3_TFSTATE_BUCKET: ((ecr-tf-state-bucket))
+      AWS_DEFAULT_REGION: us-gov-west-1
+      TF_VAR_remote_state_bucket: ((ecr-tf-state-bucket))
+      TF_VAR_tooling_stack_name: tooling
+  - *notify-slack
+
+- name: apply-ecr
+  plan:
+  - in_parallel:
+    - get: pipeline-tasks
+    - get: cg-provision-repo
+      passed: [plan-ecr]
+  - task: create-update-ecr
+    file: pipeline-tasks/terraform-apply.yml
+    input_mapping: {terraform-templates: cg-provision-repo}
+    params:
+      <<: *tf-ecr
+      TERRAFORM_ACTION: apply
+
 - name: acme-certificate-development
   plan:
   - in_parallel:

--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -1,0 +1,57 @@
+variable "remote_state_bucket" {
+}
+
+variable "tooling_stack_name" {
+}
+
+variable "repositories" {
+  type = set(string)
+  default = [
+    "cf-cli-resource",
+    "cf-resource",
+    "concourse-task",
+    "cron-resource",
+    "email-resource",
+    "general-task",
+    "git-resource",
+    "github-pr-resource",
+    "harden-concourse-task",
+    "harden-concourse-task-staging",
+    "harden-s3-resource-simple",
+    "harden-s3-resource-simple-staging",
+    "oracle-client",
+    "registry-image-resource",
+    "s3-resource",
+    "s3-resource-simple",
+    "s3-simple-resource",
+    "semver-resource",
+    "slack-notification-resource",
+    "sql-clients",
+    "time-resource",
+    "ubuntu-hardened",
+  ]
+}
+
+terraform {
+  backend "s3" {
+  }
+}
+
+
+data "terraform_remote_state" "tooling" {
+  backend = "s3"
+  config = {
+    bucket = var.remote_state_bucket
+    key    = "${var.tooling_stack_name}/terraform.tfstate"
+  }
+}
+
+
+resource "aws_ecr_repository" "repository" {
+  for_each = var.repositories
+
+  name                 = each.key
+  image_tag_mutability = "MUTABLE"
+  tags                 = {}
+  tags_all             = {}
+}

--- a/terraform/stacks/ecr/versions.tf
+++ b/terraform/stacks/ecr/versions.tf
@@ -1,0 +1,10 @@
+
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 6.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Moves terraform for creating ECR repos from the container-scanning pipeline

## security considerations
Should not interfere with any other terraform plans, and keeps the terraform code more centrally located