### PR TITLE
Create more IaaS resources to support CSB deployment

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -126,7 +126,7 @@ jobs:
             trigger: true
       - task: terraform-plan-external-development
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &external-development-params
           TERRAFORM_ACTION: plan
           STACK_NAME: external-development
@@ -163,7 +163,7 @@ jobs:
             passed: [plan-external-development]
       - task: terraform-apply-external-development
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *external-development-params
           TERRAFORM_ACTION: apply
@@ -185,7 +185,7 @@ jobs:
             trigger: true
       - task: terraform-plan-external-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &external-staging-params
           TERRAFORM_ACTION: plan
           STACK_NAME: external-staging
@@ -222,7 +222,7 @@ jobs:
             passed: [plan-external-staging]
       - task: terraform-apply-external-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *external-staging-params
           TERRAFORM_ACTION: apply
@@ -244,7 +244,7 @@ jobs:
             trigger: true
       - task: terraform-plan-external-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &external-production-params
           TERRAFORM_ACTION: plan
           STACK_NAME: external-production
@@ -272,7 +272,7 @@ jobs:
             passed: [plan-external-production]
       - task: terraform-apply-external-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *external-production-params
           TERRAFORM_ACTION: apply
@@ -294,7 +294,7 @@ jobs:
             trigger: true
       - task: plan-dns
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &dns-params
           TERRAFORM_ACTION: plan
           STACK_NAME: dns
@@ -319,7 +319,7 @@ jobs:
             passed: [plan-dns]
       - task: terraform-apply-dns
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *dns-params
           TERRAFORM_ACTION: apply
@@ -335,7 +335,7 @@ jobs:
       - task: terraform-plan-tooling
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &tooling-params
           TERRAFORM_ACTION: plan
           STACK_NAME: tooling
@@ -412,7 +412,7 @@ jobs:
       - task: terraform-apply-tooling
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *tooling-params
           TERRAFORM_ACTION: apply
@@ -470,7 +470,7 @@ jobs:
       - task: terraform-plan-development
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &development-params
           TERRAFORM_ACTION: plan
           STACK_NAME: development
@@ -537,7 +537,7 @@ jobs:
           TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
           TF_VAR_cidr_blocks: ((cidr_blocks))
           TF_VAR_domains_lbgroup_count: 2
-          TF_VAR_waf_regex_rules: '((development_waf_regex_rules))'
+          TF_VAR_waf_regex_rules: "((development_waf_regex_rules))"
           TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
       - *notify-slack
 
@@ -552,7 +552,7 @@ jobs:
       - task: terraform-apply-development
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *development-params
           TERRAFORM_ACTION: apply
@@ -646,7 +646,7 @@ jobs:
       - task: terraform-plan-staging
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &staging-params
           TERRAFORM_ACTION: plan
           STACK_NAME: staging
@@ -711,7 +711,7 @@ jobs:
           TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
           TF_VAR_cidr_blocks: ((cidr_blocks))
           TF_VAR_domains_lbgroup_count: 3
-          TF_VAR_waf_regex_rules: '((staging_waf_regex_rules))'
+          TF_VAR_waf_regex_rules: "((staging_waf_regex_rules))"
           TF_VAR_aws_lb_listener_ssl_policy: "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
       - *notify-slack
 
@@ -725,7 +725,7 @@ jobs:
       - task: terraform-apply-staging
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *staging-params
           TERRAFORM_ACTION: apply
@@ -818,7 +818,7 @@ jobs:
       - task: terraform-plan-production
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &production-params
           TERRAFORM_ACTION: plan
           STACK_NAME: production
@@ -883,7 +883,7 @@ jobs:
           TF_VAR_cg_egress_ip_set_arn: ((cg_egress_ip_set_arn))
           TF_VAR_cidr_blocks: ((cidr_blocks))
           TF_VAR_domains_lbgroup_count: 4
-          TF_VAR_waf_regex_rules: '((production_waf_regex_rules))'
+          TF_VAR_waf_regex_rules: "((production_waf_regex_rules))"
       - *notify-slack
 
   - name: apply-production
