### PR TITLE
Adding weights for forwarding

### DIFF
--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -56,8 +56,18 @@ resource "aws_lb_listener" "cf_apps" {
   certificate_arn   = var.elb_apps_cert_id
 
   default_action {
-    target_group_arn = aws_lb_target_group.cf_apps_target_https.arn
-    type             = "forward"
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.cf_apps_target_https.arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.cf_gr_apps_target_https.arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 }
 
@@ -67,8 +77,18 @@ resource "aws_lb_listener" "cf_apps_http" {
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_lb_target_group.cf_apps_target_https.arn
-    type             = "forward"
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.cf_apps_target_https.arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.cf_gr_apps_target_https.arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 }
 
@@ -110,8 +130,18 @@ resource "aws_lb_listener_rule" "logstash_listener_rule" {
   listener_arn = aws_lb_listener.cf_apps.arn
 
   action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.cf_logstash_target_https.arn
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.cf_logstash_target_https.arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.cf_gr_logstash_target_https.arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 
   condition {

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -56,8 +56,18 @@ resource "aws_lb_listener" "cf" {
   certificate_arn   = var.elb_main_cert_id
 
   default_action {
-    target_group_arn = aws_lb_target_group.cf_target_https.arn
-    type             = "forward"
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.cf_target_https.arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.cf_gr_target_https.arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 }
 
@@ -67,8 +77,18 @@ resource "aws_lb_listener" "cf_http" {
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_lb_target_group.cf_target_https.arn
-    type             = "forward"
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.cf_target_https.arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.cf_gr_target_https.arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 }
 

--- a/terraform/modules/cloudfoundry/elb_uaa.tf
+++ b/terraform/modules/cloudfoundry/elb_uaa.tf
@@ -56,8 +56,18 @@ resource "aws_lb_listener" "cf_uaa" {
   certificate_arn   = var.elb_main_cert_id
 
   default_action {
-    target_group_arn = aws_lb_target_group.cf_uaa_target.arn
-    type             = "forward"
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.cf_uaa_target.arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.cf_gr_uaa_target.arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 }
 
@@ -67,8 +77,18 @@ resource "aws_lb_listener" "cf_uaa_http" {
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_lb_target_group.cf_uaa_target.arn
-    type             = "forward"
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.cf_uaa_target.arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.cf_gr_uaa_target.arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 }
 

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -218,3 +218,15 @@ variable "cg_egress_ip_set_arn" {
   type        = string
   description = "ARN of IP set identifying egress IP CIDR ranges for cloud.gov"
 }
+
+variable "loadbalancer_forward_original_weight" {
+  type        = number
+  description = "Weight of traffic to send to original target groups"
+  default     = 100
+}
+
+variable "loadbalancer_forward_new_weight" {
+  type        = number
+  description = "Weight of traffic to send to original target groups"
+  default     = 0
+}

--- a/terraform/modules/external_domain_broker_loadbalancer_group/resources.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/resources.tf
@@ -28,8 +28,18 @@ resource "aws_lb_listener" "domains_lbgroup_http" {
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_lb_target_group.domains_lbgroup_apps_https[count.index].arn
-    type             = "forward"
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.domains_lbgroup_apps_https[count.index].arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.domains_lbgroup_gr_apps_https[count.index].arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 }
 
@@ -43,8 +53,18 @@ resource "aws_lb_listener" "domains_lbgroup_https" {
   certificate_arn   = var.wildcard_arn
 
   default_action {
-    target_group_arn = aws_lb_target_group.domains_lbgroup_apps_https[count.index].arn
-    type             = "forward"
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.domains_lbgroup_apps_https[count.index].arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.domains_lbgroup_gr_apps_https[count.index].arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 }
 
@@ -56,8 +76,18 @@ resource "aws_lb_listener_rule" "domains_lbgroup_logstash_listener_rule" {
   listener_arn = aws_lb_listener.domains_lbgroup_https[count.index].arn
 
   action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.domains_lbgroup_logstash_https[count.index].arn
+    type = "forward"
+
+    forward {
+      target_group {
+        arn    = aws_lb_target_group.domains_lbgroup_logstash_https[count.index].arn
+        weight = var.loadbalancer_forward_original_weight
+      }
+      target_group {
+        arn    = aws_lb_target_group.domains_lbgroup_gr_logstash_https[count.index].arn
+        weight = var.loadbalancer_forward_new_weight
+      }
+    }
   }
 
   condition {

--- a/terraform/modules/external_domain_broker_loadbalancer_group/variables.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/variables.tf
@@ -32,3 +32,15 @@ variable "waf_arn" {
 variable "wildcard_arn" {
 
 }
+
+variable "loadbalancer_forward_original_weight" {
+  type        = number
+  description = "Weight of traffic to send to original target groups"
+  default     = 100
+}
+
+variable "loadbalancer_forward_new_weight" {
+  type        = number
+  description = "Weight of traffic to send to original target groups"
+  default     = 0
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -287,6 +287,9 @@ module "cf" {
   malicious_ja3_fingerprint_ids               = var.malicious_ja3_fingerprint_ids
   internal_vpc_cidrs_set_arn                  = var.internal_vpc_cidrs_set_arn
   cg_egress_ip_set_arn                        = var.cg_egress_ip_set_arn
+
+  loadbalancer_forward_original_weight = var.loadbalancer_forward_original_weight
+  loadbalancer_forward_new_weight      = var.loadbalancer_forward_new_weight
 }
 
 

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -220,3 +220,15 @@ variable "cidr_blocks" {
 
 variable "domains_lbgroup_count" {
 }
+
+variable "loadbalancer_forward_original_weight" {
+  type        = number
+  description = "Weight of traffic to send to original target groups"
+  default     = 100
+}
+
+variable "loadbalancer_forward_new_weight" {
+  type        = number
+  description = "Weight of traffic to send to original target groups"
+  default     = 0
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- This enables forwarding traffic to two different target groups (old and new)
- Preps for shifting traffic to new target group easier by adjusting one variable

## security considerations
None, this won't do anything until we change the weights