### PR TITLE
add new rule to rate limit source IP as a count action

### DIFF
--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -170,16 +170,16 @@ variable "non_cdn_traffic_rate_limit_challenge_by_source_ip" {
   default     = 2000
 }
 
-variable "non_cdn_traffic_rate_limit_challenge_by_forwarded_ip" {
+variable "cdn_traffic_rate_limit_challenge_by_forwarded_ip" {
   type        = number
   description = "Number of requests to allow per forwarded IP per 5 minute interval before challenging requests"
   default     = 2000
 }
 
-variable "non_cdn_traffic_rate_limit_block_by_forwarded_ip" {
+variable "non_cdn_traffic_rate_limit_block_by_source_ip" {
   type        = number
-  description = "Number of requests to allow per forwarded IP per 5 minute interval before blocking requests"
-  default     = 250000
+  description = "Number of requests to allow per source IP per 5 minute interval before blocking requests"
+  default     = 5000
 }
 
 variable "gsa_ip_range_ip_set_arn" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove rule that was blocking IPs making more than 250000 requests per 5 minutes
- Add new rule with a COUNT action for source IPs of non-CDN traffic making more than 5000 requests per 5 minutes. This rule is initially in COUNT mode so that we can evaluate its effectiveness and later we may change it to BLOCK.

## security considerations

The WAF rule being removed has such a higher rate limit threshold it has had no effect on actual DDoS events. The WAF rule being added has the potential to be effective as a backstop to handle DDoS traffic, but we want to evaluate its effectiveness before setting it to BLOCK traffic.
