### PR TITLE
add delete repo permissions for ECR to concourse-worker role

### DIFF
--- a/terraform/modules/iam_role_policy/ecr/policy.json
+++ b/terraform/modules/iam_role_policy/ecr/policy.json
@@ -22,6 +22,7 @@
         "Effect": "Allow",
         "Action": [
             "ecr:CreateRepository",
+            "ecr:DeleteRepository",
             "ecr:GetAuthorizationToken",
             "ecr:DeleteLifecyclePolicy",
             "ecr:GetLifecyclePolicy",


### PR DESCRIPTION
## Changes proposed in this pull request:

CI is failing when trying to delete an ECR repo because it doesn't have permissions, so this PR adds those missing permissions

## security considerations

Deleting ECR repos is an expected behavior of this repo since it now manages ECR repos: https://github.com/cloud-gov/cg-provision/blob/main/terraform/stacks/ecr/stack.tf
