### PR TITLE
Update external domain broker gov IAM perms

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -23,11 +23,25 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
 
   statement {
     actions = [
-      "iam:ListServerCertificates",
       "iam:GetServerCertificate"
     ]
     resources = [
       "arn:aws-us-gov:iam::${var.account_id}:server-certificate/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+  }
+
+
+  statement {
+    actions = [
+      "iam:ListServerCertificates",
+    ]
+    resources = [
+      "*",
     ]
     condition {
       test     = "StringEquals"

--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -5,16 +5,29 @@
 data "aws_iam_policy_document" "external_domain_broker_policy" {
   statement {
     actions = [
-      "iam:ListServerCertificates",
       "iam:UploadServerCertificate",
       "iam:DeleteServerCertificate",
       "iam:TagServerCertificate",
       "iam:UntagServerCertificate",
-      "iam:GetServerCertificate"
     ]
     resources = [
       "arn:aws-us-gov:iam::${var.account_id}:server-certificate/alb/external-domains-*",
       "arn:aws-us-gov:iam::${var.account_id}:server-certificate/domains*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+  }
+
+  statement {
+    actions = [
+      "iam:ListServerCertificates",
+      "iam:GetServerCertificate"
+    ]
+    resources = [
+      "arn:aws-us-gov:iam::${var.account_id}:server-certificate/*",
     ]
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
## Changes proposed in this pull request:

- give `GetServerCertificate` permission on all certificates so that we can detect if certificates were already deleted
- give `ListServerCertificates` permission on all certificates [as required by IAM](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsidentityandaccessmanagementiam.html)

## security considerations

These permissions are read-only and scoped to a specific IAM user.