### PR TITLE
feat: move certificate deletion to its own task

### DIFF
--- a/ci/delete-old-certificates.sh
+++ b/ci/delete-old-certificates.sh
@@ -12,12 +12,11 @@ if [[ -n "${ASSUME_ROLE_ARN}" ]]; then
   export AWS_SESSION_TOKEN="${session_token}"
 fi
 
-# Upload new certificate if present
-if [[ -s acme/cert.pem ]]; then
-  aws iam upload-server-certificate \
-    --path "${CERT_PATH}" \
-    --server-certificate-name "${CERT_PREFIX}-$(date +%Y-%m-%d-%H-%M)" \
-    --certificate-body file://acme/cert.pem \
-    --certificate-chain file://acme/chain.pem \
-    --private-key file://acme/privkey.pem
-fi
+# Delete expired certificates
+cutoff=$(date --date '-1 month' --iso-8601=seconds --utc | sed 's/+0000$/Z/')
+certificates=$(jq -r --arg cutoff "${cutoff}" \
+  '.ServerCertificateMetadataList[] | select(.Expiration < $cutoff) | .ServerCertificateName' \
+  < certificates/metadata)
+for certificate in ${certificates}; do
+  aws iam delete-server-certificate --server-certificate-name "${certificate}"
+done

--- a/ci/delete-old-certificates.yml
+++ b/ci/delete-old-certificates.yml
@@ -1,0 +1,18 @@
+---
+# upload a certificate to the tooling account
+platform: linux
+
+inputs:
+- name: cg-provision-repo
+- name: terraform-yaml-tooling
+- name: certificates
+- name: acme
+
+run:
+  path: cg-provision-repo/ci/delete-old-certificates.sh
+
+params:
+  AWS_DEFAULT_REGION:
+  CERT_PATH:
+  CERT_PREFIX:
+  ASSUME_ROLE_ARN:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,6 +43,7 @@ groups:
       - acme-certificate-dev-pages
       - acme-certificate-dev-wildcard-pages
       - acme-certificate-dev-wildcard-pages-sites
+      - delete-old-certificates
 jobs:
   - name: pull-status-check
     plan:
@@ -1438,6 +1439,49 @@ jobs:
         channel: ((slack-channel))
         username: ((slack-username))
         icon_url: ((slack-icon-url))
+
+  - name: delete-old-certificates
+    plan:
+      - in_parallel:
+          - get: general-task
+          - get: staging-weekly-timer
+            trigger: true
+            passed:
+             - acme-certificate-development
+             - acme-certificate-staging
+             - acme-certificate-staging-pages
+             - acme-certificate-production
+             - acme-certificate-production-apps
+             - acme-certificate-pages
+             - acme-certificate-wildcard-pages
+             - acme-certificate-wildcard-pages-sites
+             - acme-certificate-staging-pages
+             - acme-certificate-staging-wildcard-pages
+             - acme-certificate-staging-wildcard-pages-sites
+             - acme-certificate-dev-pages
+             - acme-certificate-dev-wildcard-pages
+             - acme-certificate-dev-wildcard-pages-sites
+          - get: cg-provision-repo
+            resource: cg-provision-repo-development
+          - get: terraform-yaml-tooling
+            resource: terraform-yaml-tooling
+          - get: terraform-yaml-external
+            resource: terraform-yaml-external-development
+      - task: delete-certificates
+        image: general-task
+        file: cg-provision-repo/ci/delete-old-certificates.yml
+        params:
+          AWS_DEFAULT_REGION: ((aws_default_region))
+    on_failure:
+      put: slack
+      params:
+        text: |
+          :x: Failed to delete old certificates
+          <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+        channel: ((slack-channel))
+        username: ((slack-username))
+        icon_url: ((slack-icon-url))
+
 
 resources:
   - name: pipeline-tasks


### PR DESCRIPTION
## Changes proposed in this pull request:
-  move certificate deletion to its own task. Since cert deletion is global, we only need to do it once

## security considerations
None