### PR TITLE
moving domain broker rds to min 20GB for gp3

### DIFF
--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -57,7 +57,7 @@ output "domains_broker_internal_target_group" {
 resource "aws_db_instance" "domains_broker" {
   db_name                     = "domains_broker"
   storage_type                = "gp3"
-  allocated_storage           = 10
+  allocated_storage           = 20
   instance_class              = "db.t2.small"
   username                    = var.domains_broker_rds_username
   password                    = var.domains_broker_rds_password


### PR DESCRIPTION
## Changes proposed in this pull request:
- with the move of domain broker RDS storage to gp3, the min volume size needs to be 20 GB to avoid errors

## security considerations
n/a
