### PR TITLE
fix WAF rules to have unique metric names

### DIFF
--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -460,7 +460,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
     }
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.stack_description}-AWS-AWSManagedRulesCommonRuleSet"
+      metric_name                = "${var.stack_description}-CG-RegexPatternSets"
       sampled_requests_enabled   = true
     }
   }

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -663,7 +663,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.stack_description}-RateLimitSourceIPChallenge"
+      metric_name                = "${var.stack_description}-RateLimitNonCDNBySourceIPChallenge"
       sampled_requests_enabled   = true
     }
   }
@@ -708,7 +708,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.stack_description}-RateLimitSourceIPChallenge"
+      metric_name                = "${var.stack_description}-RateLimitForwardedIPChallenge"
       sampled_requests_enabled   = true
     }
   }
@@ -777,7 +777,7 @@ resource "aws_wafv2_web_acl" "cf_uaa_waf_core" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.stack_description}-RateLimitSourceIPChallenge"
+      metric_name                = "${var.stack_description}-RateLimitNonCDNBySourceIPBlock"
       sampled_requests_enabled   = true
     }
   }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Make sure our WAF rules have different metric names. Right now, multiple rules are being aggregated with the same metric name, which doesn't allow us to see the specific request counts per rule

## security considerations

Improves our visibility into WAF rule effectiveness
