### PR TITLE
upgrade credhub staging to Postgres 15.5

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -374,6 +374,8 @@ jobs:
           TF_VAR_defectdojo_staging_oidc_client_secret: ((tooling_defectdojo_staging_oidc_client_secret))
           TF_VAR_rds_db_engine_version_bosh: "15.5"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
+          TF_VAR_rds_db_engine_version_credhub_staging: "15.5"
+          TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
       - *notify-slack
 
   - name: apply-tooling

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -223,8 +223,8 @@ module "credhub_staging" {
   rds_subnet_group                = module.stack.rds_subnet_group
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_parameter_group_name        = "tooling-credhub-staging"
-  rds_parameter_group_family      = var.rds_parameter_group_family
-  rds_db_engine_version           = var.rds_db_engine_version
+  rds_parameter_group_family      = var.rds_parameter_group_family_credhub_staging
+  rds_db_engine_version           = var.rds_db_engine_version_credhub_staging
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -45,6 +45,13 @@ variable "rds_parameter_group_family_bosh" {
   default = "postgres15"
 }
 
+variable "rds_db_engine_version_credhub_staging" {
+  default = "15.5"
+}
+
+variable "rds_parameter_group_family_credhub_staging" {
+  default = "postgres15"
+}
 variable "remote_state_bucket" {
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Upgrade credhub staging RDS to Postgres 15.5
- https://github.com/cloud-gov/private/issues/1368


## security considerations
None
