### PR TITLE
add wafv2:GetWebACL and shield:ListProtections permissions

### DIFF
--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -120,6 +120,20 @@ data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy
 
   statement {
     actions = [
+      "shield:ListProtections",
+    ]
+    resources = [
+      "*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+  }
+
+  statement {
+    actions = [
       "wafv2:CreateWebACL",
     ]
     resources = [
@@ -150,7 +164,8 @@ data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy
 
   statement {
     actions = [
-      "wafv2:DeleteWebACL"
+      "wafv2:DeleteWebACL",
+      "wafv2:GetWebACL"
     ]
     resources = [
       "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*"


### PR DESCRIPTION
## Changes proposed in this pull request:

Part of https://github.com/cloud-gov/private/issues/1098

- add necessary permissions for external domain broker

## security considerations

These are the minimal permissions necessary for the broker to run and they are limited to only running for the provisioned IAM user