### PR TITLE
add permissions for managing SNS topics

### DIFF
--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -221,6 +221,23 @@ data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy
       values   = [aws_iam_user.iam_user.arn]
     }
   }
+
+  statement {
+    actions = [
+      "sns:CreateTopic",
+      "sns:DeleteTopic",
+      "sns:TagResource",
+      "sns:UntagResource"
+    ]
+    resources = [
+      "arn:${var.aws_partition}:sns:${var.aws_region}:${var.account_id}:cg-external-domains-*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+  }
 }
 
 resource "aws_iam_user" "iam_user" {


### PR DESCRIPTION
Related to https://github.com/cloud-gov/private/issues/1097

## Changes proposed in this pull request:

- Add permissions for creating/deleting/tagging SNS topics

## security considerations

These are the limited set of SNS permissions need by the external-domain-broker. These permissions are scoped only to the IAM user for the broker.
