### PR TITLE
Delete Cloudfront resources

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,19 @@
 version: 2
 updates:
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/autoscaler"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/bosh_vpc"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
-    directory: "/terraform/modules/cdn_broker"
+    directory: "/terraform/modules/bosh_vpc_v2"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
-    directory: "/terraform/modules/cloudwatch"
+    directory: "/terraform/modules/cdn_broker"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
@@ -25,7 +29,15 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/cloudwatch"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/concourse"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/concourse_v2"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
@@ -33,7 +45,23 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/credhub_v2"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/csb"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/cvd_mirror"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/cvd_mirror_v2"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/defect_dojo"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
@@ -66,6 +94,10 @@ updates:
       interval: "weekly"
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/external_domain_broker_govcloud"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/external_domain_broker_loadbalancer_group"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
@@ -121,6 +153,10 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/iam_role_policy/logs_opensearch_ingestor"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/iam_role_policy/logsearch_ingestor"
     schedule:
       interval: "weekly"
@@ -165,7 +201,27 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/iam_user/s3_logstash"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/iam_user/terraform_provision"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/jumpbox"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/log_bucket"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/log_bucket_v2"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/logs_opensearch"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
@@ -177,6 +233,10 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/monitoring_v2"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/rds"
     schedule:
       interval: "weekly"
@@ -185,11 +245,19 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/rds_network_v2"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/regionalmaster_dns"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
     directory: "/terraform/modules/s3_bucket/encrypted_bucket"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/s3_bucket/encrypted_bucket_v2"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
@@ -205,6 +273,10 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/s3_bucket/semver_bucket"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/shibboleth"
     schedule:
       interval: "weekly"
@@ -213,11 +285,23 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/sns"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/stack/base"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/modules/stack/base_v2"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/modules/stack/spoke"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/modules/test_cdn_dns"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
@@ -233,11 +317,23 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
+    directory: "/terraform/stacks/bootstrap-westa-hub"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
     directory: "/terraform/stacks/cloudfront"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
     directory: "/terraform/stacks/dns"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/stacks/dns-westa-hub"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/stacks/ecr"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
@@ -258,5 +354,9 @@ updates:
       interval: "weekly"
   - package-ecosystem: "terraform"
     directory: "/terraform/stacks/tooling"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/stacks/westa-hub"
     schedule:
       interval: "weekly"

--- a/terraform/modules/cloudfront/distribution.tf
+++ b/terraform/modules/cloudfront/distribution.tf
@@ -45,8 +45,3 @@ resource "aws_cloudfront_distribution" "distribution" {
   }
   web_acl_id = var.acl_arn
 }
-
-resource "aws_shield_protection" "shield_protection" {
-  name         = aws_cloudfront_distribution.distribution.domain_name
-  resource_arn = aws_cloudfront_distribution.distribution.arn
-}

--- a/terraform/stacks/cloudfront/stack.tf
+++ b/terraform/stacks/cloudfront/stack.tf
@@ -1,17 +1,3 @@
-# Most stacks do not pass credentials this way. For an explanation of why
-# access and state are managed differently in the cloudfront stack compared
-# to the other stacks, see README.md, "DNS and CloudFront Stacks" in the root
-# of the repo.
-variable "aws_access_key" {
-}
-
-variable "aws_secret_key" {
-  sensitive = true
-}
-
-variable "aws_region" {
-}
-
 terraform {
   backend "s3" {
   }
@@ -45,33 +31,4 @@ data "terraform_remote_state" "govcloud" {
     region = var.remote_state_region
     key    = "${var.stack_description}/terraform.tfstate"
   }
-}
-
-# One ACL for all distributions in the environment.
-resource "aws_wafv2_web_acl" "commercial_acl" {
-  name        = "${var.stack_description}-commercial-acl"
-  description = "ACL for use with CloudFront and Shield Advanced."
-  scope       = "CLOUDFRONT"
-
-  default_action {
-    # no rules needed; they'll be added by Shield Advanced.
-    allow {
-    }
-  }
-
-  visibility_config {
-    cloudwatch_metrics_enabled = true
-    metric_name                = "${var.stack_description}-commercial-acl-metric"
-    sampled_requests_enabled   = true
-  }
-}
-
-module "star_admin" {
-  source = "../../modules/cloudfront"
-  origin = {
-    lb_dns_name   = data.terraform_remote_state.govcloud.outputs.cf_lb_dns_name
-    lb_http_port  = 80  # modules/cloudfoundry/elb_main.tf "aws_lb" "cf"
-    lb_https_port = 443 # modules/cloudfoundry/elb_main.tf "aws_lb" "cf"
-  }
-  acl_arn = aws_wafv2_web_acl.commercial_acl.arn
 }

--- a/terraform/stacks/cloudfront/variables.tf
+++ b/terraform/stacks/cloudfront/variables.tf
@@ -1,3 +1,17 @@
+# Most stacks do not pass credentials this way. For an explanation of why
+# access and state are managed differently in the cloudfront stack compared
+# to the other stacks, see README.md, "DNS and CloudFront Stacks" in the root
+# of the repo.
+variable "aws_access_key" {
+}
+
+variable "aws_secret_key" {
+  sensitive = true
+}
+
+variable "aws_region" {
+}
+
 variable "stack_description" {
   type = string
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- Delete unused CloudFront distributions in external accounts
- Update dependabot file for monitoring code

## security considerations

These CloudFront distributions are not currently used by anything, so there is no harm to deleting them 
