### PR TITLE
Add Autoscaler RDS

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -512,6 +512,7 @@ jobs:
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_vpc_cidr: ((development_vpc_cidr))
       TF_VAR_cf_rds_password: ((development_cf_rds_password))
+      TF_VAR_cf_as_rds_instance_type: ((development_cf_as_rds_instance_type))
       TF_VAR_credhub_rds_password: ((development_credhub_rds_password))
       TF_VAR_restricted_ingress_web_cidrs: ((development_restricted_ingress_web_cidrs))
       TF_VAR_restricted_ingress_web_ipv6_cidrs: ((development_restricted_ingress_web_ipv6_cidrs))
@@ -676,6 +677,7 @@ jobs:
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_vpc_cidr: ((staging_vpc_cidr))
       TF_VAR_cf_rds_password: ((staging_cf_rds_password))
+      TF_VAR_cf_as_rds_instance_type: ((staging_cf_as_rds_instance_type))
       TF_VAR_restricted_ingress_web_cidrs: ((staging_restricted_ingress_web_cidrs))
       TF_VAR_restricted_ingress_web_ipv6_cidrs: ((staging_restricted_ingress_web_ipv6_cidrs))
       TF_VAR_wildcard_certificate_name_prefix: star.fr-stage.cloud.gov
@@ -836,6 +838,7 @@ jobs:
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_vpc_cidr: ((production_vpc_cidr))
       TF_VAR_cf_rds_password: ((production_cf_rds_password))
+      TF_VAR_cf_as_rds_instance_type: ((production_cf_as_rds_instance_type))
       TF_VAR_restricted_ingress_web_cidrs: ((production_restricted_ingress_web_cidrs))
       TF_VAR_restricted_ingress_web_ipv6_cidrs: ((production_restricted_ingress_web_ipv6_cidrs))
       TF_VAR_wildcard_certificate_name_prefix: star.fr.cloud.gov

--- a/terraform/modules/autoscaler/database.tf
+++ b/terraform/modules/autoscaler/database.tf
@@ -1,0 +1,19 @@
+module "cf_as_database" {
+  source = "../rds"
+
+  stack_description               = var.stack_description
+  rds_instance_type               = var.rds_instance_type
+  rds_db_size                     = var.rds_db_size
+  rds_db_engine                   = var.rds_db_engine
+  rds_db_engine_version           = var.rds_db_engine_version
+  rds_db_name                     = var.rds_db_name
+  rds_username                    = var.rds_username
+  rds_password                    = var.rds_password
+  rds_subnet_group                = var.rds_subnet_group
+  rds_security_groups             = var.rds_security_groups
+  rds_parameter_group_family      = var.rds_parameter_group_family
+  rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  rds_apply_immediately           = var.rds_apply_immediately
+}
+
+

--- a/terraform/modules/autoscaler/outputs.tf
+++ b/terraform/modules/autoscaler/outputs.tf
@@ -1,0 +1,26 @@
+
+output "cf_as_rds_url" {
+  value = module.cf_as_database.rds_url
+}
+
+output "cf_as_rds_host" {
+  value = module.cf_as_database.rds_host
+}
+
+output "cf_as_rds_port" {
+  value = module.cf_as_database.rds_port
+}
+
+output "cf_as_rds_username" {
+  value = module.cf_as_database.rds_username
+}
+
+output "cf_as_rds_password" {
+  value     = module.cf_as_database.rds_password
+  sensitive = true
+}
+
+output "cf_as_rds_engine" {
+  value = module.cf_as_database.rds_engine
+}
+

--- a/terraform/modules/autoscaler/variables.tf
+++ b/terraform/modules/autoscaler/variables.tf
@@ -1,0 +1,49 @@
+variable "stack_description" {
+}
+
+variable "rds_instance_type" {
+  default = "db.t3.small"
+}
+
+variable "rds_db_size" {
+  default = 20
+}
+
+variable "rds_db_name" {
+  default = "autoscaler"
+}
+
+variable "rds_db_engine" {
+  default = "postgres"
+}
+
+variable "rds_db_engine_version" {
+  default = "15.3"
+}
+
+variable "rds_parameter_group_family" {
+  default = "postgres15"
+}
+
+variable "rds_username" {
+  default = "ascaler"
+}
+
+variable "rds_password" {
+  sensitive = true
+}
+
+variable "rds_subnet_group" {
+}
+
+variable "rds_security_groups" {
+  type = list(string)
+}
+
+variable "rds_apply_immediately" {
+  default = "false"
+}
+
+variable "rds_allow_major_version_upgrade" {
+  default = "false"
+}

