### PR TITLE
update database versions for tooling stack

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -126,7 +126,7 @@ jobs:
             trigger: true
       - task: terraform-plan-external-development
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &external-development-params
           TERRAFORM_ACTION: plan
           STACK_NAME: external-development
@@ -164,7 +164,7 @@ jobs:
             passed: [plan-external-development]
       - task: terraform-apply-external-development
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *external-development-params
           TERRAFORM_ACTION: apply
@@ -186,7 +186,7 @@ jobs:
             trigger: true
       - task: terraform-plan-external-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &external-staging-params
           TERRAFORM_ACTION: plan
           STACK_NAME: external-staging
@@ -224,7 +224,7 @@ jobs:
             passed: [plan-external-staging]
       - task: terraform-apply-external-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *external-staging-params
           TERRAFORM_ACTION: apply
@@ -246,7 +246,7 @@ jobs:
             trigger: true
       - task: terraform-plan-external-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &external-production-params
           TERRAFORM_ACTION: plan
           STACK_NAME: external-production
@@ -275,7 +275,7 @@ jobs:
             passed: [plan-external-production]
       - task: terraform-apply-external-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *external-production-params
           TERRAFORM_ACTION: apply
@@ -297,7 +297,7 @@ jobs:
             trigger: true
       - task: plan-dns
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &dns-params
           TERRAFORM_ACTION: plan
           STACK_NAME: dns
@@ -322,7 +322,7 @@ jobs:
             passed: [plan-dns]
       - task: terraform-apply-dns
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *dns-params
           TERRAFORM_ACTION: apply
@@ -338,7 +338,7 @@ jobs:
       - task: terraform-plan-tooling
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &tooling-params
           TERRAFORM_ACTION: plan
           STACK_NAME: tooling
@@ -391,17 +391,17 @@ jobs:
           TF_VAR_defectdojo_staging_oidc_client_secret: ((tooling_defectdojo_staging_oidc_client_secret))
           TF_VAR_rds_db_engine_version_bosh: "15.5"
           TF_VAR_rds_parameter_group_family_bosh: "postgres15"
-          TF_VAR_rds_db_engine_version_bosh_credhub: "15.5"
+          TF_VAR_rds_db_engine_version_bosh_credhub: "15.7"
           TF_VAR_rds_parameter_group_family_bosh_credhub: "postgres15"
-          TF_VAR_rds_db_engine_version_credhub_staging: "15.5"
+          TF_VAR_rds_db_engine_version_credhub_staging: "15.7"
           TF_VAR_rds_parameter_group_family_credhub_staging: "postgres15"
-          TF_VAR_rds_db_engine_version_credhub_production: "15.5"
+          TF_VAR_rds_db_engine_version_credhub_production: "15.7"
           TF_VAR_rds_parameter_group_family_credhub_production: "postgres15"
-          TF_VAR_rds_db_engine_version_concourse_staging: "15.5"
+          TF_VAR_rds_db_engine_version_concourse_staging: "15.7"
           TF_VAR_rds_parameter_group_family_concourse_staging: "postgres15"
-          TF_VAR_rds_db_engine_version_concourse_production: "15.5"
+          TF_VAR_rds_db_engine_version_concourse_production: "15.7"
           TF_VAR_rds_parameter_group_family_concourse_production: "postgres15"
-          TF_VAR_rds_db_engine_version_opsuaa: "16.1"
+          TF_VAR_rds_db_engine_version_opsuaa: "16.3"
           TF_VAR_rds_parameter_group_family_opsuaa: "postgres16"
       - *notify-slack
 
@@ -415,7 +415,7 @@ jobs:
       - task: terraform-apply-tooling
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *tooling-params
           TERRAFORM_ACTION: apply
@@ -473,7 +473,7 @@ jobs:
       - task: terraform-plan-development
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &development-params
           TERRAFORM_ACTION: plan
           STACK_NAME: development
@@ -555,7 +555,7 @@ jobs:
       - task: terraform-apply-development
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *development-params
           TERRAFORM_ACTION: apply
@@ -649,7 +649,7 @@ jobs:
       - task: terraform-plan-staging
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &staging-params
           TERRAFORM_ACTION: plan
           STACK_NAME: staging
@@ -728,7 +728,7 @@ jobs:
       - task: terraform-apply-staging
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *staging-params
           TERRAFORM_ACTION: apply
@@ -821,7 +821,7 @@ jobs:
       - task: terraform-plan-production
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &production-params
           TERRAFORM_ACTION: plan
           STACK_NAME: production
@@ -899,7 +899,7 @@ jobs:
       - task: terraform-apply-production
         tags: [iaas]
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *production-params
           TERRAFORM_ACTION: apply
@@ -989,7 +989,7 @@ jobs:
             trigger: true
       - task: terraform-plan-ecr
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &tf-ecr
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: terraform/stacks/ecr
@@ -1008,7 +1008,7 @@ jobs:
             passed: [plan-ecr]
       - task: terraform-apply-ecr
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *tf-ecr
           TERRAFORM_ACTION: apply
@@ -1023,7 +1023,7 @@ jobs:
             trigger: true
       - task: terraform-plan-concourse-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &tf-concourse-staging
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: terraform/stacks/concourse
@@ -1046,7 +1046,7 @@ jobs:
             passed: [plan-concourse-staging]
       - task: terraform-apply-concourse-staging
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *tf-concourse-staging
           TERRAFORM_ACTION: apply
@@ -1061,7 +1061,7 @@ jobs:
             trigger: true
       - task: terraform-plan-concourse-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params: &tf-concourse-production
           TERRAFORM_ACTION: plan
           TEMPLATE_SUBDIR: terraform/stacks/concourse
@@ -1084,7 +1084,7 @@ jobs:
             passed: [plan-concourse-production]
       - task: terraform-apply-concourse-production
         file: pipeline-tasks/terraform-apply.yml
-        input_mapping: { terraform-templates: cg-provision-repo }
+        input_mapping: {terraform-templates: cg-provision-repo}
         params:
           <<: *tf-concourse-production
           TERRAFORM_ACTION: apply


### PR DESCRIPTION
## Changes proposed in this pull request:

- `plan-tooling` is detecting changes for databases that have been updated to new versions RDS. Updating database versions in Terraform variables to match current database versions so that no changes are detected

## security considerations

None
