### PR TITLE
add opensearch images to ECR

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -43,6 +43,8 @@ variable "repositories" {
     "s3-simple-resource",
     "semver-resource",
     "slack-notification-resource",
+    "opensearch-testing",
+    "opensearch-dashboards-testing",
     "time-resource",
     "ubuntu-hardened",
   ]


### PR DESCRIPTION
## Changes proposed in this pull request:
- Creates ECR repos for opensearch test images
- Uses naming convention of other testing images by ending in `-testing`

## security considerations
Creating ECR repos for hardened images
