### PR TITLE
only keep the two latest images

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -92,6 +92,18 @@ resource "aws_ecr_lifecycle_policy" "ecr_repository_lifecycle_policy" {
             "action": {
                 "type": "expire"
             }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Only keep the two latest images",
+            "selection": {
+                "tagStatus": "all",
+                "countType": "imageCountMoreThan",
+                "countNumber": 2
+            },
+            "action": {
+                "type": "expire"
+            }
         }
     ]
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds a lifecycle rule to ECR repositories so that we only keep the two latest images

## security considerations
As part of our container hardening and scanning requirements we need to demonstrate that all images in ECR have a clean scan, which means older images that are no longer being scanned should be removed.
