### PR TITLE
Adding 20 rule for acl

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -523,6 +523,7 @@ jobs:
       TF_VAR_customer_whitelist_source_ip_ranges_set_arn: ((customer_whitelist_source_ip_ranges_set_arn))
       TF_VAR_internal_vpc_cidrs_set_arn: ((internal_vpc_cidrs_set_arn))
       TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
+      TF_VAR_block_range_20: ((block_range_20))
   - *notify-slack
 
 - name: bootstrap-development
@@ -683,6 +684,7 @@ jobs:
       TF_VAR_customer_whitelist_source_ip_ranges_set_arn: ((customer_whitelist_source_ip_ranges_set_arn))
       TF_VAR_internal_vpc_cidrs_set_arn: ((internal_vpc_cidrs_set_arn))
       TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
+      TF_VAR_block_range_20: ((block_range_20))
   - *notify-slack
 
 - name: bootstrap-staging
@@ -841,6 +843,8 @@ jobs:
       TF_VAR_customer_whitelist_source_ip_ranges_set_arn: ((customer_whitelist_source_ip_ranges_set_arn))
       TF_VAR_internal_vpc_cidrs_set_arn: ((internal_vpc_cidrs_set_arn))
       TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
+      TF_VAR_block_range_20: ((block_range_20))
+
   - *notify-slack
 
 - name: bootstrap-production

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -65,3 +65,8 @@ variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }
+
+#Placeholder for real value, passed as a secret
+variable "block_range_20" {
+  default = "192.168.0.0/32"
+}

--- a/terraform/modules/bosh_vpc/vpc.tf
+++ b/terraform/modules/bosh_vpc/vpc.tf
@@ -74,3 +74,30 @@ resource "aws_flow_log" "main_vpc_flow_log" {
   traffic_type    = "ALL"
 }
 
+data "aws_network_acls" "default" {
+  vpc_id = aws_vpc.main_vpc.id
+}
+
+resource "aws_network_acl_rule" "deny_rule_ingress_rule_20" {
+  count          = length(data.aws_network_acls.default.ids)
+  rule_number    = 20
+  network_acl_id = data.aws_network_acl.default.ids[count.index]
+  rule_action    = "deny"
+  protocol       = "-1"
+  cidr_block     = var.block_range
+  from_port      = 0
+  to_port        = 0
+  egress         = false
+}
+
+resource "aws_network_acl_rule" "deny_rule_egress_rule_20" {
+  count          = length(data.aws_network_acls.default.ids)
+  rule_number    = 20
+  network_acl_id = data.aws_network_acl.default.id[count.index]
+  rule_action    = "deny"
+  protocol       = "-1"
+  cidr_block     = var.block_range
+  from_port      = 0
+  to_port        = 0
+  egress         = true
+}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -17,6 +17,7 @@ module "vpc" {
   concourse_security_group_cidrs    = var.target_concourse_security_group_cidrs
   bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
   s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
+  block_range_20                    = var.block_range_20
 }
 
 module "rds_network" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -184,3 +184,9 @@ variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }
+
+
+#Placeholder for real value, passed as a secret
+variable "block_range_20" {
+  default = "192.168.0.0/32"
+}

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -29,6 +29,7 @@ module "base" {
   restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
   bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
   s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
+  block_range_20                    = var.block_range_20
 
   rds_security_groups = [
     module.base.bosh_security_group,

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -167,3 +167,9 @@ variable "s3_gateway_policy_accounts" {
   type    = list(string)
   default = []
 }
+
+
+#Placeholder for real value, passed as a secret
+variable "block_range_20" {
+  default = "192.168.0.0/32"
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -213,6 +213,7 @@ module "stack" {
   target_account_id                 = data.aws_caller_identity.tooling.account_id
   bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
   s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
+  block_range_20                    = var.block_range_20
 
   target_vpc_id          = data.terraform_remote_state.target_vpc.outputs.vpc_id
   target_vpc_cidr        = data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -203,3 +203,8 @@ variable "cg_egress_ip_set_arn" {
   type        = string
   description = "ARN of IP set identifying egress IP CIDR ranges for cloud.gov"
 }
+
+#Placeholder for real value, passed as a secret
+variable "block_range_20" {
+  default = "192.168.0.0/32"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add new block_20 for ingress/egress to default ACL for each spoke VPC
-
-

## security considerations
Real value stashed in s3 bucket