@@ -896,7 +896,7 @@ jobs:
       - task: terraform-apply-production
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *production-params
           TERRAFORM_ACTION: apply
@@ -986,7 +986,7 @@ jobs:
             trigger: true
       - task: terraform-plan-ecr
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &tf-ecr
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: terraform/stacks/ecr
@@ -1005,7 +1005,7 @@ jobs:
             passed: [plan-ecr]
       - task: terraform-apply-ecr
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *tf-ecr
           TERRAFORM_ACTION: apply
@@ -1020,7 +1020,7 @@ jobs:
             trigger: true
       - task: terraform-plan-concourse-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &tf-concourse-staging
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: terraform/stacks/concourse
@@ -1043,7 +1043,7 @@ jobs:
             passed: [plan-concourse-staging]
       - task: terraform-apply-concourse-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *tf-concourse-staging
           TERRAFORM_ACTION: apply
@@ -1058,7 +1058,7 @@ jobs:
             trigger: true
       - task: terraform-plan-concourse-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params: &tf-concourse-production
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: terraform/stacks/concourse
@@ -1081,7 +1081,7 @@ jobs:
             passed: [plan-concourse-production]
       - task: terraform-apply-concourse-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: {terraform-templates: cg-provision-repo}
+        input_mapping: { terraform-templates: cg-provision-repo }
         params:
           <<: *tf-concourse-production
           TERRAFORM_ACTION: apply

--- a/terraform/modules/csb/README.md
+++ b/terraform/modules/csb/README.md
@@ -3,3 +3,11 @@
 Resources related to the Cloud Service Broker.
 
 See also https://github.com/cloud-gov/csb.
+
+## Why two modules?
+
+The `iam` module contains the IAM policy that the broker uses to deploy resources on behalf of customers. This is distinct from the IAM policy in the `broker` module used by Cloud Foundry to pull the CSB image. Some brokerpaks must create resources in AWS Commercial, so both a Commercial and a GovCloud IAM user must be created. They are managed in a separate module for the following reasons:
+
+- To support deploying them to two separate partitions using two providers, without forcing the rest of the broker resources to specify `provider=`, since they will only ever be deployed to GovCloud.
+- To keep the policies together in the codebase, since they are related. (We could have split up the CSB resources by GovCloud vs Commercial, but the brokerpak-related policies would no longer all be in one place.)
+- To maintain a dedicated space for the policies, which are expected to grow as we add more brokerpaks.

--- a/terraform/modules/csb/broker/main.tf
+++ b/terraform/modules/csb/broker/main.tf
@@ -17,3 +17,17 @@ module "db" {
   rds_allow_major_version_upgrade = var.rds_allow_major_version_upgrade
   rds_apply_immediately           = var.rds_apply_immediately
 }
+
+resource "cloudfoundry_user_provided_service" "db" {
+  name  = "csb-db"
+  space = "cloud-gov/services"
+  credentials = {
+    "db_name"  = module.db.rds_name
+    "host"     = module.db.rds_host
+    "name"     = module.db.rds_name
+    "password" = module.db.rds_password
+    "port"     = module.db.rds_port
+    "uri"      = module.db.rds_url
+    "username" = module.db.rds_username
+  }
+}

--- a/terraform/modules/csb/broker/main.tf
+++ b/terraform/modules/csb/broker/main.tf
@@ -18,16 +18,23 @@ module "db" {
   rds_apply_immediately           = var.rds_apply_immediately
 }
 
