### PR TITLE
Upgrade for tooling bosh to v15

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -372,6 +372,8 @@ jobs:
           TF_VAR_defectdojo_staging_hosts: '["defectdojo.fr-stage.cloud.gov"]'
           TF_VAR_defectdojo_staging_oidc_client: ((tooling_defectdojo_staging_oidc_client))
           TF_VAR_defectdojo_staging_oidc_client_secret: ((tooling_defectdojo_staging_oidc_client_secret))
+          TF_VAR_rds_db_engine_version_bosh: "15.5"
+          TF_VAR_rds_parameter_group_family_bosh: "postgres15"
       - *notify-slack
 
   - name: apply-tooling

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -96,8 +96,8 @@ module "stack" {
   rds_multi_az                           = var.rds_multi_az
   rds_security_groups                    = [module.stack.bosh_security_group]
   rds_security_groups_count              = "1"
-  rds_db_engine_version                  = var.rds_db_engine_version
-  rds_parameter_group_family             = var.rds_parameter_group_family
+  rds_db_engine_version                  = var.rds_db_engine_version_bosh
+  rds_parameter_group_family             = var.rds_parameter_group_family_bosh
   rds_allow_major_version_upgrade        = var.rds_allow_major_version_upgrade
   rds_apply_immediately                  = var.rds_apply_immediately
   bosh_default_ssh_public_key            = var.bosh_default_ssh_public_key

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -37,6 +37,14 @@ variable "rds_parameter_group_family" {
   default = "postgres12"
 }
 
+variable "rds_db_engine_version_bosh" {
+  default = "15.5"
+}
+
+variable "rds_parameter_group_family_bosh" {
+  default = "postgres15"
+}
+
 variable "remote_state_bucket" {
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Separate variables used to control bosh director postgres versions for tooling director from the other RDS resources.  Each of these will be dealt with similarly but separately.
-
-

## security considerations
Will parameterize the variable values later into config files in s3 or credhub, either way, values are NOT sensitive in nature.
