### PR TITLE
add SNS subscribe/unsubscribe permissions for external domain broker

### DIFF
--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -227,7 +227,9 @@ data "aws_iam_policy_document" "external_domain_broker_manage_protections_policy
       "sns:CreateTopic",
       "sns:DeleteTopic",
       "sns:TagResource",
-      "sns:UntagResource"
+      "sns:UntagResource",
+      "sns:Subscribe",
+      "sns:Unsubscribe"
     ]
     resources = [
       "arn:${var.aws_partition}:sns:${var.aws_region}:${var.account_id}:cg-external-domains-*"


### PR DESCRIPTION
## Changes proposed in this pull request:

- see title

## security considerations

These permissions are the least privilege permissions necessary for the broker. They are scoped to only work for a specific IAM user.