-resource "cloudfoundry_user_provided_service" "db" {
-  name  = "csb-db"
-  space = "cloud-gov/services"
-  credentials = {
-    "db_name"  = module.db.rds_name
-    "host"     = module.db.rds_host
-    "name"     = module.db.rds_name
-    "password" = module.db.rds_password
-    "port"     = module.db.rds_port
-    "uri"      = module.db.rds_url
-    "username" = module.db.rds_username
+data "terraform_remote_state" "ecr" {
+  backend = "s3"
+
+  config = {
+    bucket = var.remote_state_bucket
+    region = var.remote_state_region
+    key    = "${var.ecr_stack_name}/terraform.tfstate"
   }
+}
+
+locals {
+  csb_ecr_repository_arn = data.terraform_remote_state.ecr.outputs.repository_arns["csb"]
+}
+
+// A user with ECR pull permissions so Cloud Foundry can pull the CSB image.
+module "ecr_user" {
+  source         = "../../iam_user/ecr_pull_user"
+  username       = "csb-ecr-${var.stack_description}"
+  repository_arn = local.csb_ecr_repository_arn
 }

--- a/terraform/modules/csb/broker/outputs.tf
+++ b/terraform/modules/csb/broker/outputs.tf
@@ -1,0 +1,46 @@
+output "ecr_user_username" {
+  value = module.ecr_user.username
+}
+
+output "ecr_user_access_key_id_curr" {
+  value = module.ecr_user.access_key_id_curr
+}
+
+output "ecr_user_secret_access_key_curr" {
+  value     = module.ecr_user.secret_access_key_curr
+  sensitive = true
+}
+
+output "ecr_user_access_key_id_prev" {
+  value = module.ecr_user.access_key_id_prev
+}
+
+output "ecr_user_secret_access_key_prev" {
+  value     = module.ecr_user.secret_access_key_prev
+  sensitive = true
+}
+
+output "rds_host" {
+  value = module.db.rds_host
+}
+
+output "rds_port" {
+  value = module.db.rds_port
+}
+
+output "rds_url" {
+  value = module.db.rds_url
+}
+
+output "rds_name" {
+  value = module.db.rds_name
+}
+
+output "rds_username" {
+  value = module.db.rds_username
+}
+
+output "rds_password" {
+  value     = module.db.rds_password
+  sensitive = true
+}

--- a/terraform/modules/csb/broker/variables.tf
+++ b/terraform/modules/csb/broker/variables.tf
@@ -3,6 +3,14 @@ variable "stack_description" {
   description = "Like development, staging, or production."
 }
 
+variable "remote_state_bucket" {
+  type = string
+}
+
+variable "remote_state_region" {
+  type = string
+}
+
 # RDS variables
 
 variable "rds_instance_type" {

--- a/terraform/modules/csb/broker/variables.tf
+++ b/terraform/modules/csb/broker/variables.tf
@@ -1,38 +1,47 @@
 variable "stack_description" {
+  type        = string
   description = "Like development, staging, or production."
 }
 
 # RDS variables
 
 variable "rds_instance_type" {
+  type    = string
   default = "db.t3.small"
 }
 
 variable "rds_db_size" {
+  type    = string
   default = 20
 }
 
 variable "rds_db_name" {
+  type    = string
   default = "csb"
 }
 
 variable "rds_db_engine" {
+  type    = string
   default = "mysql"
 }
 
 variable "rds_db_engine_version" {
+  type    = string
   default = "8.0"
 }
 
 variable "rds_parameter_group_family" {
+  type    = string
   default = "mysql8.0"
 }
 
 variable "rds_username" {
+  type    = string
   default = "csb"
 }
 
 variable "rds_password" {
+  type      = string
   sensitive = true
 }
 

--- a/terraform/modules/csb/broker/variables.tf
+++ b/terraform/modules/csb/broker/variables.tf
@@ -11,6 +11,11 @@ variable "remote_state_region" {
   type = string
 }
 
+variable "ecr_stack_name" {
+  type        = string
+  description = "The name of the stack that configures ECR."
+}
+
 # RDS variables
 
 variable "rds_instance_type" {

--- a/terraform/modules/csb/broker/versions.tf
+++ b/terraform/modules/csb/broker/versions.tf
@@ -5,5 +5,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "< 6.0.0"
     }
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "< 1.0"
+    }
   }
 }

