### PR TITLE
add harden-playwright ECR repo for hardened Playwright image

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -32,6 +32,7 @@ variable "repositories" {
     "pages-dind-v25",
     "pages-node-v20",
     "pages-python-v3.11",
+    "harden-playwright"
   ]
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- add harden-playwright ECR repo for hardened Playwright image

## security considerations
 
We are adding this ECR repo to host a hardened image containing Playwright that we can use for running Playwright tests in CI.

Hardened image source: https://github.com/cloud-gov/playwright-image