### PR TITLE
Add NS records for appmail subdomain to parent zones

### DIFF
--- a/terraform/modules/environment_dns/dns.tf
+++ b/terraform/modules/environment_dns/dns.tf
@@ -210,3 +210,15 @@ resource "aws_route53_zone" "brokered_mail_zone" {
   name    = local.brokered_mail_subdomain
   comment = "If customers create a brokered SES identity but do not specify a domain, a subdomain will be created for them in this zone. This allows sending mail for testing purposes."
 }
+
+data "aws_route53_zone" "apex_domain" {
+  name = var.domain
+}
+
+resource "aws_route53_record" "brokered_mail_ns" {
+  zone_id = data.aws_route53_zone.apex_domain.zone_id
+  name    = local.brokered_mail_subdomain
+  type    = "NS"
+  ttl     = "30"
+  records = aws_route53_zone.brokered_mail_zone.name_servers
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title. The previous PR https://github.com/cloud-gov/cg-provision/pull/1721 removed the NS record from the appmail zone itself, which was correct, because the NS record is created there automatically. This PR adds a NS record to the *parent* zone pointing to the appmail zone, which is required for DNS resolution. 
- I will increase the TTL in a future PR once it's all confirmed to work.

## security considerations

None