### PR TITLE
Rotate ext domain broker keys

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/outputs.tf
+++ b/terraform/modules/external_domain_broker_govcloud/outputs.tf
@@ -3,7 +3,7 @@ output "username" {
 }
 
 output "access_key_id_prev" {
-  value = aws_iam_access_key.iam_access_key_v2.secret
+  value = aws_iam_access_key.iam_access_key_v2.id
 }
 
 output "secret_access_key_prev" {

--- a/terraform/modules/external_domain_broker_govcloud/outputs.tf
+++ b/terraform/modules/external_domain_broker_govcloud/outputs.tf
@@ -3,18 +3,18 @@ output "username" {
 }
 
 output "access_key_id_prev" {
-  value = aws_iam_access_key.iam_access_key_v1.id
+  value = aws_iam_access_key.iam_access_key_v2.secret
 }
 
 output "secret_access_key_prev" {
-  value = aws_iam_access_key.iam_access_key_v1.secret
+  value = aws_iam_access_key.iam_access_key_v2.secret
 }
 
 output "access_key_id_curr" {
-  value = aws_iam_access_key.iam_access_key_v2.id
+  value = aws_iam_access_key.iam_access_key_v3.id
 }
 
 output "secret_access_key_curr" {
-  value = aws_iam_access_key.iam_access_key_v2.secret
+  value = aws_iam_access_key.iam_access_key_v3.secret
 }
 

--- a/terraform/modules/external_domain_broker_govcloud/resources.tf
+++ b/terraform/modules/external_domain_broker_govcloud/resources.tf
@@ -15,11 +15,11 @@ resource "aws_iam_user" "iam_user" {
   name = "external-domain-broker-gov-${var.stack_description}"
 }
 
-resource "aws_iam_access_key" "iam_access_key_v1" {
+resource "aws_iam_access_key" "iam_access_key_v2" {
   user = aws_iam_user.iam_user.name
 }
 
-resource "aws_iam_access_key" "iam_access_key_v2" {
+resource "aws_iam_access_key" "iam_access_key_v3" {
   user = aws_iam_user.iam_user.name
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- removing one of the keys as there were two keys in IAM (Manually deleted the unused)
- creating the new key to rotate to while leaving behind the old key that is currently being used

## security considerations
None
