### PR TITLE
sort cidr blocks for security group to avoid unnecessary TF changes

### DIFF
--- a/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
@@ -14,16 +14,16 @@ resource "aws_security_group" "restricted_web_traffic" {
     from_port        = 80
     to_port          = 80
     protocol         = "tcp"
-    cidr_blocks      = var.restricted_ingress_web_cidrs
-    ipv6_cidr_blocks = var.restricted_ingress_web_ipv6_cidrs
+    cidr_blocks      = sort(var.restricted_ingress_web_cidrs)
+    ipv6_cidr_blocks = sort(var.restricted_ingress_web_ipv6_cidrs)
   }
 
   ingress {
     from_port        = 443
     to_port          = 443
     protocol         = "tcp"
-    cidr_blocks      = var.restricted_ingress_web_cidrs
-    ipv6_cidr_blocks = var.restricted_ingress_web_ipv6_cidrs
+    cidr_blocks      = sort(var.restricted_ingress_web_cidrs)
+    ipv6_cidr_blocks = sort(var.restricted_ingress_web_ipv6_cidrs)
   }
 
   egress {


### PR DESCRIPTION
## Changes proposed in this pull request:

Terraform sometimes shows that there are pending changes to the CIDR blocks for a security group when in reality it is just reordering them. I think that by sorting the CIDR blocks input to the security group, it should cause Terraform to always apply them in a consistent order and avoid confusing `plan` output that implies that things are changing when in fact they're just being reorganized.

## security considerations

None, just addressing some confusing Terraform behavior
