### PR TITLE
Set rds default rds_db_iops to 3000 for gp3 disk

### DIFF
--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -14,7 +14,7 @@ variable "rds_db_storage_type" {
 }
 
 variable "rds_db_iops" {
-  default = 0
+  default = 3000
 }
 
 variable "rds_db_name" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Set rds default rds_db_iops to 3000 for gp3 disk
-
-

## security considerations
None
