### PR TITLE
Switch to list of ip cidrs to block

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -684,7 +684,7 @@ jobs:
       TF_VAR_customer_whitelist_source_ip_ranges_set_arn: ((customer_whitelist_source_ip_ranges_set_arn))
       TF_VAR_internal_vpc_cidrs_set_arn: ((internal_vpc_cidrs_set_arn))
       TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
-      TF_VAR_block_range_20: ((block_range_20))
+      TF_VAR_cidr_blocks: ((cidr_blocks))
   - *notify-slack
 
 - name: bootstrap-staging
@@ -843,7 +843,7 @@ jobs:
       TF_VAR_customer_whitelist_source_ip_ranges_set_arn: ((customer_whitelist_source_ip_ranges_set_arn))
       TF_VAR_internal_vpc_cidrs_set_arn: ((internal_vpc_cidrs_set_arn))
       TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
-      TF_VAR_block_range_20: ((block_range_20))
+      TF_VAR_cidr_blocks: ((cidr_blocks))
 
   - *notify-slack
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1407,8 +1407,8 @@ resources:
 - name: cg-provision-repo-development
   type: git
   source:
-    uri: cidr_blocks #((cg_provision_git_url))
-    branch: ((cg_provision_git_branch_development))
+    uri: ((cg_provision_git_url))
+    branch: cidr_blocks #((cg_provision_git_branch_development))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: pull-request

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -523,7 +523,7 @@ jobs:
       TF_VAR_customer_whitelist_source_ip_ranges_set_arn: ((customer_whitelist_source_ip_ranges_set_arn))
       TF_VAR_internal_vpc_cidrs_set_arn: ((internal_vpc_cidrs_set_arn))
       TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
-      TF_VAR_block_range_20: ((block_range_20))
+      TF_VAR_cidr_blocks: ((cidr_blocks))
   - *notify-slack
 
 - name: bootstrap-development
@@ -1407,7 +1407,7 @@ resources:
 - name: cg-provision-repo-development
   type: git
   source:
-    uri: ((cg_provision_git_url))
+    uri: cidr_blocks #((cg_provision_git_url))
     branch: ((cg_provision_git_branch_development))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1408,7 +1408,7 @@ resources:
   type: git
   source:
     uri: ((cg_provision_git_url))
-    branch: cidr_blocks #((cg_provision_git_branch_development))
+    branch: ((cg_provision_git_branch_development))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: pull-request

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -67,6 +67,8 @@ variable "s3_gateway_policy_accounts" {
 }
 
 #Placeholder for real value, passed as a secret
