### PR TITLE
add public access block and lifecycle for cloudfront log buckets

### DIFF
--- a/terraform/modules/external_domain_broker/resources.tf
+++ b/terraform/modules/external_domain_broker/resources.tf
@@ -57,6 +57,39 @@ resource "aws_s3_bucket" "cloudfront_log_bucket" {
   bucket = "external-domain-broker-cloudfront-logs-${var.stack_description}"
 }
 
+resource "aws_s3_bucket_public_access_block" "cloudfront_log_bucket_block_public" {
+  bucket = aws_s3_bucket.cloudfront_log_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_log_bucket_lifecycle" {
+  bucket = aws_s3_bucket.cloudfront_log_bucket.id
+  rule {
+    id = "log-rule"
+    filter {
+      prefix = ""
+    }
+    status = "Enabled"
+    transition {
+      days          = 90
+      storage_class = "GLACIER_IR"
+    }
+    transition {
+      days          = 365
+      storage_class = "DEEP_ARCHIVE"
+    }
+    # Delete objects after 30 months per M-21-31 guidelines
+    # 31 days * 30 months = 930 days
+    expiration {
+      days = 930
+    }
+  }
+}
+
 resource "aws_s3_bucket_acl" "cloudfront_log_bucket_acl" {
   bucket = aws_s3_bucket.cloudfront_log_bucket.id
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- add public access block to cloudfront log buckets so that objects can never be public
- add lifecycle to cloudfront log buckets to move them into cheaper storage classes as they age and delete them entirely after 930 days. 930 days = 30 months and is the maximum required storage duration of logs per M-21-31

## security considerations

Ensures that objects can never be made public accidentally and still confirms with M-21-31 guidelines