### PR TITLE
Set cf prod to v12 until Wednesday

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -815,6 +815,8 @@ jobs:
           TF_VAR_vpc_cidr: ((production_vpc_cidr))
           TF_VAR_cf_rds_password: ((production_cf_rds_password))
           TF_VAR_cf_as_rds_instance_type: ((production_cf_as_rds_instance_type))
+          TF_VAR_rds_db_engine_version_cf: "12.17"             # FLIP WEDNESDAY 16.1
+          TF_VAR_rds_parameter_group_family_cf: "postgres12"   # FLIP WEDNESDAY "postgres16"
           TF_VAR_restricted_ingress_web_cidrs: ((production_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((production_restricted_ingress_web_ipv6_cidrs))
           TF_VAR_wildcard_certificate_name_prefix: star.fr.cloud.gov


### PR DESCRIPTION
## Changes proposed in this pull request:
- Force the production CF db to stay on Postgres 12.17 until the migration is complete on Wednesday.
- Allows the pipeline to flush through
- Part of https://github.com/cloud-gov/private/issues/1372

## security considerations
None, preserves what is currently deployed
