### PR TITLE
Fix external domain broker code

### DIFF
--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -66,7 +66,9 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       "arn:aws:route53:::hostedzone/${aws_route53_zone.zone.zone_id}"
     ]
   }
+}
 
+data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy" {
   statement {
     actions = [
       "shield:AssociateHealthCheck",
@@ -143,8 +145,22 @@ resource "aws_iam_access_key" "iam_access_key_v3" {
   user = aws_iam_user.iam_user.name
 }
 
-resource "aws_iam_user_policy" "iam_policy" {
+resource "aws_iam_policy" "base_policy" {
   name   = "${aws_iam_user.iam_user.name}-policy"
-  user   = aws_iam_user.iam_user.name
   policy = data.aws_iam_policy_document.external_domain_broker_policy.json
+}
+
+resource "aws_iam_user_policy_attachment" "attach_base_policy" {
+  user       = aws_iam_user.iam_user.name
+  policy_arn = aws_iam_policy.base_policy.arn
+}
+
+resource "aws_iam_policy" "manage_protections_policy" {
+  name   = "${aws_iam_user.iam_user.name}-manage-protections-policy"
+  policy = data.aws_iam_policy_document.external_domain_broker_manage_protections_policy.json
+}
+
+resource "aws_iam_user_policy_attachment" "attach_manage_protections_policy" {
+  user       = aws_iam_user.iam_user.name
+  policy_arn = aws_iam_policy.manage_protections_policy.arn
 }

--- a/terraform/modules/external_domain_broker/outputs.tf
+++ b/terraform/modules/external_domain_broker/outputs.tf
@@ -17,3 +17,7 @@ output "access_key_id_curr" {
 output "secret_access_key_curr" {
   value = aws_iam_access_key.iam_access_key_v3.secret
 }
+
+output "waf_rate_limit_group_arn" {
+  value = aws_wafv2_rule_group.rate_limit_group.arn
+}

--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -44,6 +44,10 @@ output "external_domain_broker_secret_access_key_curr" {
   sensitive = true
 }
 
+output "external_domain_broker_rate_limit_group_arn" {
+  value = module.external_domain_broker.waf_rate_limit_group_arn
+}
+
 /* external domain broker test user */
 output "external_domain_broker_tests_username" {
   value = module.external_domain_broker_tests.username


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/1098

Fixes for #1735. Those changes are failing with:

```
LimitExceeded: Maximum policy size of 2048 bytes exceeded
```

So this PR splits one IAM policy into multiple policies to avoid hitting that limit. It also adds an output for the rule group ARN that is needed for reference elsewhere.

## security considerations

None, just refactoring the IAM policies to address errors.
