### PR TITLE
update policy to allow puts on the container scanning bucket

### DIFF
--- a/terraform/modules/iam_role_policy/concourse_worker/policy.json
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.json
@@ -68,7 +68,9 @@
         "arn:${aws_partition}:s3:::${varz_bucket}/*-creds.yml",
         "arn:${aws_partition}:s3:::${build_artifacts_bucket}/*",
         "arn:${aws_partition}:s3:::${terraform_state_bucket}/*",
-        "arn:${aws_partition}:s3:::${github_backups_bucket_name}/*"
+        "arn:${aws_partition}:s3:::${github_backups_bucket_name}/*",
+        "arn:${aws_partition}:s3:::${container_scanning_bucket_name}",
+        "arn:${aws_partition}:s3:::${container_scanning_bucket_name}/*"
       ]
     }
   ]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Need to allow puts on the container scanning bucket so conmon scans can be uploaded to s3


## security considerations
Updating concourse worker policy to allow putting files into the container scanning bucket