### PR TITLE
Output objects must be marked sensitive if their children are sensitive

### DIFF
--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -142,6 +142,7 @@ output "lets_encrypt_secret_access_key_curr" {
 
 output "csb" {
   description = "Values required to deploy the Cloud Service Broker."
+  sensitive   = true
   value = {
     broker_user = {
       access_key_id_curr     = module.csb_iam.access_key_id_curr

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -748,6 +748,7 @@ output "tcp_lb_security_groups" {
 
 output "csb" {
   description = "Values required to deploy the Cloud Service Broker."
+  sensitive   = true
   value = {
     ecr_user = {
       username               = module.csb_broker[0].ecr_user_username


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixes a build error
- Related to https://github.com/cloud-gov/product/issues/2989

## security considerations
In line with standard TF security practices