### PR TITLE
Match other keys in not marking access_key_id sensitive

### DIFF
--- a/terraform/modules/csb/outputs.tf
+++ b/terraform/modules/csb/outputs.tf
@@ -11,8 +11,7 @@ output "secret_access_key_prev" {
 }
 
 output "access_key_id_curr" {
-  value     = aws_iam_access_key.iam_access_key.id
-  sensitive = true
+  value = aws_iam_access_key.iam_access_key.id
 }
 
 output "secret_access_key_curr" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Required to fix a build error in which the sensitivity between the module and stack outputs does not match
-
-

## security considerations

Follows existing practice, which is also best practice for handling AWS access keys.