### PR TITLE
remove oracle client ECR repo

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -19,7 +19,6 @@ variable "repositories" {
     "harden-concourse-task-staging",
     "harden-s3-resource-simple",
     "harden-s3-resource-simple-staging",
-    "oracle-client",
     "registry-image-resource",
     "s3-resource",
     "s3-resource-simple",


### PR DESCRIPTION
## Changes proposed in this pull request:

Corresponding PR to https://github.com/cloud-gov/container-scanning/pull/80 to remove oracle-client ECR repo since we're no longer using that resource

## security considerations

Removes unnecessary resources to improve system clarity and maintainability
