### PR TITLE
Support brokered SES sending mail from a default domain

### DIFF
--- a/terraform/modules/environment_dns/dns.tf
+++ b/terraform/modules/environment_dns/dns.tf
@@ -202,3 +202,19 @@ resource "aws_route53_record" "tcp_aaaa" {
   }
 }
 
+locals {
+  brokered_mail_subdomain = "appmail.${var.domain}"
+}
+
+resource "aws_route53_zone" "brokered_mail_zone" {
+  name    = local.brokered_mail_subdomain
+  comment = "If customers create a brokered SES identity but do not specify a domain, a subdomain will be created for them in this zone. This allows sending mail for testing purposes."
+}
+
+resource "aws_route53_record" "brokered_mail_ns" {
+  zone_id = aws_route53_zone.brokered_mail_zone.zone_id
+  name    = local.brokered_mail_subdomain
+  type    = "NS"
+  ttl     = "30"
+  records = aws_route53_zone.brokered_mail_zone.name_servers
+}


### PR DESCRIPTION
There are two ways to send mail with the SMTP brokerpak: From a domain the user controls, or from a subdomain of a default domain the platform provides. This PR creates the default subdomain zone, which will be `appmail.cloud.gov` in production. One is created for each of our environments. Customers who do not specify a domain for sending mail will have one created like `ses-abcdef0123456789.appmail.cloud.gov`, which is useful for rapid testing.

Relates to https://github.com/cloud-gov/product/issues/2988

## security considerations

No sensitive info included here. The broker will create subdomain records for e.g. DKIM directly and handle secure storage of related HCL.