### PR TITLE
use FIPs elb sec policy in dev

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -536,6 +536,7 @@ jobs:
           TF_VAR_cidr_blocks: ((cidr_blocks))
           TF_VAR_domains_lbgroup_count: 2
           TF_VAR_waf_regex_rules: '((development_waf_regex_rules))'
+          TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
       - *notify-slack
 
   - name: apply-development

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -256,5 +256,5 @@ variable "waf_regex_rules" {
 
 variable "aws_lb_listener_ssl_policy" {
   type    = string
-  default = "ELBSecurityPolicy-TLS13-1-2-EXT1-2021-06"
+  default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }

--- a/terraform/modules/external_domain_broker_loadbalancer_group/variables.tf
+++ b/terraform/modules/external_domain_broker_loadbalancer_group/variables.tf
@@ -47,5 +47,5 @@ variable "loadbalancer_forward_new_weight" {
 
 variable "aws_lb_listener_ssl_policy" {
   type    = string
-  default = "ELBSecurityPolicy-TLS13-1-2-EXT1-2021-06"
+  default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -282,5 +282,5 @@ variable "waf_regex_rules" {
 
 variable "aws_lb_listener_ssl_policy" {
   type    = string
-  default = "ELBSecurityPolicy-TLS13-1-2-EXT1-2021-06"
+  default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }

--- a/terraform/stacks/regionalmasterbosh/variables.tf
+++ b/terraform/stacks/regionalmasterbosh/variables.tf
@@ -119,5 +119,5 @@ variable "bosh_default_ssh_public_key" {
 
 variable "aws_lb_listener_ssl_policy" {
   type    = string
-  default = "ELBSecurityPolicy-TLS13-1-2-EXT1-2021-06"
+  default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -274,5 +274,5 @@ variable "rds_parameter_group_family_bosh_credhub" {
 
 variable "aws_lb_listener_ssl_policy" {
   type    = string
-  default = "ELBSecurityPolicy-TLS13-1-2-EXT1-2021-06"
+  default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }

--- a/terraform/stacks/westa-hub/variables.tf
+++ b/terraform/stacks/westa-hub/variables.tf
@@ -269,5 +269,5 @@ variable "create_jumpbox" {
 
 variable "aws_lb_listener_ssl_policy" {
   type    = string
-  default = "ELBSecurityPolicy-TLS13-1-2-EXT1-2021-06"
+  default = "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Sets the dev FIPS ELB security policy (ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04)

## security considerations

This policy removes the TLS_CHACHA20_POLY1305_SHA256 cipher. See: https://docs.google.com/document/d/1RxMgUkYlrfeWwSQBLiSBt36z-oJrl7QtXft_j4HjACc/edit#heading=h.1m5bzhlxtci
