### PR TITLE
add missing IAM permissions

### DIFF
--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -11,7 +11,8 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       "iam:UploadServerCertificate",
       "iam:UpdateServerCertificate",
       "iam:TagServerCertificate",
-      "iam:UntagServerCertificate"
+      "iam:UntagServerCertificate",
+      "iam:GetServerCertificate"
     ]
     resources = [
       "arn:aws:iam::${var.account_id}:server-certificate/cloudfront/external-domains-*",

--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -9,7 +9,8 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       "iam:UploadServerCertificate",
       "iam:DeleteServerCertificate",
       "iam:TagServerCertificate",
-      "iam:UntagServerCertificate"
+      "iam:UntagServerCertificate",
+      "iam:GetServerCertificate"
     ]
     resources = [
       "arn:aws-us-gov:iam::${var.account_id}:server-certificate/alb/external-domains-*",


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/private/issues/1098

- adds missing iam:GetServerCertificate permissions

## security considerations

Adds only minimal permissions for external domain broker to work. These permissions are scoped to specific resources and constrained to a specific IAM user.
