### PR TITLE
Remove pages concourse resources

### DIFF
--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -346,60 +346,6 @@ output "production_concourse_lb_target_group" {
   value = module.concourse_production.concourse_lb_target_group
 }
 
-/* Production Concourse Pages */
-output "production_concourse_pages_subnet" {
-  value = module.concourse_production_pages.concourse_subnet
-}
-
-output "production_concourse_pages_subnet_reserved" {
-  value = "${cidrhost(module.concourse_production_pages.concourse_subnet_cidr, 0)} - ${cidrhost(module.concourse_production_pages.concourse_subnet_cidr, 3)}"
-}
-
-output "production_concourse_pages_subnet_cidr" {
-  value = module.concourse_production_pages.concourse_subnet_cidr
-}
-
-output "production_concourse_pages_subnet_gateway" {
-  value = cidrhost(module.concourse_production_pages.concourse_subnet_cidr, 1)
-}
-
-output "production_concourse_pages_security_group" {
-  value = module.concourse_production_pages.concourse_security_group
-}
-
-output "production_concourse_pages_rds_identifier" {
-  value = module.concourse_production_pages.concourse_rds_identifier
-}
-
-output "production_concourse_pages_rds_name" {
-  value = module.concourse_production_pages.concourse_rds_name
-}
-
-output "production_concourse_pages_rds_host" {
-  value = module.concourse_production_pages.concourse_rds_host
-}
-
-output "production_concourse_pages_rds_port" {
-  value = module.concourse_production_pages.concourse_rds_port
-}
-
-output "production_concourse_pages_rds_url" {
-  value = module.concourse_production_pages.concourse_rds_url
-}
-
-output "production_concourse_pages_rds_username" {
-  value = module.concourse_production_pages.concourse_rds_username
-}
-
-output "production_concourse_pages_rds_password" {
-  value     = module.concourse_production_pages.concourse_rds_password
-  sensitive = true
-}
-
-output "production_concourse_pages_lb_target_group" {
-  value = module.concourse_production_pages.concourse_lb_target_group
-}
-
 /* Staging Concourse */
 output "staging_concourse_subnet" {
   value = module.concourse_staging.concourse_subnet

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -132,32 +132,6 @@ module "concourse_production" {
   hosts                           = var.concourse_production_hosts
 }
 
-module "concourse_production_pages" {
-  source                          = "../../modules/concourse"
-  stack_description               = var.stack_description
-  vpc_id                          = module.stack.vpc_id
-  concourse_cidr                  = cidrsubnet(var.vpc_cidr, 8, 38)
-  concourse_az                    = data.aws_availability_zones.available.names[1]
-  suffix                          = "pages"
-  route_table_id                  = module.stack.private_route_table_az1
-  rds_password                    = var.concourse_prod_pages_rds_password
-  rds_subnet_group                = module.stack.rds_subnet_group
-  rds_security_groups             = [module.stack.rds_postgres_security_group]
-  rds_parameter_group_name        = "tooling-concourse-production-pages"
-  rds_parameter_group_family      = "postgres15"
-  rds_db_engine_version           = "15.5"
-  rds_apply_immediately           = var.rds_apply_immediately
-  rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
-  rds_instance_type               = "db.m5.large"
-  rds_db_size                     = 400
-  rds_db_storage_type             = "gp3"
-  rds_db_iops                     = 12000
-  rds_multi_az                    = var.rds_multi_az
-  rds_final_snapshot_identifier   = "final-snapshot-atc-tooling-staging"
-  listener_arn                    = aws_lb_listener.main.arn
-  hosts                           = var.concourse_production_pages_hosts
-}
-
 module "concourse_staging" {
   source                          = "../../modules/concourse"
   stack_description               = var.stack_description

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -103,10 +103,6 @@ variable "concourse_production_hosts" {
   type = list(string)
 }
 
-variable "concourse_production_pages_hosts" {
-  type = list(string)
-}
-
 variable "concourse_staging_hosts" {
   type = list(string)
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- RDS DB is no longer needed, deployment was torn down
- Closes https://github.com/cloud-gov/private/issues/1369
-

## security considerations
None.  Removes a RDS db and associated outputs
