### PR TITLE
Allow brokered ElasticSearch clusters to write to CloudWatch

### DIFF
--- a/terraform/modules/cloudwatch/policies.tf
+++ b/terraform/modules/cloudwatch/policies.tf
@@ -1,0 +1,22 @@
+# Allow managed OpenSearch clusters, which we broker to customers, to publish logs
+# to CloudWatch. Necessary to enable logging on those clusters.
+data "aws_iam_policy_document" "elasticsearch-log-publishing-policy" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["arn:aws:logs:*"]
+
+    principals {
+      identifiers = ["es.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "elasticsearch-log-publishing-policy" {
+  policy_document = data.aws_iam_policy_document.elasticsearch-log-publishing-policy.json
+  policy_name     = "elasticsearch-log-publishing-policy"
+}


### PR DESCRIPTION
Without one policy that applies to all log groups, we must create one-off policies for each cluster + log group, and we quickly hit the quota of ten policies per account. See the "Important" callout here: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/createdomain-configure-slow-logs.html#createdomain-configure-slow-logs-console

Related ticket: https://cloud-gov-new.zendesk.com/agent/tickets/8298

Example code from https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy#example-usage

## security considerations

Allows the ElasticSearch service to write to all log groups in CloudWatch. Because ElasticSearch logging can only be configured by cloud.gov staff, and there was no way to limit the principal so that clusters could only write to their own log groups in the first place, this is a lateral security move. 