-variable "block_range_20" {
-  default = "192.168.0.0/32"
+variable "cidr_blocks" {
+  type    = list(string)
+  default = ["192.168.0.0/32", "192.168.0.1/32"]
 }
+

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -66,9 +66,8 @@ variable "s3_gateway_policy_accounts" {
   default = []
 }
 
-#Placeholder for real value, passed as a secret
 variable "cidr_blocks" {
   type    = list(string)
-  default = ["192.168.0.0/32", "192.168.0.1/32"]
+  default = []
 }
 

--- a/terraform/modules/bosh_vpc/vpc.tf
+++ b/terraform/modules/bosh_vpc/vpc.tf
@@ -78,25 +78,27 @@ data "aws_network_acls" "default" {
   vpc_id = aws_vpc.main_vpc.id
 }
 
-resource "aws_network_acl_rule" "deny_rule_ingress_rule_20" {
-  count          = length(data.aws_network_acls.default.ids)
-  rule_number    = 20
-  network_acl_id = data.aws_network_acls.default.ids[count.index]
+resource "aws_network_acl_rule" "deny_rule_ingress_rules" {
+  count = length(data.aws_network_acls.default.ids) * length(var.cidr_blocks)
+
+  rule_number    = 201 + count.index
+  network_acl_id = data.aws_network_acls.default.ids[count.index / length(var.cidr_blocks)]
   rule_action    = "deny"
   protocol       = "-1"
-  cidr_block     = var.block_range_20
+  cidr_block     = var.cidr_blocks[count.index % length(var.cidr_blocks)]
   from_port      = 0
   to_port        = 0
   egress         = false
 }
 
-resource "aws_network_acl_rule" "deny_rule_egress_rule_20" {
-  count          = length(data.aws_network_acls.default.ids)
-  rule_number    = 20
-  network_acl_id = data.aws_network_acls.default.ids[count.index]
+resource "aws_network_acl_rule" "deny_rule_egress_rules" {
+  count = length(data.aws_network_acls.default.ids) * length(var.cidr_blocks)
+
+  rule_number    = 201 + count.index
+  network_acl_id = data.aws_network_acls.default.ids[count.index / length(var.cidr_blocks)]
   rule_action    = "deny"
   protocol       = "-1"
-  cidr_block     = var.block_range_20
+  cidr_block     = var.cidr_blocks[count.index % length(var.cidr_blocks)]
   from_port      = 0
   to_port        = 0
   egress         = true

--- a/terraform/modules/bosh_vpc/vpc.tf
+++ b/terraform/modules/bosh_vpc/vpc.tf
@@ -79,26 +79,26 @@ data "aws_network_acls" "default" {
 }
 
 resource "aws_network_acl_rule" "deny_rule_ingress_rules" {
-  count = length(data.aws_network_acls.default.ids) * length(var.cidr_blocks)
+  count          = length(var.cidr_blocks)
 
   rule_number    = 201 + count.index
-  network_acl_id = data.aws_network_acls.default.ids[count.index / length(var.cidr_blocks)]
+  network_acl_id = data.aws_network_acls.default.ids[0]
   rule_action    = "deny"
   protocol       = "-1"
-  cidr_block     = var.cidr_blocks[count.index % length(var.cidr_blocks)]
+  cidr_block     = var.cidr_blocks[count.index]
   from_port      = 0
   to_port        = 0
   egress         = false
 }
 
 resource "aws_network_acl_rule" "deny_rule_egress_rules" {
-  count = length(data.aws_network_acls.default.ids) * length(var.cidr_blocks)
+  count          = length(var.cidr_blocks)
 
   rule_number    = 201 + count.index
-  network_acl_id = data.aws_network_acls.default.ids[count.index / length(var.cidr_blocks)]
+  network_acl_id = data.aws_network_acls.default.ids[0]
   rule_action    = "deny"
   protocol       = "-1"
-  cidr_block     = var.cidr_blocks[count.index % length(var.cidr_blocks)]
+  cidr_block     = var.cidr_blocks[count.index]
   from_port      = 0
   to_port        = 0
   egress         = true

--- a/terraform/modules/bosh_vpc/vpc.tf
+++ b/terraform/modules/bosh_vpc/vpc.tf
@@ -81,7 +81,7 @@ data "aws_network_acls" "default" {
 resource "aws_network_acl_rule" "deny_rule_ingress_rules" {
   count          = length(var.cidr_blocks)
 
-  rule_number    = 10 + count.index
+  rule_number    = 20 + count.index
   network_acl_id = data.aws_network_acls.default.ids[0]
   rule_action    = "deny"
   protocol       = "-1"
@@ -94,7 +94,7 @@ resource "aws_network_acl_rule" "deny_rule_ingress_rules" {
 resource "aws_network_acl_rule" "deny_rule_egress_rules" {
   count          = length(var.cidr_blocks)
 
-  rule_number    = 10 + count.index
+  rule_number    = 20 + count.index
   network_acl_id = data.aws_network_acls.default.ids[0]
   rule_action    = "deny"
   protocol       = "-1"

--- a/terraform/modules/bosh_vpc/vpc.tf
+++ b/terraform/modules/bosh_vpc/vpc.tf
@@ -81,7 +81,7 @@ data "aws_network_acls" "default" {
 resource "aws_network_acl_rule" "deny_rule_ingress_rules" {
   count          = length(var.cidr_blocks)
 
-  rule_number    = 201 + count.index
+  rule_number    = 10 + count.index
   network_acl_id = data.aws_network_acls.default.ids[0]
   rule_action    = "deny"
   protocol       = "-1"
@@ -94,7 +94,7 @@ resource "aws_network_acl_rule" "deny_rule_ingress_rules" {
 resource "aws_network_acl_rule" "deny_rule_egress_rules" {
   count          = length(var.cidr_blocks)
 
-  rule_number    = 201 + count.index
+  rule_number    = 10 + count.index
   network_acl_id = data.aws_network_acls.default.ids[0]
   rule_action    = "deny"
   protocol       = "-1"

--- a/terraform/modules/bosh_vpc/vpc.tf
+++ b/terraform/modules/bosh_vpc/vpc.tf
@@ -79,7 +79,7 @@ data "aws_network_acls" "default" {
 }
 
 resource "aws_network_acl_rule" "deny_rule_ingress_rules" {
-  count          = length(var.cidr_blocks)
+  count = length(var.cidr_blocks)
 
   rule_number    = 20 + count.index
   network_acl_id = data.aws_network_acls.default.ids[0]
@@ -92,7 +92,7 @@ resource "aws_network_acl_rule" "deny_rule_ingress_rules" {
 }
 
 resource "aws_network_acl_rule" "deny_rule_egress_rules" {
-  count          = length(var.cidr_blocks)
+  count = length(var.cidr_blocks)
 
   rule_number    = 20 + count.index
   network_acl_id = data.aws_network_acls.default.ids[0]

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -17,7 +17,7 @@ module "vpc" {
   concourse_security_group_cidrs    = var.target_concourse_security_group_cidrs
   bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
   s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
-  block_range_20                    = var.block_range_20
+  cidr_blocks                       = var.cidr_blocks
 }
 
 module "rds_network" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -187,6 +187,7 @@ variable "s3_gateway_policy_accounts" {
 
 
 #Placeholder for real value, passed as a secret
-variable "block_range_20" {
-  default = "192.168.0.0/32"
+variable "cidr_blocks" {
+  type    = list(string)
+  default = ["192.168.0.0/32", "192.168.0.1/32"]
 }

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -186,8 +186,7 @@ variable "s3_gateway_policy_accounts" {
 }
 
 
-#Placeholder for real value, passed as a secret
 variable "cidr_blocks" {
   type    = list(string)
-  default = ["192.168.0.0/32", "192.168.0.1/32"]
+  default = []
 }

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -29,7 +29,7 @@ module "base" {
   restricted_ingress_web_ipv6_cidrs = var.restricted_ingress_web_ipv6_cidrs
   bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
   s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
-  block_range_20                    = var.block_range_20
+  cidr_blocks                       = var.cidr_blocks
 
   rds_security_groups = [
     module.base.bosh_security_group,

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -170,6 +170,7 @@ variable "s3_gateway_policy_accounts" {
 
 
 #Placeholder for real value, passed as a secret
-variable "block_range_20" {
-  default = "192.168.0.0/32"
+variable "cidr_blocks" {
+  type    = list(string)
+  default = ["192.168.0.0/32", "192.168.0.1/32"]
 }

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -169,8 +169,7 @@ variable "s3_gateway_policy_accounts" {
 }
 
 
-#Placeholder for real value, passed as a secret
 variable "cidr_blocks" {
   type    = list(string)
-  default = ["192.168.0.0/32", "192.168.0.1/32"]
+  default = []
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -213,7 +213,7 @@ module "stack" {
   target_account_id                 = data.aws_caller_identity.tooling.account_id
   bosh_default_ssh_public_key       = var.bosh_default_ssh_public_key
   s3_gateway_policy_accounts        = var.s3_gateway_policy_accounts
-  block_range_20                    = var.block_range_20
+  cidr_blocks                       = var.cidr_blocks
 
   target_vpc_id          = data.terraform_remote_state.target_vpc.outputs.vpc_id
   target_vpc_cidr        = data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -204,7 +204,9 @@ variable "cg_egress_ip_set_arn" {
   description = "ARN of IP set identifying egress IP CIDR ranges for cloud.gov"
 }
 
+
 #Placeholder for real value, passed as a secret
-variable "block_range_20" {
-  default = "192.168.0.0/32"
+variable "cidr_blocks" {
+  type    = list(string)
+  default = ["192.168.0.0/32", "192.168.0.1/32"]
 }

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -204,9 +204,7 @@ variable "cg_egress_ip_set_arn" {
   description = "ARN of IP set identifying egress IP CIDR ranges for cloud.gov"
 }
 
-
-#Placeholder for real value, passed as a secret
 variable "cidr_blocks" {
   type    = list(string)
-  default = ["192.168.0.0/32", "192.168.0.1/32"]
+  default = []
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch for a single cidr range to a list of cidr ranges which will dynamically be created starting at rule 20
- This solution has a maximum of 80 cidr ranges without intervention
- Tested manually against dev

## security considerations
None, end result is the exact same acl rules just future proofing if we need to expand the list of ip cidrs
