### PR TITLE
adding create snapshot permission for the aws-broker so redis tests will pass in staging

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -184,6 +184,7 @@
           "elasticache:ListTagsForResource",
           "elasticache:ModifyReplicationGroupShardConfiguration",
           "elasticache:DescribeSnapshots",
+          "elasticache:CreateSnapshot",
           "elasticache:CopySnapshot",
           "elasticache:DeleteSnapshot"
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updated the aws-broker policy to include CreateSnapshot which is required for the redis tests

## security considerations
None, just adding a policy