### PR TITLE
Fixes cloud-gov/private#945

### DIFF
--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -26,7 +26,7 @@ variable "stack_description" {
 }
 
 variable "rds_instance_type" {
-  default = "db.m4.large"
+  default = "db.m5.large"
 }
 
 variable "rds_db_size" {

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -34,7 +34,7 @@ variable "rds_db_storage_type" {
 }
 
 variable "rds_instance_type" {
-  default = "db.m4.xlarge"
+  default = "db.m5.xlarge"
 }
 
 variable "rds_db_engine_version" {

--- a/terraform/modules/concourse_v2/variables.tf
+++ b/terraform/modules/concourse_v2/variables.tf
@@ -36,7 +36,7 @@ variable "rds_db_storage_type" {
 }
 
 variable "rds_instance_type" {
-  default = "db.m4.xlarge"
+  default = "db.m5.xlarge"
 }
 
 variable "rds_db_engine_version" {

--- a/terraform/modules/credhub/variables.tf
+++ b/terraform/modules/credhub/variables.tf
@@ -42,7 +42,7 @@ variable "rds_db_storage_type" {
 }
 
 variable "rds_instance_type" {
-  default = "db.m4.xlarge"
+  default = "db.m5.xlarge"
 }
 
 variable "rds_db_engine_version" {

--- a/terraform/modules/credhub_v2/variables.tf
+++ b/terraform/modules/credhub_v2/variables.tf
@@ -36,7 +36,7 @@ variable "rds_db_storage_type" {
 }
 
 variable "rds_instance_type" {
-  default = "db.m4.xlarge"
+  default = "db.m5.xlarge"
 }
 
 variable "rds_db_engine_version" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -2,7 +2,7 @@ variable "stack_description" {
 }
 
 variable "rds_instance_type" {
-  default = "db.m4.large"
+  default = "db.m5.large"
 }
 
 variable "rds_db_size" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -48,7 +48,7 @@ variable "rds_private_cidr_4" {
 }
 
 variable "rds_instance_type" {
-  default = "db.m4.large"
+  default = "db.m5.large"
 }
 
 variable "rds_db_size" {
@@ -145,7 +145,7 @@ variable "credhub_rds_db_storage_type" {
 }
 
 variable "credhub_rds_instance_type" {
-  default = "db.t2.medium"
+  default = "db.t3.medium"
 }
 
 variable "credhub_rds_db_size" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -48,7 +48,7 @@ variable "rds_private_cidr_4" {
 }
 
 variable "rds_instance_type" {
-  default = "db.m4.large"
+  default = "db.m5.large"
 }
 
 variable "rds_db_size" {

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -58,7 +58,7 @@ resource "aws_db_instance" "domains_broker" {
   db_name                     = "domains_broker"
   storage_type                = "gp3"
   allocated_storage           = 20
-  instance_class              = "db.t2.small"
+  instance_class              = "db.t3.small"
   username                    = var.domains_broker_rds_username
   password                    = var.domains_broker_rds_password
   engine                      = "postgres"

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -108,7 +108,7 @@ variable "parent_stack_name" {
 }
 
 variable "domains_broker_rds_version" {
-  default = "11"
+  default = "12.17"
 }
 variable "cf_rds_instance_type" {
   default = "db.m5.large"

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -21,7 +21,7 @@ variable "rds_password" {
 }
 
 variable "rds_instance_type" {
-  default = "db.m4.large"
+  default = "db.m5.large"
 }
 
 variable "cf_rds_password" {
@@ -111,7 +111,7 @@ variable "domains_broker_rds_version" {
   default = "11"
 }
 variable "cf_rds_instance_type" {
-  default = "db.m4.large"
+  default = "db.m5.large"
 }
 
 variable "cf_as_rds_instance_type" {

--- a/terraform/stacks/regionalmasterbosh/opsuaa.tf
+++ b/terraform/stacks/regionalmasterbosh/opsuaa.tf
@@ -6,7 +6,7 @@ module "opsuaa_db" {
   source = "../../modules/rds"
 
   stack_description               = var.stack_description
-  rds_instance_type               = "db.t2.medium"
+  rds_instance_type               = "db.t3.medium"
   rds_db_name                     = "opsuaa"
   rds_username                    = "opsuaa"
   rds_password                    = var.opsuaa_rds_password

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -6,7 +6,7 @@ module "opsuaa_db" {
   source = "../../modules/rds"
 
   stack_description               = var.stack_description
-  rds_instance_type               = "db.t2.medium"
+  rds_instance_type               = "db.t3.medium"
   rds_db_name                     = "opsuaa"
   rds_username                    = "opsuaa"
   rds_password                    = var.opsuaa_rds_password

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -174,7 +174,7 @@ module "credhub_production" {
   rds_db_engine_version           = var.rds_db_engine_version
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
-  rds_instance_type               = "db.m4.large"
+  rds_instance_type               = "db.m5.large"
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = "final-snapshot-credhub-tooling-production"
   listener_arn                    = aws_lb_listener.main.arn


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switches `db.m4` to `db.m5` for RDS databases
- Switches `db.t2` to `db.t3` for RDS databases
- Making the changes in AWS Console first to control the actual rollout so prod is done during the established maintenance window on 2/29 at 9am ET

## security considerations
None
