### PR TITLE
feat: config-driven waf rules

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -521,6 +521,7 @@ jobs:
           TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
           TF_VAR_cidr_blocks: ((cidr_blocks))
           TF_VAR_domains_lbgroup_count: 2
+          TF_VAR_waf_regex_rules: '[]'
       - *notify-slack
 
   - name: apply-development
@@ -691,6 +692,7 @@ jobs:
           TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
           TF_VAR_cidr_blocks: ((cidr_blocks))
           TF_VAR_domains_lbgroup_count: 3
+          TF_VAR_waf_regex_rules: '[]'
       - *notify-slack
 
   - name: apply-staging
@@ -859,6 +861,7 @@ jobs:
           TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
           TF_VAR_cidr_blocks: ((cidr_blocks))
           TF_VAR_domains_lbgroup_count: 4
+          TF_VAR_waf_regex_rules: '[]'
       - *notify-slack
 
   - name: apply-production

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -234,3 +234,21 @@ variable "loadbalancer_forward_new_weight" {
   description = "Weight of traffic to send to original target groups"
   default     = 0
 }
+
+variable "waf_regex_rules" {
+  type = list(object({
+    # path_regex is matched against the uri path of a request
+    # before comparison, the path is normalized (so self/parent path references are collapsed)
+    path_regex = string
+    # host_regex is matched against the host header on requests
+    host_regex = string
+    priority   = number
+    # when block is true, requests matching the rules are blocked.
+    # When false, they are instead counted
+    block = bool
+    # `name` is used for metrics and logging
+    name = string
+  }))
+  description = "list of objects defining regular expression rules for waf"
+  default     = []
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -283,6 +283,7 @@ module "cf" {
   tcp_allow_cidrs_ipv6                    = var.force_restricted_network == "no" ? ["::/0"] : var.restricted_ingress_web_ipv6_cidrs
   waf_regular_expressions                 = var.waf_regular_expressions
   waf_drop_logs_hosts_regular_expressions = var.waf_drop_logs_hosts_regular_expressions
+  waf_regex_rules                         = var.waf_regex_rules
 
   scope_down_known_bad_inputs_not_match_uri_path_regex_string = var.scope_down_known_bad_inputs_not_match_uri_path_regex_string
   scope_down_known_bad_inputs_not_match_origin_search_string  = var.scope_down_known_bad_inputs_not_match_origin_search_string

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -261,3 +261,21 @@ variable "rds_db_engine_version_bosh_credhub" {
 variable "rds_parameter_group_family_bosh_credhub" {
   default = "postgres15"
 }
+
+variable "waf_regex_rules" {
+  type = list(object({
+    # path_regex is matched against the uri path of a request
+    # before comparison, the path is normalized (so self/parent path references are collapsed)
+    path_regex = string
+    # host_regex is matched against the host header on requests
+    host_regex = string
+    priority   = number
+    # when block is true, requests matching the rules are blocked.
+    # When false, they are instead counted
+    block = bool
+    # `name` is used for metrics and logging
+    name = string
+  }))
+  description = "list of objects defining regular expression rules for waf"
+  default     = []
+}


### PR DESCRIPTION

## Changes proposed in this pull request:
- create TF config to build regex-based WAF rules from complex config objects

## security considerations
This should improve security. It allows us to build non-public WAF rules without relying on clickops