### PR TITLE
add missing CloudFront permissions

### DIFF
--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -38,11 +38,13 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
 
   statement {
     actions = [
-      "cloudfront:CreateDistributionWithTags",
       "cloudfront:CreateDistribution",
       "cloudfront:UpdateDistribution",
       "cloudfront:DeleteDistribution",
-      "cloudfront:GetDistributionConfig"
+      "cloudfront:GetDistribution",
+      "cloudfront:GetDistributionConfig",
+      "cloudfront:TagResource",
+      "cloudfront:UntagResource"
     ]
     resources = [
       "arn:${var.aws_partition}:cloudfront::${var.account_id}:distribution/*"


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/1098

Adds missing CloudFront permissions for tagging resources and getting resource config

## security considerations

These permissions are necessary for the broker and are a more limited set than the initial `*` permissions that were on the policy. See #1735