--- a/terraform/modules/iam_user/ecr_pull_user/outputs.tf
+++ b/terraform/modules/iam_user/ecr_pull_user/outputs.tf
@@ -1,5 +1,5 @@
 output "username" {
-  value = aws_iam_user.iam_user.name
+  value = var.username
 }
 
 output "access_key_id_prev" {
@@ -12,10 +12,10 @@ output "secret_access_key_prev" {
 }
 
 output "access_key_id_curr" {
-  value = aws_iam_access_key.iam_access_key.id
+  value = aws_iam_access_key.iam_access_key_v3.id
 }
 
 output "secret_access_key_curr" {
-  value     = aws_iam_access_key.iam_access_key.secret
+  value     = aws_iam_access_key.iam_access_key_v3.secret
   sensitive = true
 }

--- a/terraform/modules/iam_user/ecr_pull_user/policy.json
+++ b/terraform/modules/iam_user/ecr_pull_user/policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": "${repository_arn}"
+    }
+  ]
+}

--- a/terraform/modules/iam_user/ecr_pull_user/user.tf
+++ b/terraform/modules/iam_user/ecr_pull_user/user.tf
@@ -1,0 +1,20 @@
+data "template_file" "policy" {
+  template = file("${path.module}/policy.json")
+  vars = {
+    "repository_arn" = var.repository_arn
+  }
+}
+
+resource "aws_iam_user" "iam_user" {
+  name = var.username
+}
+
+resource "aws_iam_access_key" "iam_access_key_v3" {
+  user = aws_iam_user.iam_user.name
+}
+
+resource "aws_iam_user_policy" "iam_policy" {
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
+}

--- a/terraform/modules/iam_user/ecr_pull_user/variables.tf
+++ b/terraform/modules/iam_user/ecr_pull_user/variables.tf
@@ -1,0 +1,9 @@
+variable "username" {
+  type        = string
+  description = "The username of the IAM user."
+}
+
+variable "repository_arn" {
+  type        = string
+  description = "The ARN of the repository in ECR from which the user will pull images."
+}

--- a/terraform/modules/iam_user/ecr_pull_user/versions.tf
+++ b/terraform/modules/iam_user/ecr_pull_user/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 6.0.0"
+    }
+  }
+}

--- a/terraform/stacks/ecr/outputs.tf
+++ b/terraform/stacks/ecr/outputs.tf
@@ -1,0 +1,3 @@
+output "repository_arns" {
+  value = { for k, v in aws_ecr_repository.repository : k => v.arn }
+}

--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -140,11 +140,14 @@ output "lets_encrypt_secret_access_key_curr" {
   sensitive = true
 }
 
