### PR TITLE
add ecr jobs to group

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,6 +3,7 @@ groups:
   jobs:
   - apply-cloudfront-staging
   - apply-dns
+  - apply-ecr
   - bootstrap-development
   - bootstrap-external-development
   - bootstrap-external-production
@@ -19,6 +20,7 @@ groups:
   - plan-bootstrap-tooling
   - plan-cloudfront-staging
   - plan-dns
+  - plan-ecr
   - pull-status-check
   - webacl-test-development
   - webacl-test-production


### PR DESCRIPTION
## Changes proposed in this pull request:
- ECR terraform jobs need to be added to group so we can fly the pipeline

## security considerations
None, just need to add jobs to a group so that the pipeline can fly correctly
