### PR TITLE
Restrict CSB resources to development environment only while iterating

### DIFF
--- a/terraform/modules/csb/iam.tf
+++ b/terraform/modules/csb/iam.tf
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "brokerpak_smtp" {
 }
 
 resource "aws_iam_policy" "brokerpak_smtp" {
-  name        = "brokerpak_smtp"
+  name        = "${var.stack_description}-brokerpak-smtp"
   description = "SMTP broker policy (covers SES, IAM, and supplementary Route53)"
   policy      = data.aws_iam_policy_document.brokerpak_smtp.json
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -434,9 +434,6 @@ module "sns" {
 }
 
 module "csb" {
-  // Deploy only to development while iterating.
-  // See progress at https://github.com/cloud-gov/product/issues/2512.
-  count  = var.stack_description == "development" ? 1 : 0
   source = "../../modules/csb"
 
   stack_description = var.stack_description

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -434,6 +434,9 @@ module "sns" {
 }
 
 module "csb" {
+  // Deploy only to development while iterating.
+  // See progress at https://github.com/cloud-gov/product/issues/2512.
+  count  = var.stack_description == "development" ? 1 : 0
   source = "../../modules/csb"
 
   stack_description = var.stack_description


### PR DESCRIPTION
## Changes proposed in this pull request:

- Restrict CSB resources to development environment only while iterating
- Resources should not be deployed to production until the SCR is approved
- Avoids naming conflicts for certain resources, like the IAM policy, while iterating
- Related to https://github.com/cloud-gov/product/issues/2988 and https://github.com/cloud-gov/product/issues/2989

## security considerations

Improves security by keeping pre-prod configurations out of production.
