### PR TITLE
updates for moving from Postgres 12.17 to 16.1 for staging ccdb

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -636,6 +636,8 @@ jobs:
           #TF_VAR_rds_allow_major_version_upgrade: "true"
           TF_VAR_rds_db_engine_version: "15.5"
           TF_VAR_rds_parameter_group_family: "postgres15"
+          TF_VAR_rds_db_engine_version_cf: "16.1"
+          TF_VAR_rds_parameter_group_family_cf: "postgres16"
           TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((staging_vpc_cidr))


### PR DESCRIPTION
## Changes proposed in this pull request:
- This moves the ccdb for staging from Postgres 12.17 to 16.1
- This implements https://github.com/cloud-gov/private/issues/1367
-

## security considerations
None
