### PR TITLE
Upgrade bosh credhub postgres to v15.5 in staging and production

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -653,6 +653,8 @@ jobs:
           TF_VAR_rds_db_engine_version_cf: "16.1"
           TF_VAR_rds_parameter_group_family_cf: "postgres16"
           TF_VAR_credhub_rds_password: ((staging_credhub_rds_password))
+          TF_VAR_rds_db_engine_version_bosh_credhub: "15.5"
+          TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((staging_vpc_cidr))
           TF_VAR_cf_rds_password: ((staging_cf_rds_password))
@@ -817,6 +819,8 @@ jobs:
           #TF_VAR_rds_apply_immediately: "true"
           #TF_VAR_rds_allow_major_version_upgrade: "true"
           TF_VAR_credhub_rds_password: ((production_credhub_rds_password))
+          TF_VAR_rds_db_engine_version_bosh_credhub: "15.5"
+          TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
           TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
           TF_VAR_vpc_cidr: ((production_vpc_cidr))
           TF_VAR_cf_rds_password: ((production_cf_rds_password))


### PR DESCRIPTION
## Changes proposed in this pull request:
- Upgrade bosh credhub to pg 15.5
- Part of https://github.com/cloud-gov/private/issues/1409
-

## security considerations
Upgrades postgres version being used

