### PR TITLE
add ECR repo for playwright-python

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -18,7 +18,7 @@ variable "repositories" {
     "github-pr-resource",
     "harden-concourse-task",
     "harden-concourse-task-staging",
-    "harden-playwright",
+    "playwright-python",
     "harden-s3-resource-simple",
     "harden-s3-resource-simple-staging",
     "pages-dind-v25",


### PR DESCRIPTION
## Changes proposed in this pull request:

The hardened Playwright image is now specific to Python: https://github.com/cloud-gov/playwright-python, so renaming the ECR repo to make it contents clearer

## security considerations

No security concerns for this change, but having the ECR repo facilitates using hardened images in CI
