### PR TITLE
ecr:GetAuthorizationToken must be granted on *

### DIFF
--- a/terraform/modules/iam_user/ecr_pull_user/policy.json
+++ b/terraform/modules/iam_user/ecr_pull_user/policy.json
@@ -6,10 +6,14 @@
       "Action": [
         "ecr:BatchCheckLayerAvailability",
         "ecr:GetDownloadUrlForLayer",
-        "ecr:BatchGetImage",
-        "ecr:GetAuthorizationToken"
+        "ecr:BatchGetImage"
       ],
       "Resource": "${repository_arn}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ecr:GetAuthorizationToken"],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixes user not being able to pull from ECR 
- Tested successfully in console already

## security considerations
None.