### PR TITLE
Add check-s3-cidr-ranges and tf for concourse-http-jq-resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -465,6 +465,8 @@ jobs:
             trigger: true
           - get: plan-timer
             trigger: true
+          - get: check-s3-cidr-ranges
+            trigger: true
       - task: terraform-plan-development
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
@@ -639,6 +641,8 @@ jobs:
             trigger: true
           - get: plan-timer
             trigger: true
+          - get: check-s3-cidr-ranges
+            trigger: true
       - task: terraform-plan-staging
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
@@ -808,6 +812,8 @@ jobs:
           - get: cg-provision-repo
             trigger: true
           - get: plan-timer
+            trigger: true
+          - get: check-s3-cidr-ranges
             trigger: true
       - task: terraform-plan-production
         tags: [iaas]
@@ -1757,6 +1763,12 @@ resources:
       aws_region: us-gov-west-1
       tag: latest
 
+  - name: check-s3-cidr-ranges
+    type: http-jq-resource
+    source:
+      base_url: https://ip-ranges.amazonaws.com/ip-ranges.json
+      jq_filter: '[.prefixes[] | select(.service=="S3") | select(.region=="us-gov-west-1")] | [.[].ip_prefix] | sort | {"range" : join("__")}'
+
 resource_types:
   - name: registry-image
     type: registry-image
@@ -1809,5 +1821,14 @@ resource_types:
       aws_access_key_id: ((ecr_aws_key))
       aws_secret_access_key: ((ecr_aws_secret))
       repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: http-jq-resource
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: concourse-http-jq-resource
       aws_region: us-gov-west-1
       tag: latest

--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -13,6 +13,7 @@ variable "repositories" {
     "cf-cli-resource",
     "cf-resource",
     "cloud-service-broker",
+    "concourse-http-jq-resource",
     "concourse-task",
     "cron-resource",
     "csb",


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add `concourse-http-jq-resource` as an ECR repo
- Add a new resource `check-s3-cidr-ranges` to keep track of ip ranges published by AWS.  This specifically looks for S3 CIDRs ranges for the `aws-gov-west-1` region as a trigger to plan the `plan-{development, staging, production}` pipelines.  The output from the `apply-...` jobs feed the `deploy-cf` pipeline terraform jobs for each of the environments to configure the application security groups.  Specifically not using `createDate:` in the output since that would generate more churn than what is needed as it would change if any of the thousands of ip cidrs changes, we are only interest in a small handful of them. It may (hopefully) be years before a change is detected.
- Part of https://github.com/cloud-gov/private/issues/1438

## Security considerations
Adds a new image that is being scanned via common-pipelines.  The security footprint should be rather small as it uses the hardened image plus `wget` and `jq`
