### PR TITLE
Remove reference to pages concourse from each spoke

### DIFF
--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -220,7 +220,6 @@ module "stack" {
 
   target_concourse_security_group_cidrs = [
     data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr,
-    data.terraform_remote_state.target_vpc.outputs.production_concourse_pages_subnet_cidr,
     data.terraform_remote_state.target_vpc.outputs.staging_concourse_subnet_cidr,
     data.terraform_remote_state.target_vpc.outputs.private_subnet_az1_cidr,
   ]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove pages concourse subnet cidr range from security group of allowed traffic
- Closes https://github.com/cloud-gov/private/issues/1369
- Will need to be applied to dev, stage, prod terraform-provision jobs

## security considerations
Closes access to no longer use subnet
