### PR TITLE
Fix S3 lifecycle configuration

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+echo "Applying Terraform fomatting"
+
 terraform fmt -recursive -diff

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+terraform fmt -recursive -diff

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+add-githooks:
+	find .git/hooks -type l -exec rm {} \;
+	find .githooks -type f -exec ln -sf ../../{} .git/hooks/ \;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloud.gov Provisioning System 
+# Cloud.gov Provisioning System
 
 This repository holds the terraform configuration (and BOSH vars and ops-files)
 to bootstrap our infrastructure.
@@ -6,6 +6,15 @@ to bootstrap our infrastructure.
 Be sure to read the internal developer documentation ("cg-provision") for
 non-public information about using this repository.
 
+## Local development
+
+### Git hooks
+
+Some [Git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) that may be useful when updating this code are provided in the `.githooks` directory. To install these Git hooks so that they run automatically, use the provided `make` command:
+
+```shell
+make add-githooks
+```
 
 ## Layout
 
@@ -97,7 +106,7 @@ The IAM role and `TF_VAR_` credentials are used as follows:
 * The terraform provider is configured with the Commercial credentials, ensuring that all resources will be created in the Commercial account.
 * The `terraform_remote_state` data blocks for each GovCloud s3 state object are configured with the GovCloud region. Because they are accessed using Terraform's initialization process, but separately from the initial `terraform init`, they are not passed the Commercial credentials. Without any credentials set explicitly, the AWS SDK uses the GovCloud IAM role.
 
-## Development Workflow
+## Deployment Workflow
 
 Since IaaS is a shared resource (we don't have the money or time to provision
 entire stacks for each developer), we never apply this configuration manually.

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -27,13 +27,16 @@ resource "aws_s3_bucket_acl" "encrypted_bucket_acl" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
   bucket = aws_s3_bucket.encrypted_bucket.id
+  # since the only rule is an expiration rule, we only create the lifecycle
+  # configuration if expiration days are set
+  count = var.expiration_days == 0 ? 0 : 1
 
   dynamic "rule" {
-    # if expiration_days is 0 then the rule is not created
     for_each = var.expiration_days == 0 ? [] : [var.expiration_days]
 
     content {
-      id     = "expiration-rule"
+      id = "expiration-rule"
+      # if expiration_days is 0 then the rule is disabled
       status = "Enabled"
 
       expiration {

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -36,7 +36,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
 
     content {
       id = "expiration-rule"
-      # if expiration_days is 0 then the rule is disabled
       status = "Enabled"
 
       expiration {

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -35,7 +35,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
     for_each = var.expiration_days == 0 ? [] : [var.expiration_days]
 
     content {
-      id = "expiration-rule"
+      id     = "expiration-rule"
       status = "Enabled"
 
       expiration {

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -28,16 +28,16 @@ resource "aws_s3_bucket_acl" "encrypted_bucket_acl" {
 resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
   bucket = aws_s3_bucket.encrypted_bucket.id
 
-  rule {
-    id = "rule0"
-    # if expiration_days is 0 then the rule is disabled
-    status = var.expiration_days == 0 ? "Disabled" : "Enabled"
+  dynamic "rule" {
+    # if expiration_days is 0 then the rule is not created
+    for_each = var.expiration_days == 0 ? [] : [var.expiration_days]
 
-    dynamic "expiration" {
-      for_each = var.expiration_days == 0 ? [] : [var.expiration_days]
+    content {
+      id     = "expiration-rule"
+      status = "Enabled"
 
-      content {
-        days = expiration.value
+      expiration {
+        days = rule.value
       }
     }
   }

--- a/terraform/modules/s3_bucket/encrypted_bucket_v2/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket_v2/encrypted_bucket.tf
@@ -30,7 +30,10 @@ resource "aws_s3_bucket_versioning" "encrypted_bucket_versioning" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
   bucket = aws_s3_bucket.encrypted_bucket.id
-  
+  # since the only rule is an expiration rule, we only create the lifecycle
+  # configuration if expiration days are set
+  count = var.expiration_days == 0 ? 0 : 1
+
   dynamic "rule" {
     # if expiration_days is 0 then the rule is not created
     for_each = var.expiration_days == 0 ? [] : [var.expiration_days]

--- a/terraform/modules/s3_bucket/encrypted_bucket_v2/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket_v2/encrypted_bucket.tf
@@ -30,17 +30,17 @@ resource "aws_s3_bucket_versioning" "encrypted_bucket_versioning" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "encrypted_bucket_lifecycle" {
   bucket = aws_s3_bucket.encrypted_bucket.id
-  rule {
-    id = "rule0"
+  
+  dynamic "rule" {
+    # if expiration_days is 0 then the rule is not created
+    for_each = var.expiration_days == 0 ? [] : [var.expiration_days]
 
-    # if expiration_days is 0 then the rule is disabled
-    status = var.expiration_days == 0 ? "Disabled" : "Enabled"
+    content {
+      id     = "expiration-rule"
+      status = "Enabled"
 
-    dynamic "expiration" {
-      for_each = var.expiration_days == 0 ? [] : [var.expiration_days]
-
-      content {
-        days = expiration.value
+      expiration {
+        days = rule.value
       }
     }
   }

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -47,9 +47,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle
   bucket = aws_s3_bucket.log_encrypted_bucket.id
   rule {
     id = "log-rule"
-
-    #if expiration_days is 0 then the rule is disabled
-    status = var.expiration_days == 0 ? "Disabled" : "Enabled"
+    status = "Enabled"
 
     transition {
       days          = 90

--- a/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/log_encrypted_bucket/log_encrypted_bucket.tf
@@ -46,7 +46,7 @@ resource "aws_s3_bucket_acl" "log_encrypted_bucket_acl" {
 resource "aws_s3_bucket_lifecycle_configuration" "log_encrypted_bucket_lifecycle" {
   bucket = aws_s3_bucket.log_encrypted_bucket.id
   rule {
-    id = "log-rule"
+    id     = "log-rule"
     status = "Enabled"
 
     transition {


### PR DESCRIPTION
## Changes proposed in this pull request:

Follow-up to https://github.com/cloud-gov/cg-provision/pull/1670 to only conditionally create S3 lifecycle blocks when a value is set for expiration, since these configurations currently only provide expiration rules and at least 1 rule is required for a configuration to be set.

Also, for convenience, this PR adds a `pre-commit` Git hook that will automatically run the Terraform code formatter on every commit, which means that once enabled, this Git hook should ensure that the Terraform formatting checker in CI never fails. To install the Git hooks, use the `make` command:

```shell
make add-githooks
```

## security considerations

None, just refactoring Terraform to make dynamic behavior work correctly
