### PR TITLE
Add tagging permissions for brokers

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -152,7 +152,11 @@
         "iam:CreatePolicyVersion",
         "iam:DeletePolicyVersion",
         "iam:TagUser",
-        "iam:UntagUser"
+        "iam:UntagUser",
+        "iam:TagPolicy",
+        "iam:UntagPolicy",
+        "iam:TagRole",
+        "iam:UntagRole"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -150,7 +150,9 @@
         "iam:GetPolicy",
         "iam:GetPolicyVersion",
         "iam:CreatePolicyVersion",
-        "iam:DeletePolicyVersion"
+        "iam:DeletePolicyVersion",
+        "iam:TagUser",
+        "iam:UntagUser"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/terraform/modules/iam_role_policy/s3_broker/policy.json
+++ b/terraform/modules/iam_role_policy/s3_broker/policy.json
@@ -25,7 +25,9 @@
         "iam:AttachUserPolicy",
         "iam:DetachUserPolicy",
         "iam:TagUser",
-        "iam:UntagUser"
+        "iam:UntagUser",
+        "iam:TagPolicy",
+        "iam:UntagPolicy"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/terraform/modules/iam_role_policy/s3_broker/policy.json
+++ b/terraform/modules/iam_role_policy/s3_broker/policy.json
@@ -23,7 +23,9 @@
         "iam:DeletePolicy",
         "iam:ListAttachedUserPolicies",
         "iam:AttachUserPolicy",
-        "iam:DetachUserPolicy"
+        "iam:DetachUserPolicy",
+        "iam:TagUser",
+        "iam:UntagUser"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
Related to https://github.com/cloud-gov/aws-broker/pull/351
Related to https://github.com/cloud-gov/s3-broker/issues/62

## Changes proposed in this pull request:

We want to tag all IAM resources created by brokers. This PR updates the policies used for the brokers to give them permission to tag the IAM resources.

## security considerations

We are giving more permissions to the brokers, but in this case just allowing them to tag resources. And these permissions are just adding on to existing IAM policies
