### PR TITLE
use FIPS elb security policy in tooling and prod

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -400,6 +400,7 @@ jobs:
           TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
           TF_VAR_rds_db_engine_version_opsuaa: "16.1"
           TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
+          TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
       - *notify-slack
 
   - name: apply-tooling
@@ -878,6 +879,7 @@ jobs:
           TF_VAR_cidr_blocks: ((cidr_blocks))
           TF_VAR_domains_lbgroup_count: 4
           TF_VAR_waf_regex_rules: '((production_waf_regex_rules))'
+          TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
       - *notify-slack
 
   - name: apply-production


### PR DESCRIPTION
## Changes proposed in this pull request:

- Uses the fips 140 compliant ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04 in prod and tooling.

## security considerations

See: https://docs.google.com/document/d/1RxMgUkYlrfeWwSQBLiSBt36z-oJrl7QtXft_j4HjACc/edit#heading=h.depy2n7g7i28
