### PR TITLE
Remove deprecated page-playwright-v1 image

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -23,7 +23,6 @@ variable "repositories" {
     "harden-s3-resource-simple-staging",
     "pages-dind-v25",
     "pages-node-v20",
-    "pages-playwright-v1",
     "pages-python-v3.11",
     "playwright-python",
     "registry-image-resource",


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes deprecated page-playwright-v1 image

## security considerations
None
