### PR TITLE
Upgrading concourse staging rds to v15.5

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -378,6 +378,8 @@ jobs:
           TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
           TF_VAR_rds_db_engine_version_credhub_production: "15.5"
           TF_VAR_rds_parameter_group_family_credhub_production: "postgres15"
+          TF_VAR_rds_db_engine_version_concourse_staging: "15.5"
+          TF_VAR_rds_parameter_group_family_concourse_staging: "postgres15"
       - *notify-slack
 
   - name: apply-tooling

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -144,8 +144,8 @@ module "concourse_staging" {
   rds_subnet_group                = module.stack.rds_subnet_group
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_parameter_group_name        = "tooling-concourse-staging"
-  rds_parameter_group_family      = var.rds_parameter_group_family
-  rds_db_engine_version           = var.rds_db_engine_version
+  rds_parameter_group_family      = var.rds_parameter_group_family_concourse_staging
+  rds_db_engine_version           = var.rds_db_engine_version_concourse_staging
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.large"

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -52,6 +52,7 @@ variable "rds_db_engine_version_credhub_staging" {
 variable "rds_parameter_group_family_credhub_staging" {
   default = "postgres15"
 }
+
 variable "rds_db_engine_version_credhub_production" {
   default = "15.5"
 }
@@ -59,6 +60,15 @@ variable "rds_db_engine_version_credhub_production" {
 variable "rds_parameter_group_family_credhub_production" {
   default = "postgres15"
 }
+
+variable "rds_db_engine_version_concourse_staging" {
+  default = "15.5"
+}
+
+variable "rds_parameter_group_family_concourse_staging" {
+  default = "postgres15"
+}
+
 
 variable "remote_state_bucket" {
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Upgrades concourse staging and parameter group to postgres 15.5 and makes the version configurable uniquely in the pipeline
- Closes https://github.com/cloud-gov/private/issues/1373
-

## security considerations
Bumps postgres to be more recent version
