### PR TITLE
Update resource arn for elasticsearch logs

### DIFF
--- a/terraform/modules/cloudwatch/policies.tf
+++ b/terraform/modules/cloudwatch/policies.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "elasticsearch-log-publishing-policy" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*"]
+    resources = ["arn:${var.aws_partition}:logs:*"]
 
     principals {
       identifiers = ["es.amazonaws.com"]

--- a/terraform/modules/cloudwatch/variables.tf
+++ b/terraform/modules/cloudwatch/variables.tf
@@ -16,3 +16,7 @@ variable "cg_platform_slack_notifications_arn" {
 variable "load_balancer_dns" {
 
 }
+
+variable "aws_partition" {
+
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -426,6 +426,7 @@ module "cloudwatch" {
   cg_platform_notifications_arn       = module.sns.cg_platform_notifications_arn
   cg_platform_slack_notifications_arn = module.sns.cg_platform_slack_notifications_arn
   load_balancer_dns                   = module.cf.lb_arn_suffix
+  aws_partition                       = data.aws_partition.current.partition
 }
 
 module "sns" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updates resource policy to use `arn:aws-us-gov:logs` as opposed to `arn:aws:logs`

## security considerations
None
