### PR TITLE
Undo 3000

### DIFF
--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -14,7 +14,7 @@ variable "rds_db_storage_type" {
 }
 
 variable "rds_db_iops" {
-  default = 0
+  default = null
 }
 
 variable "rds_db_name" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -14,7 +14,7 @@ variable "rds_db_storage_type" {
 }
 
 variable "rds_db_iops" {
-  default = 3000
+  default = 0
 }
 
 variable "rds_db_name" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Undo the change to 3000, `You can't specify IOPS or storage throughput for engine postgres and a storage size less than 400.`
-
-

## security considerations
None
