### PR TITLE
Add WAF log group for external domain broker

### DIFF
--- a/terraform/modules/external_domain_broker/cloudwatch.tf
+++ b/terraform/modules/external_domain_broker/cloudwatch.tf
@@ -1,4 +1,4 @@
 resource "aws_cloudwatch_log_group" "external_domain_waf_logs" {
-  name = "aws-waf-logs-external-domain-broker-${var.stack_description}"
+  name              = "aws-waf-logs-external-domain-broker-${var.stack_description}"
   retention_in_days = 365
 }

--- a/terraform/modules/external_domain_broker/cloudwatch.tf
+++ b/terraform/modules/external_domain_broker/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "external_domain_waf_logs" {
+  name = "aws-waf-logs-external-domain-broker-${var.stack_description}"
+  retention_in_days = 365
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

Closes https://github.com/cloud-gov/private/issues/1096

- add cloudwatch log group for WAF on resources created by external domain broker

## security considerations

This PR creates predictably named Cloudwatch log groups for the web ACLs that will be applied to resources created by the external domain broker. These logs allow us to audit the behavior of the web ACLs and inspect the incoming traffic
