### PR TITLE
Add an IAM user for the Cloud Service Broker and the SMTP brokerpak

### DIFF
--- a/terraform/modules/csb/README.md
+++ b/terraform/modules/csb/README.md
@@ -1,0 +1,5 @@
+# Module CSB
+
+Resources related to the Cloud Service Broker.
+
+See also https://github.com/cloud-gov/csb.

--- a/terraform/modules/csb/iam.tf
+++ b/terraform/modules/csb/iam.tf
@@ -1,0 +1,86 @@
+// Originally from https://github.com/GSA-TTS/datagov-brokerpak-smtp/blob/main/permission-policies.tf
+locals {
+  this_aws_account_id = data.aws_caller_identity.current.account_id
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "brokerpak_smtp" {
+  statement {
+    effect    = "Allow"
+    actions   = ["ses:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateUser",
+      "iam:DeleteUser",
+      "iam:GetUser",
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:GetUserPolicy",
+      "iam:PutUserPolicy",
+      "iam:DeleteUserPolicy",
+      "iam:CreatePolicy",
+      "iam:DeletePolicy",
+      "iam:GetPolicy",
+      "iam:AttachUserPolicy",
+      "iam:DetachUserPolicy",
+      "iam:List*"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["route53:ListHostedZones"]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sns:CreateTopic",
+      "sns:DeleteTopic",
+      "sns:SetTopicAttributes",
+      "sns:GetTopicAttributes",
+      "sns:ListTagsForResource",
+      "sns:Subscribe",
+      "sns:Unsubscribe",
+      "sns:GetSubscriptionAttributes"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "brokerpak_smtp" {
+  name        = "brokerpak_smtp"
+  description = "SMTP broker policy (covers SES, IAM, and supplementary Route53)"
+  policy      = data.aws_iam_policy_document.brokerpak_smtp.json
+}
+
+resource "aws_iam_user" "iam_user" {
+  name = "${var.stack_description}-csb"
+}
+
+resource "aws_iam_access_key" "iam_access_key" {
+  user = aws_iam_user.iam_user.name
+}
+
+resource "aws_iam_user_policy_attachment" "csb_policies" {
+  for_each = toset([
+    // ACM manager: for aws_acm_certificate, aws_acm_certificate_validation
+    "arn:aws-us-gov:iam::aws:policy/AWSCertificateManagerFullAccess",
+
+    // Route53 manager: for aws_route53_record, aws_route53_zone
+    "arn:aws-us-gov:iam::aws:policy/AmazonRoute53FullAccess",
+
+    // SMTP brokerpak policy defined above
+    "arn:aws-us-gov:iam::${local.this_aws_account_id}:policy/${aws_iam_policy.brokerpak_smtp.name}",
+  ])
+
+  user       = aws_iam_user.iam_user.name
+  policy_arn = each.key
+}

--- a/terraform/modules/csb/outputs.tf
+++ b/terraform/modules/csb/outputs.tf
@@ -1,0 +1,22 @@
+output "username" {
+  value = aws_iam_user.iam_user.name
+}
+
+output "access_key_id_prev" {
+  value = ""
+}
+
+output "secret_access_key_prev" {
+  value = ""
+}
+
+output "access_key_id_curr" {
+  value     = aws_iam_access_key.iam_access_key.id
+  sensitive = true
+}
+
+output "secret_access_key_curr" {
+  value     = aws_iam_access_key.iam_access_key.secret
+  sensitive = true
+}
+

--- a/terraform/modules/csb/variables.tf
+++ b/terraform/modules/csb/variables.tf
@@ -1,0 +1,3 @@
+variable "stack_description" {
+  description = "Like development, staging, or production."
+}

--- a/terraform/modules/csb/versions.tf
+++ b/terraform/modules/csb/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 6.0.0"
+    }
+  }
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -434,7 +434,7 @@ module "sns" {
 }
 
 module "cloud_service_broker" {
-  source "../../modules/csb"
+  source = "../../modules/csb"
 
   stack_description = var.stack_description
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -432,3 +432,9 @@ module "sns" {
   sns_cg_platform_slack_notifications_name  = "${var.stack_description}-platform-slack-notifications"
   sns_cg_platform_slack_notifications_email = var.sns_cg_platform_slack_notifications_email
 }
+
+module "cloud_service_broker" {
+  source "../../modules/csb"
+
+  stack_description = var.stack_description
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Code based on previous work by data.gov: https://github.com/GSA-TTS/datagov-brokerpak-smtp/blob/main/permission-policies.tf
- Related to https://github.com/cloud-gov/product/issues/2988
- Related to https://github.com/cloud-gov/product/issues/2989

## security considerations

The new user has access that might be better scoped down, but not having run the brokerpak yet, I'm not sure exactly what it needs. I will make a note to use the IAM Access Analyzer to scope down the permissions after testing — especially the two FullAccess policies. Issue here: https://github.com/cloud-gov/product/issues/2993