### PR TITLE
add SNS topics for notifications to external stack

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -142,6 +142,8 @@ jobs:
           TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_development))
           TF_VAR_external_domain_waf_rate_limit_count_threshold: ((external_domain_waf_rate_limit_count_threshold))
           TF_VAR_external_domain_waf_rate_limit_challenge_threshold: ((external_domain_waf_rate_limit_challenge_threshold))
+          TF_VAR_sns_cg_platform_notifications_email: ((development_sns_cg_platform_notifications_email))
+          TF_VAR_sns_cg_platform_slack_notifications_email: ((development_sns_cg_platform_slack_notifications_email))
       - &notify-slack
         put: slack
         params:
@@ -199,6 +201,8 @@ jobs:
           TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_staging))
           TF_VAR_external_domain_waf_rate_limit_count_threshold: ((external_domain_waf_rate_limit_count_threshold))
           TF_VAR_external_domain_waf_rate_limit_challenge_threshold: ((external_domain_waf_rate_limit_challenge_threshold))
+          TF_VAR_sns_cg_platform_notifications_email: ((staging_sns_cg_platform_notifications_email))
+          TF_VAR_sns_cg_platform_slack_notifications_email: ((staging_sns_cg_platform_slack_notifications_email))
       - &notify-slack
         put: slack
         params:
@@ -256,6 +260,8 @@ jobs:
           TF_VAR_external_domain_broker_hosted_zone: ((external_domain_broker_hosted_zone_production))
           TF_VAR_external_domain_waf_rate_limit_count_threshold: ((external_domain_waf_rate_limit_count_threshold))
           TF_VAR_external_domain_waf_rate_limit_challenge_threshold: ((external_domain_waf_rate_limit_challenge_threshold))
+          TF_VAR_sns_cg_platform_notifications_email: ((production_sns_cg_platform_notifications_email))
+          TF_VAR_sns_cg_platform_slack_notifications_email: ((production_sns_cg_platform_slack_notifications_email))
       - *notify-slack
 
   - name: apply-external-production

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -93,3 +93,12 @@ module "csb" {
 
   stack_description = var.stack_description
 }
+
+module "sns" {
+  source = "../../modules/sns"
+
+  sns_cg_platform_notifications_name        = "${var.stack_description}-platform-notifications"
+  sns_cg_platform_notifications_email       = var.sns_cg_platform_notifications_email
+  sns_cg_platform_slack_notifications_name  = "${var.stack_description}-platform-slack-notifications"
+  sns_cg_platform_slack_notifications_email = var.sns_cg_platform_slack_notifications_email
+}

--- a/terraform/stacks/external/variables.tf
+++ b/terraform/stacks/external/variables.tf
@@ -21,3 +21,14 @@ variable "external_domain_waf_rate_limit_count_threshold" {
   type        = number
   description = "Number of requests at which traffic by the aggregate key is counted. This threshold is useful to update if you suspect a lower rate-limit threshold might be effective and want to evaluate it without disrupting traffic."
 }
+
+variable "sns_cg_platform_notifications_email" {
+  type        = string
+  description = "Email to receive platform notifications"
+
+}
+
+variable "sns_cg_platform_slack_notifications_email" {
+  type        = string
+  description = "Email to receive platform slack notifications"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/1098

- Add SNS topics to be used for notifications from the external stack resources

## security considerations

None, just adding topics that can be used for sending platform related notifications
