### PR TITLE
Create a user for reading terraform state of external stack

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -144,6 +144,7 @@ jobs:
           TF_VAR_external_domain_waf_rate_limit_challenge_threshold: ((external_domain_waf_rate_limit_challenge_threshold))
           TF_VAR_sns_cg_platform_notifications_email: ((development_sns_cg_platform_notifications_email))
           TF_VAR_sns_cg_platform_slack_notifications_email: ((development_sns_cg_platform_slack_notifications_email))
+          TF_VAR_terraform_state_bucket: ((aws_external_s3_tfstate_bucket))
       - &notify-slack
         put: slack
         params:
@@ -203,6 +204,7 @@ jobs:
           TF_VAR_external_domain_waf_rate_limit_challenge_threshold: ((external_domain_waf_rate_limit_challenge_threshold))
           TF_VAR_sns_cg_platform_notifications_email: ((staging_sns_cg_platform_notifications_email))
           TF_VAR_sns_cg_platform_slack_notifications_email: ((staging_sns_cg_platform_slack_notifications_email))
+          TF_VAR_terraform_state_bucket: ((aws_external_s3_tfstate_bucket))
       - &notify-slack
         put: slack
         params:
@@ -262,6 +264,7 @@ jobs:
           TF_VAR_external_domain_waf_rate_limit_challenge_threshold: ((external_domain_waf_rate_limit_challenge_threshold))
           TF_VAR_sns_cg_platform_notifications_email: ((production_sns_cg_platform_notifications_email))
           TF_VAR_sns_cg_platform_slack_notifications_email: ((production_sns_cg_platform_slack_notifications_email))
+          TF_VAR_terraform_state_bucket: ((aws_external_s3_tfstate_bucket))
       - *notify-slack
 
   - name: apply-external-production

--- a/terraform/modules/iam_user/s3_bucket_readonly/outputs.tf
+++ b/terraform/modules/iam_user/s3_bucket_readonly/outputs.tf
@@ -1,0 +1,21 @@
+output "username" {
+  value = var.username
+}
+
+output "access_key_id_prev" {
+  value = ""
+}
+
+output "secret_access_key_prev" {
+  value     = ""
+  sensitive = true
+}
+
+output "access_key_id_curr" {
+  value = aws_iam_access_key.iam_access_key_v3.id
+}
+
+output "secret_access_key_curr" {
+  value     = aws_iam_access_key.iam_access_key_v3.secret
+  sensitive = true
+}

--- a/terraform/modules/iam_user/s3_bucket_readonly/policy.json
+++ b/terraform/modules/iam_user/s3_bucket_readonly/policy.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:ListBucket"],
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ]
+    }
+  ]
+}

--- a/terraform/modules/iam_user/s3_bucket_readonly/user.tf
+++ b/terraform/modules/iam_user/s3_bucket_readonly/user.tf
@@ -1,0 +1,20 @@
+data "template_file" "policy" {
+  template = file("${path.module}/policy.json")
+  vars = {
+    "bucket_name" = var.bucket_name
+  }
+}
+
+resource "aws_iam_user" "iam_user" {
+  name = var.username
+}
+
+resource "aws_iam_access_key" "iam_access_key_v3" {
+  user = aws_iam_user.iam_user.name
+}
+
+resource "aws_iam_user_policy" "iam_policy" {
+  name   = "${aws_iam_user.iam_user.name}-policy"
+  user   = aws_iam_user.iam_user.name
+  policy = data.template_file.policy.rendered
+}

--- a/terraform/modules/iam_user/s3_bucket_readonly/variables.tf
+++ b/terraform/modules/iam_user/s3_bucket_readonly/variables.tf
@@ -1,0 +1,9 @@
+variable "username" {
+  type        = string
+  description = "The username of the IAM user."
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "The name of the bucket to which the user will be granted read-only access."
+}

--- a/terraform/modules/iam_user/s3_bucket_readonly/versions.tf
+++ b/terraform/modules/iam_user/s3_bucket_readonly/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "< 6.0.0"
+    }
+  }
+}

--- a/terraform/stacks/external/outputs.tf
+++ b/terraform/stacks/external/outputs.tf
@@ -150,5 +150,11 @@ output "csb" {
       access_key_id_prev     = module.csb_iam.access_key_id_prev
       secret_access_key_prev = module.csb_iam.secret_access_key_prev
     }
+    external_terraform_state_reader = {
+      access_key_id_curr     = module.terraform_state_reader.access_key_id_curr
+      secret_access_key_curr = module.terraform_state_reader.secret_access_key_curr
+      access_key_id_prev     = module.terraform_state_reader.access_key_id_prev
+      secret_access_key_prev = module.terraform_state_reader.secret_access_key_prev
+    }
   }
 }

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -102,3 +102,10 @@ module "sns" {
   sns_cg_platform_slack_notifications_name  = "${var.stack_description}-platform-slack-notifications"
   sns_cg_platform_slack_notifications_email = var.sns_cg_platform_slack_notifications_email
 }
+
+module "terraform_state_reader" {
+  source = "../../modules/iam_user/s3_bucket_readonly"
+
+  bucket_name = var.terraform_state_bucket
+  username    = "${var.stack_description}-terraform-state-reader"
+}

--- a/terraform/stacks/external/variables.tf
+++ b/terraform/stacks/external/variables.tf
@@ -1,6 +1,11 @@
 variable "stack_description" {
 }
 
+variable "terraform_state_bucket" {
+  type        = string
+  description = "The name of the bucket in which terraform state for this stack is stored."
+}
+
 
 variable "external_domain_broker_hosted_zone" {
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Required so the job in cg-deploy-cf can read the outputs relating to its user in the commercial environment. 
- Related to https://github.com/cloud-gov/product/issues/2989

## security considerations
Observes standard security practices related to terraform, including marking sensitive outputs as such.
