### PR TITLE
Simplify/refactor WAF rules

### DIFF
--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -468,6 +468,30 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
         statement {
           ip_set_reference_statement {
+            arn = var.cg_egress_ip_set_arn
+
+            ip_set_forwarded_ip_config {
+              header_name       = var.forwarded_ip_header_name
+              fallback_behavior = "NO_MATCH"
+              position          = "FIRST"
+            }
+          }
+        }
+
+        statement {
+          ip_set_reference_statement {
+            arn = var.gsa_ip_range_ip_set_arn
+
+            ip_set_forwarded_ip_config {
+              header_name       = var.forwarded_ip_header_name
+              fallback_behavior = "NO_MATCH"
+              position          = "FIRST"
+            }
+          }
+        }
+
+        statement {
+          ip_set_reference_statement {
             arn = var.internal_vpc_cidrs_set_arn
 
             ip_set_forwarded_ip_config {

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -445,8 +445,75 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   }
 
   rule {
-    name     = "BlockMaliciousJA3FingerprintIDs"
+    name     = "AllowTrustedIPs"
     priority = 6
+    
+    action {
+      allow {}
+    }
+
+    statement {
+      or_statement {
+        statement {
+          ip_set_reference_statement {
+            arn = var.cg_egress_ip_set_arn
+          }
+        }
+
+        statement {
+          ip_set_reference_statement {
+            arn = var.gsa_ip_range_ip_set_arn
+          }
+        }
+
+        statement {
+          ip_set_reference_statement {
+            arn = var.internal_vpc_cidrs_set_arn
+
+            ip_set_forwarded_ip_config {
+              header_name       = var.forwarded_ip_header_name
+              fallback_behavior = "NO_MATCH"
+              position          = "FIRST"
+            }
+          }
+        }
+
+        statement {
+          ip_set_reference_statement {
+            arn = var.cg_egress_ip_set_arn
+
+            ip_set_forwarded_ip_config {
+              header_name       = var.forwarded_ip_header_name
+              fallback_behavior = "NO_MATCH"
+              position          = "FIRST"
+            }
+          }
+        }
+
+        statement {
+          ip_set_reference_statement {
+            arn = var.customer_whitelist_ip_ranges_set_arn
+
+            ip_set_forwarded_ip_config {
+              header_name       = var.forwarded_ip_header_name
+              fallback_behavior = "NO_MATCH"
+              position          = "FIRST"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.stack_description}-AllowTrustedIPs"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "BlockMaliciousJA3FingerprintIDs"
+    priority = 7
     action {
       count {}
     }
@@ -468,13 +535,13 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${var.stack_description}-BlockMaliciousFingerprints"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
   rule {
     name     = "RateLimitNonCDNBySourceIP-Challenge"
-    priority = 7
+    priority = 8
 
     action {
       challenge {}
@@ -490,26 +557,6 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
             statement {
               not_statement {
                 statement {
-                  ip_set_reference_statement {
-                    arn = var.cg_egress_ip_set_arn
-                  }
-                }
-              }
-            }
-
-            statement {
-              not_statement {
-                statement {
-                  ip_set_reference_statement {
-                    arn = var.gsa_ip_range_ip_set_arn
-                  }
-                }
-              }
-            }
-
-            statement {
-              not_statement {
-                statement {
                   byte_match_statement {
                     field_to_match {
                       single_header {
@@ -549,22 +596,6 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
                 }
               }
             }
-
-            statement {
-              not_statement {
-                statement {
-                  ip_set_reference_statement {
-                    arn = var.internal_vpc_cidrs_set_arn
-
-                    ip_set_forwarded_ip_config {
-                      header_name       = var.forwarded_ip_header_name
-                      fallback_behavior = "NO_MATCH"
-                      position          = "FIRST"
-                    }
-                  }
-                }
-              }
-            }
           }
         }
       }
@@ -573,13 +604,13 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${var.stack_description}-RateLimitSourceIPChallenge"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
   rule {
     name     = "RateLimitCDNByForwardedIP-Challenge"
-    priority = 8
+    priority = 9
 
     action {
       challenge {}
@@ -591,71 +622,19 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
         aggregate_key_type = "FORWARDED_IP"
 
         scope_down_statement {
-          and_statement {
-            statement {
-              not_statement {
-                statement {
-                  ip_set_reference_statement {
-                    arn = var.cg_egress_ip_set_arn
-
-                    ip_set_forwarded_ip_config {
-                      header_name       = var.forwarded_ip_header_name
-                      fallback_behavior = "NO_MATCH"
-                      position          = "FIRST"
-                    }
-                  }
-                }
+          byte_match_statement {
+            field_to_match {
+              single_header {
+                name = var.user_agent_header_name
               }
             }
 
-            statement {
-              not_statement {
-                statement {
-                  ip_set_reference_statement {
-                    arn = var.gsa_ip_range_ip_set_arn
+            search_string         = var.cloudfront_user_agent_header
+            positional_constraint = "EXACTLY"
 
-                    ip_set_forwarded_ip_config {
-                      header_name       = var.forwarded_ip_header_name
-                      fallback_behavior = "NO_MATCH"
-                      position          = "FIRST"
-                    }
-                  }
-                }
-              }
-            }
-
-            statement {
-              byte_match_statement {
-                field_to_match {
-                  single_header {
-                    name = var.user_agent_header_name
-                  }
-                }
-
-                search_string         = var.cloudfront_user_agent_header
-                positional_constraint = "EXACTLY"
-
-                text_transformation {
-                  priority = 0
-                  type     = "NONE"
-                }
-              }
-            }
-
-            statement {
-              not_statement {
-                statement {
-                  ip_set_reference_statement {
-                    arn = var.customer_whitelist_ip_ranges_set_arn
-
-                    ip_set_forwarded_ip_config {
-                      header_name       = var.forwarded_ip_header_name
-                      fallback_behavior = "NO_MATCH"
-                      position          = "FIRST"
-                    }
-                  }
-                }
-              }
+            text_transformation {
+              priority = 0
+              type     = "NONE"
             }
           }
         }
@@ -670,13 +649,13 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${var.stack_description}-RateLimitSourceIPChallenge"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
   rule {
     name     = "RateLimitNonCDNBySourceIP-Block"
-    priority = 9
+    priority = 10
 
     action {
       count {}
@@ -692,26 +671,6 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
             statement {
               not_statement {
                 statement {
-                  ip_set_reference_statement {
-                    arn = var.cg_egress_ip_set_arn
-                  }
-                }
-              }
-            }
-
-            statement {
-              not_statement {
-                statement {
-                  ip_set_reference_statement {
-                    arn = var.gsa_ip_range_ip_set_arn
-                  }
-                }
-              }
-            }
-
-            statement {
-              not_statement {
-                statement {
                   byte_match_statement {
                     field_to_match {
                       single_header {
@@ -751,22 +710,6 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
                 }
               }
             }
-
-            statement {
-              not_statement {
-                statement {
-                  ip_set_reference_statement {
-                    arn = var.internal_vpc_cidrs_set_arn
-
-                    ip_set_forwarded_ip_config {
-                      header_name       = var.forwarded_ip_header_name
-                      fallback_behavior = "NO_MATCH"
-                      position          = "FIRST"
-                    }
-                  }
-                }
-              }
-            }
           }
         }
       }
@@ -775,7 +718,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${var.stack_description}-RateLimitSourceIPChallenge"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -447,7 +447,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
   rule {
     name     = "AllowTrustedIPs"
     priority = 6
-    
+
     action {
       allow {}
     }


### PR DESCRIPTION
## Changes proposed in this pull request:

So as recent events have demonstrated, the complexity of WAF rules is perilous since it increases the chances of misconfiguration and unexpected impact on platform traffic. 

One complexity to our WAF rules was a series of IP range exceptions for rate limiting, which were applied separately to each our rate limiting rules. Repeating this same configuration three times in our Terraform increases the chances of misconfiguration and error.

Also, it turns out there's just a better way to manage these exceptions. By creating an ALLOW rule for these trusted IP ranges with a higher priority the rate limit rules, this traffic will not even be processed by the rate limit rules, since ALLOW is a terminating action:

> Allow and Block are terminating actions – Allow and Block actions stop all other processing of the web ACL on the matching web request. If a rule in a web ACL finds a match for a request and the rule action is Allow or Block, that match determines the final disposition of the web request for the web ACL. AWS WAF doesn't process any other rules in the web ACL that come after the matching one. This is true for rules that you add directly to the web ACL and rules that are inside an added rule group. With the Block action, the protected resource doesn't receive or process the web request.

https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-rule-actions.html

So these refactored WAF rules should have the exact same effect as the current configuration but in a much more maintainable way.

## security considerations

By simplifying the configuration for WAF configuration, we're increasing its comprehensibility and improving our ability to guarantee its security efficacy.
