### PR TITLE
Adjust domains broker perms

### DIFF
--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -418,13 +418,21 @@ resource "aws_iam_policy" "domains_broker" {
     {
       "Effect": "Allow",
       "Action": [
-        "iam:ListServerCertificates",
         "iam:GetServerCertificate",
         "iam:UploadServerCertificate",
         "iam:DeleteServerCertificate"
       ],
       "Resource": [
         "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/domains/${var.stack_description}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:ListServerCertificates",
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/*"
       ]
     },
     {

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -432,7 +432,7 @@ resource "aws_iam_policy" "domains_broker" {
         "iam:ListServerCertificates",
       ],
       "Resource": [
-        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/*"
+        "*"
       ]
     },
     {


### PR DESCRIPTION
## Changes proposed in this pull request:

This recommendation came from an interaction with AWS support. Without the permission `ListServerCertificates` on all (`*`) resources, a `DeleteServerCertificate` request for an already deleted certificate will throw a 403 error. 

From AWS:

> This occurs because the DeleteServerCertificate operation includes both list and delete APIs. The list API checks for the presence of certificates, but if no matching certificate exists within the specified path, it assumes the certificate is elsewhere. Due to the path limitation, it cannot verify this, leading to the 403 error.

## security considerations

ListServerCertificates is a read-only operation, so there should be no danger to giving it access to list other certificates.
