### PR TITLE
Update external domain broker perms

### DIFF
--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -86,11 +86,20 @@ data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy
   statement {
     actions = [
       "wafv2:CreateWebACL",
+    ]
+    resources = [
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*",
+      aws_wafv2_rule_group.rate_limit_group.arn
+    ]
+  }
+
+  statement {
+    actions = [
       "wafv2:TagResource",
       "wafv2:UntagResource"
     ]
     resources = [
-      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*"
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*",
     ]
   }
 
@@ -99,7 +108,7 @@ data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy
       "wafv2:DeleteWebACL"
     ]
     resources = [
-      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*/*"
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*"
     ]
     condition {
       test     = "StringEquals"

--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -85,16 +85,18 @@ data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy
 
   statement {
     actions = [
-      "waf:CreateWebACL"
+      "wafv2:CreateWebACL",
+      "wafv2:TagResource",
+      "wafv2:UntagResource"
     ]
     resources = [
-      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*/*"
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*"
     ]
   }
 
   statement {
     actions = [
-      "waf:DeleteWebACL"
+      "wafv2:DeleteWebACL"
     ]
     resources = [
       "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*/*"
@@ -108,7 +110,7 @@ data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy
 
   statement {
     actions = [
-      "waf:GetRuleGroup",
+      "wafv2:GetRuleGroup",
     ]
     resources = [
       aws_wafv2_rule_group.rate_limit_group.arn


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/1098

- Rename `waf` -> `wafv2` in IAM permissions
- Add missing permissions for tagging/untagging WAF web ACLs
- Add `wafv2:CreateWebACL` permission on referenced rule group, which is required for creating web ACLs with referenced rule groups

## security considerations

Expands the IAM permissions for the external domain broker, but this is still a limited set of permissions scoped to only the resources related to the broker
