### PR TITLE
set action back to count for BlockMaliciousJA3FingerprintIDs

### DIFF
--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -548,7 +548,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
     name     = "BlockMaliciousJA3FingerprintIDs"
     priority = 7
     action {
-      block {}
+      count {}
     }
     statement {
       or_statement {


### PR DESCRIPTION
## Changes proposed in this pull request:

Revert action to COUNT instead of BLOCK as changed in #1629 , since it blocked legitimate traffic

## security considerations

Cannot leave this enabled since it blocks legitimate traffic