--- a/terraform/modules/autoscaler/versions.tf
+++ b/terraform/modules/autoscaler/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 6.0.0"
+    }
+  }
+}

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -450,20 +450,20 @@ output "cf_as_rds_host" {
 }
 
 output "cf_as_rds_port" {
-  value = module.autoscaler.cf_rds_port
+  value = module.autoscaler.cf_as_rds_port
 }
 
 output "cf_as_rds_username" {
-  value = module.autoscaler.cf_rds_username
+  value = module.autoscaler.cf_as_rds_username
 }
 
 output "cf_as_rds_password" {
-  value     = module.autoscaler.cf_rds_password
+  value     = module.autoscaler.cf_as_rds_password
   sensitive = true
 }
 
 output "cf_as_rds_engine" {
-  value = module.autoscaler.cf_rds_engine
+  value = module.autoscaler.cf_as_rds_engine
 }
 
 /* CredHub RDS */

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -442,11 +442,11 @@ output "cf_rds_engine" {
 
 /* CloudFoundry Autoscaler RDS */
 output "cf_as_rds_url" {
-  value = module.autoscaler.cf_rds_url
+  value = module.autoscaler.cf_as_rds_url
 }
 
 output "cf_as_rds_host" {
-  value = module.autoscaler.cf_rds_host
+  value = module.autoscaler.cf_as_rds_host
 }
 
 output "cf_as_rds_port" {

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -440,6 +440,32 @@ output "cf_rds_engine" {
   value = module.cf.cf_rds_engine
 }
 
+/* CloudFoundry Autoscaler RDS */
+output "cf_as_rds_url" {
+  value = module.autoscaler.cf_rds_url
+}
+
+output "cf_as_rds_host" {
+  value = module.autoscaler.cf_rds_host
+}
+
+output "cf_as_rds_port" {
+  value = module.autoscaler.cf_rds_port
+}
+
+output "cf_as_rds_username" {
+  value = module.autoscaler.cf_rds_username
+}
+
+output "cf_as_rds_password" {
+  value     = module.autoscaler.cf_rds_password
+  sensitive = true
+}
+
+output "cf_as_rds_engine" {
+  value = module.autoscaler.cf_rds_engine
+}
+
 /* CredHub RDS */
 output "credhub_rds_url" {
   value = module.stack.credhub_rds_url

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -293,7 +293,7 @@ module "autoscaler" {
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
-  # rds_instance_type             = var.cf_as_rds_instance_type
+  rds_instance_type               = var.cf_as_rds_instance_type
 
 }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -283,6 +283,30 @@ module "cf" {
   waf_hostname_0                                              = var.waf_hostname_0
 }
 
+
+module "autoscaler" {
+  source = "../../modules/autoscaler"
+
+  stack_description               = var.stack_description
+  rds_password                    = random_string.autoscaler_rds_password.result
+  rds_subnet_group                = module.stack.rds_subnet_group
+  rds_security_groups             = [module.stack.rds_postgres_security_group]
+  rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
+  rds_apply_immediately           = var.rds_apply_immediately
+  # rds_instance_type             = var.cf_as_rds_instance_type
+
+}
+
+resource "random_string" "autoscaler_rds_password" {
+  length      = 32
+  special     = false
+  min_special = 0
+  min_upper   = 5
+  min_numeric = 5
+  min_lower   = 5
+}
+
+
 resource "aws_wafv2_web_acl_association" "main_waf_core" {
   resource_arn = aws_lb.main.arn
   web_acl_arn  = module.cf.cf_uaa_waf_core_arn

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -114,6 +114,11 @@ variable "cf_rds_instance_type" {
   default = "db.m4.large"
 }
 
+variable "cf_as_rds_instance_type" {
+  default = "db.t3.large"
+}
+
+
 variable "bosh_default_ssh_public_key" {
 
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a module to create the RDS database needed for autoscaler in dev/stage/prod
- Allows for separate rds instance sizes for each environment to be set in cg-provision.yml
- Emits RDS outputs, similar to CF RDS, so they can be consumed by the autoscaler pipeline.

## security considerations
Passwords/hosts are passed via the state file to the pipeline for autoscaler.  The password is dynamically generated using random_string.