-output "csb_access_key_id_curr" {
-  value = module.csb_iam.access_key_id_curr
-}
-
-output "csb_secret_access_key_curr" {
-  sensitive = true
-  value     = module.csb_iam.secret_access_key_curr
+output "csb" {
+  description = "Values required to deploy the Cloud Service Broker."
+  value = {
+    broker_user = {
+      access_key_id_curr     = module.csb_iam.access_key_id_curr
+      secret_access_key_curr = module.csb_iam.secret_access_key_curr
+      access_key_id_prev     = module.csb_iam.access_key_id_prev
+      secret_access_key_prev = module.csb_iam.secret_access_key_prev
+    }
+  }
 }

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -744,3 +744,31 @@ output "tcp_lb_listener_ports" {
 output "tcp_lb_security_groups" {
   value = concat(module.cf.tcp_lb_security_groups.*.id, [module.stack.bosh_security_group])
 }
+
+
+output "csb" {
+  description = "Values required to deploy the Cloud Service Broker."
+  value = {
+    ecr_user = {
+      username               = module.csb.ecr_user_username
+      access_key_id_curr     = module.csb_broker.ecr_user_access_key_id_curr
+      secret_access_key_curr = module.csb_broker.ecr_user_secret_access_key_curr
+      access_key_id_prev     = module.csb_broker.ecr_user_access_key_id_prev
+      secret_access_key_prev = module.csb_broker.ecr_user_secret_access_key_prev
+    }
+    rds = {
+      host     = module.csb_broker.rds_host
+      port     = module.csb_broker.rds_port
+      url      = module.csb_broker.rds_url
+      name     = module.csb_broker.rds_name
+      username = module.csb_broker.rds_username
+      password = module.csb_broker.rds_password
+    }
+    broker_user = {
+      access_key_id_curr     = module.csb_iam.access_key_id_curr
+      secret_access_key_curr = module.csb_iam.secret_access_key_curr
+      access_key_id_prev     = module.csb_iam.access_key_id_prev
+      secret_access_key_prev = module.csb_iam.secret_access_key_prev
+    }
+  }
+}

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -750,19 +750,19 @@ output "csb" {
   description = "Values required to deploy the Cloud Service Broker."
   value = {
     ecr_user = {
-      username               = module.csb_broker.ecr_user_username
-      access_key_id_curr     = module.csb_broker.ecr_user_access_key_id_curr
-      secret_access_key_curr = module.csb_broker.ecr_user_secret_access_key_curr
-      access_key_id_prev     = module.csb_broker.ecr_user_access_key_id_prev
-      secret_access_key_prev = module.csb_broker.ecr_user_secret_access_key_prev
+      username               = module.csb_broker[0].ecr_user_username
+      access_key_id_curr     = module.csb_broker[0].ecr_user_access_key_id_curr
+      secret_access_key_curr = module.csb_broker[0].ecr_user_secret_access_key_curr
+      access_key_id_prev     = module.csb_broker[0].ecr_user_access_key_id_prev
+      secret_access_key_prev = module.csb_broker[0].ecr_user_secret_access_key_prev
     }
     rds = {
-      host     = module.csb_broker.rds_host
-      port     = module.csb_broker.rds_port
-      url      = module.csb_broker.rds_url
-      name     = module.csb_broker.rds_name
-      username = module.csb_broker.rds_username
-      password = module.csb_broker.rds_password
+      host     = module.csb_broker[0].rds_host
+      port     = module.csb_broker[0].rds_port
+      url      = module.csb_broker[0].rds_url
+      name     = module.csb_broker[0].rds_name
+      username = module.csb_broker[0].rds_username
+      password = module.csb_broker[0].rds_password
     }
     broker_user = {
       access_key_id_curr     = module.csb_iam.access_key_id_curr

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -750,7 +750,7 @@ output "csb" {
   description = "Values required to deploy the Cloud Service Broker."
   value = {
     ecr_user = {
-      username               = module.csb.ecr_user_username
+      username               = module.csb_broker.ecr_user_username
       access_key_id_curr     = module.csb_broker.ecr_user_access_key_id_curr
       secret_access_key_curr = module.csb_broker.ecr_user_secret_access_key_curr
       access_key_id_prev     = module.csb_broker.ecr_user_access_key_id_prev

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -482,4 +482,5 @@ module "csb_broker" {
   rds_instance_type               = var.csb_rds_instance_type
 
   stack_description = var.stack_description
+  ecr_stack_name    = var.ecr_stack_name
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -469,7 +469,9 @@ resource "random_password" "csb_rds_password" {
 module "csb_broker" {
   count = var.stack_description == "development" ? 1 : 0
 
-  source = "../../modules/csb/broker"
+  source              = "../../modules/csb/broker"
+  remote_state_bucket = var.remote_state_bucket
+  remote_state_region = var.aws_default_region
 
   rds_password        = random_password.csb_rds_password.result
   rds_subnet_group    = module.stack.rds_subnet_group

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -289,3 +289,9 @@ variable "csb_rds_instance_type" {
   type    = string
   default = "db.t3.small"
 }
+
+variable "ecr_stack_name" {
+  type        = string
+  description = "The name of the stack that configures ECR."
+  default     = "ecr"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove app-related resources, which will be managed in cg-deploy-cf
- Output ECR repository ARNs so CSB deployment can reference its image
- Create new ecr_pull_user with pull permissions scoped to one ECR repo

## security considerations

Sensitive outputs are marked as such, or sensitivity will be inferred from source module. New user's permissions follow principle of least access. 