### PR TITLE
pass variable to module

### DIFF
--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -104,6 +104,7 @@ module "dedicated_loadbalancer_group" {
   wildcard_arn                         = data.aws_iam_server_certificate.wildcard.arn
   loadbalancer_forward_original_weight = var.loadbalancer_forward_original_weight
   loadbalancer_forward_new_weight      = var.loadbalancer_forward_new_weight
+  aws_lb_listener_ssl_policy           = var.aws_lb_listener_ssl_policy
 }
 
 /* old domains broker alb */

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -301,6 +301,7 @@ module "cf" {
 
   loadbalancer_forward_original_weight = var.loadbalancer_forward_original_weight
   loadbalancer_forward_new_weight      = var.loadbalancer_forward_new_weight
+  aws_lb_listener_ssl_policy           = var.aws_lb_listener_ssl_policy
 }
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Ensures the aws_lb_listener_ssl_policy variable is passed to the module

## security considerations

See: https://docs.google.com/document/d/1RxMgUkYlrfeWwSQBLiSBt36z-oJrl7QtXft_j4HjACc/edit#heading=h.1m5bzhlxtci
