### PR TITLE
Concourse Prod config change

### DIFF
--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -18,4 +18,5 @@ module "rds_96" {
   rds_apply_immediately           = var.rds_apply_immediately
   rds_multi_az                    = var.rds_multi_az
   rds_final_snapshot_identifier   = var.rds_final_snapshot_identifier
+  performance_insights_enabled    = var.performance_insights_enabled
 }

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -84,3 +84,7 @@ variable "listener_arn" {
 variable "hosts" {
   type = list(string)
 }
+
+variable "performance_insights_enabled" {
+  default = "false"
+}

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -31,6 +31,8 @@ resource "aws_db_instance" "rds_database" {
   db_subnet_group_name   = var.rds_subnet_group
   vpc_security_group_ids = var.rds_security_groups
 
+  performance_insights_enabled = var.performance_insights_enabled
+
   parameter_group_name = var.rds_db_engine == "postgres" ? join("", aws_db_parameter_group.parameter_group_postgres.*.id) : join("", aws_db_parameter_group.parameter_group_mysql.*.id)
 
   allow_major_version_upgrade = var.rds_allow_major_version_upgrade

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -84,3 +84,7 @@ variable "rds_apply_immediately" {
 variable "rds_allow_major_version_upgrade" {
   default = "false"
 }
+
+variable "performance_insights_enabled" {
+  default = "false"
+}

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -122,7 +122,8 @@ module "concourse_production" {
   rds_db_engine_version           = var.rds_db_engine_version_concourse_production
   rds_apply_immediately           = var.rds_apply_immediately
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
-  rds_instance_type               = "db.m5.xlarge"
+  performance_insights_enabled    = "true"
+  rds_instance_type               = "db.m5.4xlarge"
   rds_db_size                     = 400
   rds_db_storage_type             = "gp3"
   rds_db_iops                     = 12000


### PR DESCRIPTION
## Changes proposed in this pull request:
- This should true up changes made manually through AWS console
- Adding ability to turn on db performance insights via terraform.  For now, doing this with concourse prod db
- Part of maintenance: https://github.com/cloud-gov/private/issues/618

## security considerations
No impact on security
