### PR TITLE
Output new CSB access key to terraform state and rename module

### DIFF
--- a/terraform/modules/csb/outputs.tf
+++ b/terraform/modules/csb/outputs.tf
@@ -19,4 +19,3 @@ output "secret_access_key_curr" {
   value     = aws_iam_access_key.iam_access_key.secret
   sensitive = true
 }
-

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -645,6 +645,15 @@ output "external_domain_broker_gov_secret_access_key_prev" {
   sensitive = true
 }
 
+output "csb_gov_access_key_id_curr" {
+  value = module.csb.access_key_id_curr
+}
+
+output "csb_gov_secret_access_key_curr" {
+  value     = module.csb.secret_access_key_curr
+  sensitive = true
+}
+
 output "domains_dedicated_lbgroup_target_group_apps_https_names" {
   value = module.dedicated_loadbalancer_group.domains_lbgroup_target_group_apps_https_names
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -433,7 +433,7 @@ module "sns" {
   sns_cg_platform_slack_notifications_email = var.sns_cg_platform_slack_notifications_email
 }
 
-module "cloud_service_broker" {
+module "csb" {
   source = "../../modules/csb"
 
   stack_description = var.stack_description


### PR DESCRIPTION
## Changes proposed in this pull request:

- Once the broker is managed in Terraform, this will no longer be necessary, but for now, there is no other way to access it.
- Also make module name "csb", consistent with other usages.

## security considerations

Outputs a new credential to terraform state. State is stored securely and sensitive values are marked as such. 