### PR TITLE
Adding 3 additional outputs for s3 ip cidr ranges

### DIFF
--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -404,6 +404,18 @@ output "s3_gateway_endpoint_cidr_2" {
   value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[1]
 }
 
+output "s3_gateway_endpoint_cidr_3" {
+  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[2]
+}
+
+output "s3_gateway_endpoint_cidr_4" {
+  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[3]
+}
+
+output "s3_gateway_endpoint_cidr_5" {
+  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[4]
+}
+
 /* s3 private gateway endpoint ips for public egress */
 output "vpc_endpoint_customer_s3_if1_ip" {
   value = module.stack.vpc_endpoint_customer_s3_if1_ip

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -397,7 +397,7 @@ output "elasticsearch_security_group" {
 
 /* S3 Gateway Endpoint CIDRs for CF ASGs*/
 output "s3_gateway_endpoint_cidrs" {
-  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[*]
+  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks
 }
 
 /* s3 private gateway endpoint ips for public egress */

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -396,24 +396,8 @@ output "elasticsearch_security_group" {
 }
 
 /* S3 Gateway Endpoint CIDRs for CF ASGs*/
-output "s3_gateway_endpoint_cidr_1" {
-  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[0]
-}
-
-output "s3_gateway_endpoint_cidr_2" {
-  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[1]
-}
-
-output "s3_gateway_endpoint_cidr_3" {
-  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[2]
-}
-
-output "s3_gateway_endpoint_cidr_4" {
-  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[3]
-}
-
-output "s3_gateway_endpoint_cidr_5" {
-  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[4]
+output "s3_gateway_endpoint_cidrs" {
+  value = data.aws_prefix_list.s3_gw_cidrs.cidr_blocks[*]
 }
 
 /* s3 private gateway endpoint ips for public egress */


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds 3 additional ip cidr ranges for S3.  This is then used as an input to cg-deploy-cf/terraform/stack/asg.tf
- Related to https://github.com/cloud-gov/cg-deploy-cf/pull/881
-

## security considerations
Makes publicly published ip ranges available as terraform output variables.
