### PR TITLE
update domains broker GetServerCertificate permissions

### DIFF
--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -418,7 +418,6 @@ resource "aws_iam_policy" "domains_broker" {
     {
       "Effect": "Allow",
       "Action": [
-        "iam:GetServerCertificate",
         "iam:UploadServerCertificate",
         "iam:DeleteServerCertificate"
       ],
@@ -429,10 +428,11 @@ resource "aws_iam_policy" "domains_broker" {
     {
       "Effect": "Allow",
       "Action": [
+        "iam:GetServerCertificate",
         "iam:ListServerCertificates"
       ],
       "Resource": [
-        "*"
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/*"
       ]
     },
     {


### PR DESCRIPTION
## Changes proposed in this pull request:

There is a bug in the [domain broker](https://github.com/cloud-gov/cf-domain-broker-alb) deletion where if the certificate was already somehow deleted, then the broker subsequently errors trying to delete the service. According to AWS support, the only way to work around this is checking if the resource still exists before attempting to delete it.

In order to get a correct `NoSuchEntity` response for IAM for the missing certificate resource, the policy for the broker needs permission to look for the server certificate under any path (`*`). This PR updates the domain broker permissions to add those permissions.

- Update IAM policy for domains broker to allow `GetServerCertificate` on all certificate resources within the account. 

## security considerations

`GetServerCertificate` is a non-destructive, read-only operation, so there should be no risk to allow it on all certificate resources within the same account
