### PR TITLE
Upgrade concourse prod to postgres 15

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -380,6 +380,8 @@ jobs:
           TF_VAR_rds_parameter_group_family_credhub_production: "postgres15"
           TF_VAR_rds_db_engine_version_concourse_staging: "15.5"
           TF_VAR_rds_parameter_group_family_concourse_staging: "postgres15"
+          TF_VAR_rds_db_engine_version_concourse_production: "15.5"
+          TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
       - *notify-slack
 
   - name: apply-tooling

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -118,8 +118,8 @@ module "concourse_production" {
   rds_subnet_group                = module.stack.rds_subnet_group
   rds_security_groups             = [module.stack.rds_postgres_security_group]
   rds_parameter_group_name        = "tooling-concourse-production"
-  rds_parameter_group_family      = var.rds_parameter_group_family
-  rds_db_engine_version           = var.rds_db_engine_version
+  rds_parameter_group_family      = var.rds_parameter_group_family_concourse_production
+  rds_db_engine_version           = var.rds_db_engine_version_concourse_production
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_instance_type               = "db.m5.xlarge"

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -69,6 +69,13 @@ variable "rds_parameter_group_family_concourse_staging" {
   default = "postgres15"
 }
 
+variable "rds_db_engine_version_concourse_production" {
+  default = "15.5"
+}
+
+variable "rds_parameter_group_family_concourse_production" {
+  default = "postgres15"
+}
 
 variable "remote_state_bucket" {
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Upgrade concourse prod to postgres 15.5
- Closes https://github.com/cloud-gov/private/issues/1394
-

## security considerations
Upgrading postgres to a newer version
