### PR TITLE
Upgrade tooling bosh credhub to pg 15.5

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -374,6 +374,8 @@ jobs:
           TF_VAR_defectdojo_staging_oidc_client_secret: ((tooling_defectdojo_staging_oidc_client_secret))
           TF_VAR_rds_db_engine_version_bosh: "15.5"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
+          TF_VAR_rds_db_engine_version_bosh_credhub: "15.5"
+          TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_rds_db_engine_version_credhub_staging: "15.5"
           TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
           TF_VAR_rds_db_engine_version_credhub_production: "15.5"

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -104,6 +104,8 @@ module "stack" {
   target_concourse_security_group_cidrs  = [cidrsubnet(var.vpc_cidr, 8, 30), cidrsubnet(var.vpc_cidr, 8, 31), cidrsubnet(var.vpc_cidr, 8, 38), cidrsubnet(var.vpc_cidr, 8, 1)]
   target_monitoring_security_group_cidrs = [cidrsubnet(var.vpc_cidr, 8, 32)]
   s3_gateway_policy_accounts             = var.s3_gateway_policy_accounts
+  credhub_rds_db_engine_version          = var.rds_db_engine_version_bosh_credhub
+  credhub_rds_parameter_group_family     = var.rds_parameter_group_family_bosh_credhub
 }
 
 module "concourse_production" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -257,3 +257,11 @@ variable "github_backups_bucket_name" {
   type    = string
   default = "github-backups"
 }
+
+variable "rds_db_engine_version_bosh_credhub" {
+  default = "15.5"
+}
+
+variable "rds_parameter_group_family_bosh_credhub" {
+  default = "postgres15"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Upgrade tooling bosh credhub to pg 15.5
- Part of https://github.com/cloud-gov/private/issues/1409
-

## security considerations
Upgrades postgres version being used
