### PR TITLE
Use separate TF resources for security group ingress/egress rules

### DIFF
--- a/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
@@ -10,31 +10,52 @@ resource "aws_security_group" "restricted_web_traffic" {
   description = "Restricted web type traffic"
   vpc_id      = aws_vpc.main_vpc.id
 
-  ingress {
-    from_port        = 80
-    to_port          = 80
-    protocol         = "tcp"
-    cidr_blocks      = sort(var.restricted_ingress_web_cidrs)
-    ipv6_cidr_blocks = sort(var.restricted_ingress_web_ipv6_cidrs)
-  }
-
-  ingress {
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = sort(var.restricted_ingress_web_cidrs)
-    ipv6_cidr_blocks = sort(var.restricted_ingress_web_ipv6_cidrs)
-  }
-
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
-
   tags = {
     Name = "${var.stack_description} - Restricted Incoming Web Traffic"
   }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "http_ipv4_ingress_rules" {
+  for_each          = var.restricted_ingress_web_cidrs
+  security_group_id = aws_security_group.restricted_web_traffic.id
+  cidr_ipv4         = each.value
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "http_ipv6_ingress_rules" {
+  for_each          = var.restricted_ingress_web_ipv6_cidrs
+  security_group_id = aws_security_group.restricted_web_traffic.id
+  cidr_ipv6         = each.value
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "https_ipv4_ingress_rules" {
+  for_each          = var.restricted_ingress_web_cidrs
+  security_group_id = aws_security_group.restricted_web_traffic.id
+  cidr_ipv4         = each.value
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "https_ipv6_ingress_rules" {
+  for_each          = var.restricted_ingress_web_ipv6_cidrs
+  security_group_id = aws_security_group.restricted_web_traffic.id
+  cidr_ipv6         = each.value
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "all_egress" {
+  security_group_id = aws_security_group.restricted_web_traffic.id
+  from_port         = 0
+  to_port           = 0
+  ip_protocol       = "-1"
+  cidr_ipv4         = ["0.0.0.0/0"]
+  cidr_ipv6         = ["::/0"]
 }

--- a/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
@@ -51,11 +51,18 @@ resource "aws_vpc_security_group_ingress_rule" "https_ipv6_ingress_rules" {
   ip_protocol       = "tcp"
 }
 
-resource "aws_vpc_security_group_egress_rule" "all_egress" {
+resource "aws_vpc_security_group_egress_rule" "all_egress_ipv4" {
   security_group_id = aws_security_group.restricted_web_traffic.id
   from_port         = 0
   to_port           = 0
   ip_protocol       = "-1"
   cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_egress_rule" "all_egress_ipv6" {
+  security_group_id = aws_security_group.restricted_web_traffic.id
+  from_port         = 0
+  to_port           = 0
+  ip_protocol       = "-1"
   cidr_ipv6         = "::/0"
 }

--- a/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
@@ -16,36 +16,36 @@ resource "aws_security_group" "restricted_web_traffic" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "http_ipv4_ingress_rules" {
-  for_each          = var.restricted_ingress_web_cidrs
+  for_each          = toset(var.restricted_ingress_web_cidrs)
   security_group_id = aws_security_group.restricted_web_traffic.id
-  cidr_ipv4         = each.value
+  cidr_ipv4         = each.key
   from_port         = 80
   to_port           = 80
   ip_protocol       = "tcp"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "http_ipv6_ingress_rules" {
-  for_each          = var.restricted_ingress_web_ipv6_cidrs
+  for_each          = toset(var.restricted_ingress_web_ipv6_cidrs)
   security_group_id = aws_security_group.restricted_web_traffic.id
-  cidr_ipv6         = each.value
+  cidr_ipv6         = each.key
   from_port         = 80
   to_port           = 80
   ip_protocol       = "tcp"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "https_ipv4_ingress_rules" {
-  for_each          = var.restricted_ingress_web_cidrs
+  for_each          = toset(var.restricted_ingress_web_cidrs)
   security_group_id = aws_security_group.restricted_web_traffic.id
-  cidr_ipv4         = each.value
+  cidr_ipv4         = each.key
   from_port         = 443
   to_port           = 443
   ip_protocol       = "tcp"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "https_ipv6_ingress_rules" {
-  for_each          = var.restricted_ingress_web_ipv6_cidrs
+  for_each          = toset(var.restricted_ingress_web_ipv6_cidrs)
   security_group_id = aws_security_group.restricted_web_traffic.id
-  cidr_ipv6         = each.value
+  cidr_ipv6         = each.key
   from_port         = 443
   to_port           = 443
   ip_protocol       = "tcp"
@@ -56,6 +56,6 @@ resource "aws_vpc_security_group_egress_rule" "all_egress" {
   from_port         = 0
   to_port           = 0
   ip_protocol       = "-1"
-  cidr_ipv4         = ["0.0.0.0/0"]
-  cidr_ipv6         = ["::/0"]
+  cidr_ipv4         = "0.0.0.0/0"
+  cidr_ipv6         = "::/0"
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

Part of https://github.com/cloud-gov/private/issues/1439

We have a problem where Terraform is constantly detecting changes to our `aws_security_group` resources, when in fact nothing is changing except that Terraform thinks the order of the `cidr_blocks` values have changed.

After looking for an easy fix in the Terraform AWS provider GitHub, I struck out and then went to the [documentation page for the `aws_security_group` resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group.html) which has this note:

> Avoid using the ingress and egress arguments of the aws_security_group resource to configure in-line rules, as they struggle with managing multiple CIDR blocks, and, due to the historical lack of unique IDs, tags and descriptions. To avoid these problems, use the current best practice of the [aws_vpc_security_group_egress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) and [aws_vpc_security_group_ingress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) resources with one CIDR block per rule.

In line with those suggestions, I am refactoring the code to use separate `aws_vpc_security_group_ingress_rule` and `aws_vpc_security_group_egress_rule` resources to have a separate ingress/egress rule for each CIDR block. I think this refactoring will resolve the issue with Terraform always detecting changes because each IP will effectively create a different resource in Terraform and thus ordering should not matter.

## security considerations

There should be no material changes to security group ingress/egress, just refactoring how those resources are declared in Terraform.
