### PR TITLE
Upgrade CF Prod db to postgres 16.1

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -815,8 +815,8 @@ jobs:
           TF_VAR_vpc_cidr: ((production_vpc_cidr))
           TF_VAR_cf_rds_password: ((production_cf_rds_password))
           TF_VAR_cf_as_rds_instance_type: ((production_cf_as_rds_instance_type))
-          TF_VAR_rds_db_engine_version_cf: "12.17"             # FLIP WEDNESDAY 16.1
-          TF_VAR_rds_parameter_group_family_cf: "postgres12"   # FLIP WEDNESDAY "postgres16"
+          TF_VAR_rds_db_engine_version_cf: "16.1"
+          TF_VAR_rds_parameter_group_family_cf: "postgres16"
           TF_VAR_restricted_ingress_web_cidrs: ((production_restricted_ingress_web_cidrs))
           TF_VAR_restricted_ingress_web_ipv6_cidrs: ((production_restricted_ingress_web_ipv6_cidrs))
           TF_VAR_wildcard_certificate_name_prefix: star.fr.cloud.gov


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switches CF prod database to use postgres v16.1, tested in lower environments
- Db upgrade done via the UI, this commit is run afterwards to associate the unique parameter group name, staging's parameter group will be used until the terraform run can complete (they have the same custom settings)
- Part of https://github.com/cloud-gov/private/issues/1372
-

## security considerations
Part of normal db engine upgrade cadence
