### PR TITLE
fix user-agent value to identify Cloudfront traffic

### DIFF
--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -155,7 +155,7 @@ variable "user_agent_header_name" {
 variable "cloudfront_user_agent_header" {
   type        = string
   description = "User-Agent header value used to identify Cloudfront traffic"
-  default     = "Amazon Cloudfront"
+  default     = "Amazon CloudFront"
 }
 
 variable "forwarded_ip_header_name" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix user-agent value to identify Cloudfront traffic so that rate limits for Cloudfront and non-Cloudfront traffic work correctly

## security considerations

None
