### PR TITLE
Upgrade opsuaa rds to 16.1

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -382,6 +382,8 @@ jobs:
           TF_VAR_rds_parameter_group_family_concourse_staging: "postgres15"
           TF_VAR_rds_db_engine_version_concourse_production: "15.5"
           TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
+          TF_VAR_rds_db_engine_version_opsuaa: "16.1"
+          TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
       - *notify-slack
 
   - name: apply-tooling

--- a/terraform/stacks/tooling/opsuaa.tf
+++ b/terraform/stacks/tooling/opsuaa.tf
@@ -12,8 +12,8 @@ module "opsuaa_db" {
   rds_password                    = var.opsuaa_rds_password
   rds_subnet_group                = module.stack.rds_subnet_group
   rds_security_groups             = [module.stack.rds_postgres_security_group]
-  rds_db_engine_version           = var.rds_db_engine_version
-  rds_parameter_group_family      = var.rds_parameter_group_family
+  rds_db_engine_version           = var.rds_db_engine_version_opsuaa
+  rds_parameter_group_family      = var.rds_parameter_group_family_opsuaa
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
 }

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -77,6 +77,14 @@ variable "rds_parameter_group_family_concourse_production" {
   default = "postgres15"
 }
 
+variable "rds_db_engine_version_opsuaa" {
+  default = "16.1"
+}
+
+variable "rds_parameter_group_family_opsuaa" {
+  default = "postgres16"
+}
+
 variable "remote_state_bucket" {
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Upgrade opsuaa rds db to use postgres v16.1
- Upgrade will be done via aws console, this will be run afterwards to true up the configuration and also to upgrade the parameter group to 16
- Part of https://github.com/cloud-gov/private/issues/1374
-

## security considerations
Bumps to newer version of Postgres
