### PR TITLE
Create commercial credentials for CSB so it can manage Route53

### DIFF
--- a/terraform/modules/csb/iam.tf
+++ b/terraform/modules/csb/iam.tf
@@ -10,7 +10,6 @@ locals {
 }
 
 data "aws_iam_policy_document" "brokerpak_smtp_govcloud" {
-  count = local.govcloud ? 1 : 0
   statement {
     effect    = "Allow"
     actions   = ["ses:*"]

--- a/terraform/modules/csb/iam.tf
+++ b/terraform/modules/csb/iam.tf
@@ -70,7 +70,7 @@ resource "aws_iam_access_key" "iam_access_key" {
 
 locals {
   govcloud_policies = [
-    aws_iam_policy.brokerpak_smtp.arn
+    aws_iam_policy.brokerpak_smtp[0].arn
   ]
   commercial_policies = [
     // Route53 manager: for aws_route53_record, aws_route53_zone

--- a/terraform/modules/csb/iam.tf
+++ b/terraform/modules/csb/iam.tf
@@ -4,8 +4,13 @@ locals {
 }
 
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+locals {
+  govcloud = data.aws_partition.current.partition == "aws-us-gov"
+}
 
-data "aws_iam_policy_document" "brokerpak_smtp" {
+data "aws_iam_policy_document" "brokerpak_smtp_govcloud" {
+  count = local.govcloud ? 1 : 0
   statement {
     effect    = "Allow"
     actions   = ["ses:*"]
@@ -34,12 +39,6 @@ data "aws_iam_policy_document" "brokerpak_smtp" {
   }
 
   statement {
-    effect    = "Allow"
-    actions   = ["route53:ListHostedZones"]
-    resources = ["*"]
-  }
-
-  statement {
     effect = "Allow"
     actions = [
       "sns:CreateTopic",
@@ -56,6 +55,7 @@ data "aws_iam_policy_document" "brokerpak_smtp" {
 }
 
 resource "aws_iam_policy" "brokerpak_smtp" {
+  count       = local.govcloud ? 1 : 0
   name        = "${var.stack_description}-brokerpak-smtp"
   description = "SMTP broker policy (covers SES, IAM, and supplementary Route53)"
   policy      = data.aws_iam_policy_document.brokerpak_smtp.json
@@ -69,17 +69,18 @@ resource "aws_iam_access_key" "iam_access_key" {
   user = aws_iam_user.iam_user.name
 }
 
-resource "aws_iam_user_policy_attachment" "csb_policies" {
-  for_each = toset([
-    // ACM manager: for aws_acm_certificate, aws_acm_certificate_validation
-    "arn:aws-us-gov:iam::aws:policy/AWSCertificateManagerFullAccess",
-
+locals {
+  govcloud_policies = [
+    aws_iam_policy.brokerpak_smtp.arn
+  ]
+  commercial_policies = [
     // Route53 manager: for aws_route53_record, aws_route53_zone
     "arn:aws-us-gov:iam::aws:policy/AmazonRoute53FullAccess",
+  ]
+}
 
-    // SMTP brokerpak policy defined above
-    "arn:aws-us-gov:iam::${local.this_aws_account_id}:policy/${aws_iam_policy.brokerpak_smtp.name}",
-  ])
+resource "aws_iam_user_policy_attachment" "csb_policies" {
+  for_each = toset(local.govcloud ? govcloud_policies : commercial_policies)
 
   user       = aws_iam_user.iam_user.name
   policy_arn = each.key

--- a/terraform/modules/csb/iam.tf
+++ b/terraform/modules/csb/iam.tf
@@ -58,7 +58,7 @@ resource "aws_iam_policy" "brokerpak_smtp" {
   count       = local.govcloud ? 1 : 0
   name        = "${var.stack_description}-brokerpak-smtp"
   description = "SMTP broker policy (covers SES, IAM, and supplementary Route53)"
-  policy      = data.aws_iam_policy_document.brokerpak_smtp.json
+  policy      = data.aws_iam_policy_document.brokerpak_smtp_govcloud.json
 }
 
 resource "aws_iam_user" "iam_user" {
@@ -80,7 +80,7 @@ locals {
 }
 
 resource "aws_iam_user_policy_attachment" "csb_policies" {
-  for_each = toset(local.govcloud ? govcloud_policies : commercial_policies)
+  for_each = toset(local.govcloud ? local.govcloud_policies : local.commercial_policies)
 
   user       = aws_iam_user.iam_user.name
   policy_arn = each.key

--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -135,3 +135,12 @@ output "lets_encrypt_secret_access_key_curr" {
   value     = module.lets_encrypt_user.secret_access_key_curr
   sensitive = true
 }
+
+output "csb_access_key_id_curr" {
+  value = module.csb.access_key_id_curr
+}
+
+output "csb_secret_access_key_curr" {
+  sensitive = true
+  value     = module.csb.secret_access_key_curr
+}

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -81,3 +81,9 @@ module "lets_encrypt_user" {
   hosted_zone   = var.lets_encrypt_hosted_zone
   username      = "lets-encrypt-${var.stack_description}"
 }
+
+module "csb" {
+  source = "../../modules/csb"
+
+  stack_description = var.stack_description
+}

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -645,11 +645,11 @@ output "external_domain_broker_gov_secret_access_key_prev" {
   sensitive = true
 }
 
-output "csb_gov_access_key_id_curr" {
+output "csb_access_key_id_curr" {
   value = module.csb.access_key_id_curr
 }
 
-output "csb_gov_secret_access_key_curr" {
+output "csb_secret_access_key_curr" {
   value     = module.csb.secret_access_key_curr
   sensitive = true
 }


### PR DESCRIPTION
- Create a CSB user in commercial, in addition to the existing one in govcloud, so the SMTP brokerpak can manage DNS. 
- Related to https://github.com/cloud-gov/product/issues/2988 and https://github.com/cloud-gov/private/issues/1301

## security considerations

Route53 is still overpermissioned; to be addressed in https://github.com/cloud-gov/private/issues/1302