### PR TITLE
Add cloudwatch perms for external domain broker

### DIFF
--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -228,6 +228,40 @@ data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy
       values   = [aws_iam_user.iam_user.arn]
     }
   }
+
+  statement {
+    actions = [
+      "cloudwatch:PutMetricAlarm",
+    ]
+    resources = [
+      "arn:${var.aws_partition}:cloudwatch:${var.aws_region}:${var.account_id}:alarm:cg-external-domains-*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+  }
+
+  statement {
+    actions = [
+      "cloudwatch:DeleteAlarms",
+      "cloudwatch:DescribeAlarms"
+    ]
+    resources = [
+      "arn:${var.aws_partition}:cloudwatch:${var.aws_region}:${var.account_id}:alarm:cg-external-domains-*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/broker"
+      values   = local.broker_tag_values
+    }
+  }
 }
 
 resource "aws_iam_user" "iam_user" {


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/1098

- Add cloudwatch perms for external domain broker

## security considerations

These permissions are scoped only to the IAM user for the external domain broker and limited only to the minimal necessary permissions
